### PR TITLE
Fix (*rpc.Conn).Err() method

### DIFF
--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -133,7 +133,7 @@ func (c *Conn) Done() <-chan struct{} {
 func (c *Conn) Err() error {
 	c.stateMu.RLock()
 	var err error
-	if c.state != connDead {
+	if c.state == connDead {
 		err = c.closeErr
 	}
 	c.stateMu.RUnlock()


### PR DESCRIPTION
Right now this method will always return nil because until connection is closed (`c.state == connDead`) `c.closeErr` is nil.

This even contradicts with docstring which says `returns nil before Done is closed` when actually `.Done()` channel is closed after `c.state` became `connDead`

Proposed change will fix this