### PR TITLE
Fix some breakage in the regen.sh script.

### DIFF
--- a/regen.sh
+++ b/regen.sh
@@ -12,7 +12,6 @@ echo "** capnpc-go"
 (cd capnpc-go && go generate && go test && go install)
 
 echo "** schemas"
-(cd std/capnp; ./gen.sh compile)
-capnp compile -ogo std/go.capnp && mv std/go.capnp.go ./
+(cd std/capnp; ../gen.sh compile)
 (cd std/capnp; capnp compile --no-standard-import -I.. -o- schema.capnp) | (cd internal/schema && capnpc-go -promises=0 -schemas=0 -structstrings=0)
 go generate ./...


### PR DESCRIPTION
I tried running this while working on something else, and hit two
problems:

* When gen.sh is called from regen.sh, it is called as ./gen.sh but
  relative to the working directory it should be ../gen.sh
* regen.sh puts go.capnp.go in the main package, which breaks the
  build; in the past this was how the package was supposed to be
  organized, but 88fcc4af3c541b3cf4e67f146acf3dfbebbfa95a moved it,
  and apparently the script was never updated. gen.sh actually
  puts it in the right place, so we can just remove this.