### PR TITLE
standardize .capnp syntax in doc.go

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -27,3 +27,4 @@ Tiit Pikma <pikma@hot.ee>
 Tom Thorogood <me+github@tomthorogood.co.uk>
 TJ Holowaychuk <tj@apex.sh>
 William Laffin <william.laffin@gmail.com>
+Colin Arnott <colin@urandom.co.uk>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -33,3 +33,4 @@ Tiit Pikma <pikma@hot.ee>
 Tom Thorogood <me+github@tomthorogood.co.uk>
 TJ Holowaychuk <tj@apex.sh>
 William Laffin <william.laffin@gmail.com>
+Colin Arnott <colin@urandom.co.uk>

--- a/doc.go
+++ b/doc.go
@@ -81,10 +81,10 @@ Structs
 
 For the following schema:
 
-struct Foo @0x8423424e9b01c0af {
-  num @0 :UInt32;
-  bar @1 :Foo;
-}
+	struct Foo @0x8423424e9b01c0af {
+	  num @0 :UInt32;
+	  bar @1 :Foo;
+	}
 
 capnpc-go will generate:
 
@@ -168,9 +168,9 @@ For each group a typedef is created with a different method set for just the
 groups fields:
 
 	struct Foo {
-		group :Group {
-			field @0 :Bool;
-		}
+	  group :Group {
+	    field @0 :Bool;
+	  }
 	}
 
 generates the following:
@@ -194,10 +194,10 @@ Named unions are treated as a group with an inner unnamed union. Unnamed
 unions generate an enum Type_Which and a corresponding Which() function:
 
 	struct Foo {
-		union {
-			a @0 :Bool;
-			b @1 :Bool;
-		}
+	  union {
+	    a @0 :Bool;
+	    b @1 :Bool;
+	  }
 	}
 
 generates the following:
@@ -225,10 +225,10 @@ For voids in unions, there is a void setter that just sets the discriminator.
 For example:
 
 	struct Foo {
-		union {
-			a @0 :Void;
-			b @1 :Void;
-		}
+	  union {
+	    a @0 :Void;
+	    b @1 :Void;
+	  }
 	}
 
 generates the following:
@@ -241,14 +241,14 @@ the discriminator. This must be called before the group getter can be
 used to set values. For example:
 
 	struct Foo {
-		union {
-			a :group {
-				v :Bool
-			}
-			b :group {
-				v :Bool
-			}
-		}
+	  union {
+	    a :group {
+	      v :Bool
+	    }
+	    b :group {
+	      v :Bool
+	    }
+	  }
 	}
 
 and in usage:
@@ -293,10 +293,10 @@ but the tags can be customized with a $Go.tag or $Go.notag annotation.
 For example:
 
 	enum ElementSize {
-		empty @0           $Go.tag("void");
-		bit @1             $Go.tag("1 bit");
-		byte @2            $Go.tag("8 bits");
-		inlineComposite @7 $Go.notag;
+	  empty @0           $Go.tag("void");
+	  bit @1             $Go.tag("1 bit");
+	  byte @2            $Go.tag("8 bits");
+	  inlineComposite @7 $Go.notag;
 	}
 
 In the generated go file:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,10 @@
-module "zombiezen.com/go/capnproto2"
+module zombiezen.com/go/capnproto2
+
+go 1.12
 
 require (
-	"github.com/kylelemons/godebug" v0.0.0-20170820004349-d65d576e9348
-	"golang.org/x/net" v0.0.0-20180218175443-cbe0f9307d01
+	github.com/kylelemons/godebug v1.1.0
+	github.com/philhofer/fwd v1.0.0 // indirect
+	github.com/tinylib/msgp v1.1.0
+	golang.org/x/net v0.0.0-20180218175443-cbe0f9307d01
 )

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,8 @@
+github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
+github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
+github.com/philhofer/fwd v1.0.0 h1:UbZqGr5Y38ApvM/V/jEljVxwocdweyH+vmYvRPBnbqQ=
+github.com/philhofer/fwd v1.0.0/go.mod h1:gk3iGcWd9+svBvR0sR+KPcfE+RNWozjowpeBVG3ZVNU=
+github.com/tinylib/msgp v1.1.0 h1:9fQd+ICuRIu/ue4vxJZu6/LzxN0HwMds2nq/0cFvxHU=
+github.com/tinylib/msgp v1.1.0/go.mod h1:+d+yLhGm8mzTaHzB+wgMYrodPfmZrzkirds8fDWklFE=
+golang.org/x/net v0.0.0-20180218175443-cbe0f9307d01 h1:po1f06KS05FvIQQA2pMuOWZAUXiy1KYdIf0ElUU2Hhc=
+golang.org/x/net v0.0.0-20180218175443-cbe0f9307d01/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=


### PR DESCRIPTION
.capnp examples either used two spaces ("  ") or tabs ("	") for
whitespace and one is incorrectly indented breaking the godoc
formatting. The latter was fixed, and all examples were moved to two
space indenting.

go.mod was formatted, tidied, and a default go directive was added.