### PR TITLE
sendCap: check for nil exports table/entries

### DIFF
--- a/rpc/export.go
+++ b/rpc/export.go
@@ -96,6 +96,9 @@ func (c *Conn) sendCap(d rpccp.CapDescriptor, client *capnp.Client, state capnp.
 
 	// Default to sender-hosted (export).
 	for id, ent := range c.exports {
+		if ent == nil {
+			continue
+		}
 		if ent.client.IsSame(client) {
 			ent.wireRefs++
 			d.SetSenderHosted(uint32(id))


### PR DESCRIPTION
Fixes #112 

Note that I'm not terribly confident that this is the best thing to do; it seems like maybe exports should be initialized to an empty slice up front somwhere (doing it lazily here feels wrong) but I'm fuzzy on where that would be.