### PR TITLE
CI: run agains Go 1.17

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.15', '1.16' ]
+        go: [ '1.15', '1.16', '1.17' ]
     name: Go ${{ matrix.go }}
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Noticed when reviewing #182 that we don't currently test against the
latest release, so let's do that.