### PR TITLE
Fix wrong error check in schemas.go

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -27,6 +27,7 @@ Jason E. Aten <j.e.aten@gmail.com>
 Johan Hernandez <im@bithavoc.io>
 Joonsung Lee <joonsung@devsisters.com>
 Lev Radomislensky <lev.radomislensky@gmail.com>
+Lukas Vogel <vogel@anapaya.net> <lukedirtwalker@gmail.com>
 Martin Sucha <martin.sucha@kiwi.com>
 Peter Waldschmidt <peterw@gnoso.com>
 Ross Light <light@google.com> <ross@zombiezen.com>

--- a/encoding/text/marshal.go
+++ b/encoding/text/marshal.go
@@ -461,7 +461,6 @@ func (enc *Encoder) marshalList(elem schema.Type, l capnp.List) error {
 	default:
 		return fmt.Errorf("unknown list type %v", elem.Which())
 	}
-	return nil
 }
 
 func (enc *Encoder) marshalEnum(typ uint64, val uint16) error {

--- a/schemas/schemas.go
+++ b/schemas/schemas.go
@@ -112,7 +112,7 @@ func (r *record) read() ([]byte, error) {
 		}
 		p := packed.NewReader(bufio.NewReader(z))
 		r.data, r.err = ioutil.ReadAll(p)
-		if err != nil {
+		if r.err != nil {
 			r.data = nil
 			return
 		}


### PR DESCRIPTION
The error is assigned to r.err but checked is err, fix this by checking r.err.
Found with nilness analyzer.

Fixes #147

Also delete unreachable return nil in marshal.go