### PR TITLE
Fix capnpc-go to use the correct length for nodes in the schema var.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -10,6 +10,7 @@
 
 # Please keep the list sorted.
 
+Anapaya Systems AG
 CloudFlare Inc.
 Daniel Darabos <darabos.daniel@gmail.com>
 Dominik Roos <domi.roos@gmail.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -30,6 +30,7 @@ Lev Radomislensky <lev.radomislensky@gmail.com>
 Martin Sucha <martin.sucha@kiwi.com>
 Peter Waldschmidt <peterw@gnoso.com>
 Ross Light <light@google.com> <ross@zombiezen.com>
+Stephen Shirley <kormat@anapaya.net> <kormat@gmail.com>
 Tiit Pikma <pikma@hot.ee>
 Tom Thorogood <me+github@tomthorogood.co.uk>
 TJ Holowaychuk <tj@apex.sh>

--- a/capnpc-go/capnpc-go.go
+++ b/capnpc-go/capnpc-go.go
@@ -144,8 +144,7 @@ func (g *generator) defineSchemaVar() error {
 		ids[i] = n.Id()
 	}
 	sort.Sort(uint64Slice(ids))
-	// TODO(light): find largest object size and use that to allocate list
-	nodes, _ := req.NewNodes(int32(len(g.nodes)))
+	nodes, _ := req.NewNodes(int32(len(fnodes)))
 	i := 0
 	for _, id := range ids {
 		n := g.nodes[id]


### PR DESCRIPTION
As there can only be `len(fnodes)` of nodes in a schema var, use that
for `NewNodes()` instead of the the number of files. This makes the
output deterministic for compiling a .capnp file on its own, or with
others on the same cmdline.

Fixes https://github.com/capnproto/go-capnproto2/issues/145