### PR TITLE
Update Bazel WORKSPACE and build files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: go
 go_import_path: zombiezen.com/go/capnproto2
 go:
-- 1.4.x
 - 1.x
 install: _travis/install.bash
 script: _travis/build.bash

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@bazel_gazelle//:def.bzl", "gazelle")
-load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_prefix", "go_test")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 # gazelle:prefix zombiezen.com/go/capnproto2
 gazelle(
@@ -11,6 +11,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "address.go",
+        "canonical.go",
         "capability.go",
         "capn.go",
         "doc.go",
@@ -25,6 +26,7 @@ go_library(
         "strings.go",
         "struct.go",
     ],
+    importpath = "zombiezen.com/go/capnproto2",
     visibility = ["//visibility:public"],
     deps = [
         "//internal/packed:go_default_library",
@@ -38,28 +40,22 @@ go_test(
     name = "go_default_test",
     srcs = [
         "address_test.go",
+        "canonical_test.go",
         "capability_test.go",
         "capn_test.go",
+        "example_test.go",
+        "integration_test.go",
+        "integrationutil_test.go",
         "list_test.go",
         "mem_test.go",
         "rawpointer_test.go",
         "readlimit_test.go",
     ],
-    library = ":go_default_library",
-)
-
-go_test(
-    name = "go_default_xtest",
-    srcs = [
-        "example_test.go",
-        "integration_test.go",
-        "integrationutil_test.go",
-    ],
     data = [
         "//internal/aircraftlib:schema",
     ],
+    embed = [":go_default_library"],
     deps = [
-        "//:go_default_library",
         "//internal/aircraftlib:go_default_library",
         "//internal/capnptool:go_default_library",
     ],

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,6 +1,11 @@
+load("@bazel_gazelle//:def.bzl", "gazelle")
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_prefix", "go_test")
 
-go_prefix("zombiezen.com/go/capnproto2")
+# gazelle:prefix zombiezen.com/go/capnproto2
+gazelle(
+    name = "gazelle",
+    command = "fix",
+)
 
 go_library(
     name = "go_default_library",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,14 +1,28 @@
 workspace(name = "com_zombiezen_go_capnproto2")
 
-git_repository(
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
     name = "io_bazel_rules_go",
-    remote = "https://github.com/bazelbuild/rules_go.git",
-    commit = "43a3bda3eb97e7bcd86f564a1e0a4b008d6c407c",
+    sha256 = "8b68d0630d63d95dacc0016c3bb4b76154fe34fca93efd65d1c366de3fcb4294",
+    urls = ["https://github.com/bazelbuild/rules_go/releases/download/0.12.1/rules_go-0.12.1.tar.gz"],
 )
 
-load("@io_bazel_rules_go//go:def.bzl", "go_repositories", "go_repository")
+http_archive(
+    name = "bazel_gazelle",
+    sha256 = "ddedc7aaeb61f2654d7d7d4fd7940052ea992ccdb031b8f9797ed143ac7e8d43",
+    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/0.12.0/bazel-gazelle-0.12.0.tar.gz"],
+)
 
-go_repositories()
+load("@io_bazel_rules_go//go:def.bzl", "go_register_toolchains", "go_rules_dependencies")
+
+go_rules_dependencies()
+
+go_register_toolchains()
+
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
+
+gazelle_dependencies()
 
 go_repository(
     name = "com_github_kylelemons_godebug",

--- a/_travis/install.bash
+++ b/_travis/install.bash
@@ -13,7 +13,7 @@ die() {
 if [[ -z "$USE_BAZEL" || "$USE_BAZEL" -eq "0" ]]; then
   must go get -t ./...
 else
-  BAZEL_VERSION="${BAZEL_VERSION:-0.5.4}"
+  BAZEL_VERSION="${BAZEL_VERSION:-0.14.1}"
   case "$TRAVIS_OS_NAME" in
     linux)
       BAZEL_INSTALLER_URL="https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh"
@@ -32,7 +32,7 @@ else
   must /tmp/bazel.sh --user
   rm -f /tmp/bazel.sh
   if [[ ! -z "$TRAVIS_GO_VERSION" ]]; then
-    must $SEDI -e "s/^go_repositories(.*/go_repositories(go_version=\"${TRAVIS_GO_VERSION}\")/" WORKSPACE
+    must $SEDI -e "s/^go_register_toolchains(.*/go_register_toolchains(go_version=\"${TRAVIS_GO_VERSION}\")/" WORKSPACE
   fi
   must "$HOME/bin/bazel" --bazelrc=_travis/bazelrc version
   must "$HOME/bin/bazel" --bazelrc=_travis/bazelrc fetch //...

--- a/_travis/install.bash
+++ b/_travis/install.bash
@@ -32,7 +32,7 @@ else
   must /tmp/bazel.sh --user
   rm -f /tmp/bazel.sh
   if [[ ! -z "$TRAVIS_GO_VERSION" ]]; then
-    must $SEDI -e "s/^go_register_toolchains(.*/go_register_toolchains(go_version=\"${TRAVIS_GO_VERSION}\")/" WORKSPACE
+    must $SEDI -e 's/^go_register_toolchains()/go_register_toolchains(go_version="host")/' WORKSPACE
   fi
   must "$HOME/bin/bazel" --bazelrc=_travis/bazelrc version
   must "$HOME/bin/bazel" --bazelrc=_travis/bazelrc fetch //...

--- a/capnpc-go/BUILD.bazel
+++ b/capnpc-go/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "templateparams.go",
         "templates.go",
     ],
+    importpath = "zombiezen.com/go/capnproto2/capnpc-go",
     visibility = ["//visibility:private"],
     deps = [
         "//:go_default_library",
@@ -18,7 +19,7 @@ go_library(
 
 go_binary(
     name = "capnpc-go",
-    library = ":go_default_library",
+    embed = [":go_default_library"],
     visibility = ["//visibility:public"],
 )
 
@@ -26,7 +27,7 @@ go_test(
     name = "go_default_test",
     srcs = ["capnpc-go_test.go"],
     data = glob(["testdata/**"]),
-    library = ":go_default_library",
+    embed = [":go_default_library"],
     deps = [
         "//:go_default_library",
         "//encoding/text:go_default_library",

--- a/encoding/text/BUILD.bazel
+++ b/encoding/text/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = ["marshal.go"],
+    importpath = "zombiezen.com/go/capnproto2/encoding/text",
     visibility = ["//visibility:public"],
     deps = [
         "//:go_default_library",
@@ -17,7 +18,7 @@ go_test(
     name = "go_default_test",
     srcs = ["marshal_test.go"],
     data = glob(["testdata/**"]),
-    library = ":go_default_library",
+    embed = [":go_default_library"],
     deps = [
         "//:go_default_library",
         "//internal/schema:go_default_library",

--- a/internal/aircraftlib/BUILD.bazel
+++ b/internal/aircraftlib/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
         "aircraft.capnp.go",
         "generate.go",
     ],
+    importpath = "zombiezen.com/go/capnproto2/internal/aircraftlib",
     visibility = ["//:__subpackages__"],
     deps = [
         "//:go_default_library",
@@ -18,6 +19,6 @@ go_library(
 
 filegroup(
     name = "schema",
-    visibility = ["//:__subpackages__"],
     srcs = ["aircraft.capnp"],
+    visibility = ["//:__subpackages__"],
 )

--- a/internal/capnptool/BUILD.bazel
+++ b/internal/capnptool/BUILD.bazel
@@ -3,5 +3,6 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["capnptool.go"],
+    importpath = "zombiezen.com/go/capnproto2/internal/capnptool",
     visibility = ["//:__subpackages__"],
 )

--- a/internal/demo/BUILD.bazel
+++ b/internal/demo/BUILD.bazel
@@ -3,15 +3,17 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = ["doc.go"],
+    importpath = "zombiezen.com/go/capnproto2/internal/demo",
     visibility = ["//:__subpackages__"],
 )
 
 go_test(
-    name = "go_default_xtest",
+    name = "go_default_test",
     srcs = [
         "book_test.go",
         "hash_test.go",
     ],
+    embed = [":go_default_library"],
     deps = [
         "//:go_default_library",
         "//internal/demo/books:go_default_library",

--- a/internal/demo/books/BUILD.bazel
+++ b/internal/demo/books/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
         "books.capnp.go",
         "gen.go",
     ],
+    importpath = "zombiezen.com/go/capnproto2/internal/demo/books",
     visibility = ["//:__subpackages__"],
     deps = [
         "//:go_default_library",

--- a/internal/demo/hashes/BUILD.bazel
+++ b/internal/demo/hashes/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
         "gen.go",
         "hash.capnp.go",
     ],
+    importpath = "zombiezen.com/go/capnproto2/internal/demo/hashes",
     visibility = ["//:__subpackages__"],
     deps = [
         "//:go_default_library",

--- a/internal/fulfiller/BUILD.bazel
+++ b/internal/fulfiller/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = ["fulfiller.go"],
+    importpath = "zombiezen.com/go/capnproto2/internal/fulfiller",
     visibility = ["//:__subpackages__"],
     deps = [
         "//:go_default_library",
@@ -13,6 +14,6 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = ["fulfiller_test.go"],
-    library = ":go_default_library",
+    embed = [":go_default_library"],
     deps = ["//:go_default_library"],
 )

--- a/internal/nodemap/BUILD.bazel
+++ b/internal/nodemap/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["nodemap.go"],
+    importpath = "zombiezen.com/go/capnproto2/internal/nodemap",
     visibility = ["//:__subpackages__"],
     deps = [
         "//:go_default_library",

--- a/internal/packed/BUILD.bazel
+++ b/internal/packed/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
         "discard_go14.go",
         "packed.go",
     ],
+    importpath = "zombiezen.com/go/capnproto2/internal/packed",
     visibility = ["//:__subpackages__"],
 )
 
@@ -14,5 +15,5 @@ go_test(
     name = "go_default_test",
     srcs = ["packed_test.go"],
     data = glob(["testdata/**"]),
-    library = ":go_default_library",
+    embed = [":go_default_library"],
 )

--- a/internal/queue/BUILD.bazel
+++ b/internal/queue/BUILD.bazel
@@ -3,11 +3,12 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = ["queue.go"],
+    importpath = "zombiezen.com/go/capnproto2/internal/queue",
     visibility = ["//:__subpackages__"],
 )
 
 go_test(
     name = "go_default_test",
     srcs = ["queue_test.go"],
-    library = ":go_default_library",
+    embed = [":go_default_library"],
 )

--- a/internal/schema/BUILD.bazel
+++ b/internal/schema/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["schema.capnp.go"],
+    importpath = "zombiezen.com/go/capnproto2/internal/schema",
     visibility = ["//:__subpackages__"],
     deps = ["//:go_default_library"],
 )

--- a/internal/strquote/BUILD.bazel
+++ b/internal/strquote/BUILD.bazel
@@ -3,5 +3,6 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["strquote.go"],
+    importpath = "zombiezen.com/go/capnproto2/internal/strquote",
     visibility = ["//:__subpackages__"],
 )

--- a/pogs/BUILD.bazel
+++ b/pogs/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
         "fields.go",
         "insert.go",
     ],
+    importpath = "zombiezen.com/go/capnproto2/pogs",
     visibility = ["//visibility:public"],
     deps = [
         "//:go_default_library",
@@ -21,24 +22,16 @@ go_test(
     srcs = [
         "bench_test.go",
         "embed_test.go",
+        "example_test.go",
         "interface_test.go",
         "pogs_test.go",
     ],
-    library = ":go_default_library",
+    embed = [":go_default_library"],
     deps = [
         "//:go_default_library",
         "//internal/aircraftlib:go_default_library",
+        "//internal/demo/books:go_default_library",
         "@com_github_kylelemons_godebug//pretty:go_default_library",
         "@org_golang_x_net//context:go_default_library",
-    ],
-)
-
-go_test(
-    name = "go_default_xtest",
-    srcs = ["example_test.go"],
-    deps = [
-        ":go_default_library",
-        "//:go_default_library",
-        "//internal/demo/books:go_default_library",
     ],
 )

--- a/rpc/BUILD.bazel
+++ b/rpc/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "tables.go",
         "transport.go",
     ],
+    importpath = "zombiezen.com/go/capnproto2/rpc",
     visibility = ["//visibility:public"],
     deps = [
         "//:go_default_library",
@@ -24,7 +25,7 @@ go_library(
 )
 
 go_test(
-    name = "go_default_xtest",
+    name = "go_default_test",
     srcs = [
         "bench_test.go",
         "cancel_test.go",
@@ -35,8 +36,8 @@ go_test(
         "release_test.go",
         "rpc_test.go",
     ],
+    embed = [":go_default_library"],
     deps = [
-        ":go_default_library",
         "//:go_default_library",
         "//rpc/internal/logtransport:go_default_library",
         "//rpc/internal/pipetransport:go_default_library",

--- a/rpc/internal/logtransport/BUILD.bazel
+++ b/rpc/internal/logtransport/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["logtransport.go"],
+    importpath = "zombiezen.com/go/capnproto2/rpc/internal/logtransport",
     visibility = ["//rpc:__subpackages__"],
     deps = [
         "//encoding/text:go_default_library",

--- a/rpc/internal/logutil/BUILD.bazel
+++ b/rpc/internal/logutil/BUILD.bazel
@@ -3,5 +3,6 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["logutil.go"],
+    importpath = "zombiezen.com/go/capnproto2/rpc/internal/logutil",
     visibility = ["//rpc:__subpackages__"],
 )

--- a/rpc/internal/pipetransport/BUILD.bazel
+++ b/rpc/internal/pipetransport/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["pipetransport.go"],
+    importpath = "zombiezen.com/go/capnproto2/rpc/internal/pipetransport",
     visibility = ["//rpc:__subpackages__"],
     deps = [
         "//:go_default_library",

--- a/rpc/internal/refcount/BUILD.bazel
+++ b/rpc/internal/refcount/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = ["refcount.go"],
+    importpath = "zombiezen.com/go/capnproto2/rpc/internal/refcount",
     visibility = ["//rpc:__subpackages__"],
     deps = ["//:go_default_library"],
 )
@@ -10,6 +11,6 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = ["refcount_test.go"],
-    library = ":go_default_library",
+    embed = [":go_default_library"],
     deps = ["//:go_default_library"],
 )

--- a/rpc/internal/testcapnp/BUILD.bazel
+++ b/rpc/internal/testcapnp/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
         "generate.go",
         "test.capnp.go",
     ],
+    importpath = "zombiezen.com/go/capnproto2/rpc/internal/testcapnp",
     visibility = ["//rpc:__subpackages__"],
     deps = [
         "//:go_default_library",

--- a/schemas/BUILD.bazel
+++ b/schemas/BUILD.bazel
@@ -3,15 +3,16 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = ["schemas.go"],
+    importpath = "zombiezen.com/go/capnproto2/schemas",
     visibility = ["//visibility:public"],
     deps = ["//internal/packed:go_default_library"],
 )
 
 go_test(
-    name = "go_default_xtest",
+    name = "go_default_test",
     srcs = ["schemas_test.go"],
+    embed = [":go_default_library"],
     deps = [
-        ":go_default_library",
         "//:go_default_library",
         "//internal/schema:go_default_library",
     ],

--- a/server/BUILD.bazel
+++ b/server/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = ["server.go"],
+    importpath = "zombiezen.com/go/capnproto2/server",
     visibility = ["//visibility:public"],
     deps = [
         "//:go_default_library",
@@ -12,10 +13,10 @@ go_library(
 )
 
 go_test(
-    name = "go_default_xtest",
+    name = "go_default_test",
     srcs = ["server_test.go"],
+    embed = [":go_default_library"],
     deps = [
-        ":go_default_library",
         "//internal/aircraftlib:go_default_library",
         "@org_golang_x_net//context:go_default_library",
     ],

--- a/std/capnp/cxx/BUILD.bazel
+++ b/std/capnp/cxx/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["c++.capnp.go"],
+    importpath = "zombiezen.com/go/capnproto2/std/capnp/cxx",
     visibility = ["//visibility:public"],
     deps = ["//schemas:go_default_library"],
 )

--- a/std/capnp/json/BUILD.bazel
+++ b/std/capnp/json/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["json.capnp.go"],
+    importpath = "zombiezen.com/go/capnproto2/std/capnp/json",
     visibility = ["//visibility:public"],
     deps = [
         "//:go_default_library",

--- a/std/capnp/persistent/BUILD.bazel
+++ b/std/capnp/persistent/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["persistent.capnp.go"],
+    importpath = "zombiezen.com/go/capnproto2/std/capnp/persistent",
     visibility = ["//visibility:public"],
     deps = [
         "//:go_default_library",

--- a/std/capnp/rpc/BUILD.bazel
+++ b/std/capnp/rpc/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["rpc.capnp.go"],
+    importpath = "zombiezen.com/go/capnproto2/std/capnp/rpc",
     visibility = ["//visibility:public"],
     deps = [
         "//:go_default_library",

--- a/std/capnp/rpctwoparty/BUILD.bazel
+++ b/std/capnp/rpctwoparty/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["rpc-twoparty.capnp.go"],
+    importpath = "zombiezen.com/go/capnproto2/std/capnp/rpctwoparty",
     visibility = ["//visibility:public"],
     deps = [
         "//:go_default_library",

--- a/std/capnp/schema/BUILD.bazel
+++ b/std/capnp/schema/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["schema.capnp.go"],
+    importpath = "zombiezen.com/go/capnproto2/std/capnp/schema",
     visibility = ["//visibility:public"],
     deps = [
         "//:go_default_library",


### PR DESCRIPTION
This change makes this repository compatible with newer versions of rules_go and Bazel. The big differences are that`importpath` attribute is now mandatory in `go_library` rules, and `go_prefix` has been removed.

This change is broken up into two commits to simplify review:

* Add rules_go 0.12.1 and Gazelle 0.12.0 (latest versions) to WORKSPACE. Remove deprecated calls. Add `//:gazelle` rule.
* Run `gazelle fix`.