### PR TITLE
Fix unsafe use of reflect.StringHeader/SliceHeader.

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"io"
 	"math/rand"
-	"reflect"
 	"testing"
 	"time"
 	"unsafe"
@@ -1724,9 +1723,7 @@ func randString(r *rand.Rand, n int) string {
 }
 
 func unsafeBytesToString(b []byte) string {
-	slice := *(*reflect.SliceHeader)(unsafe.Pointer(&b))
-	hdr := reflect.StringHeader{Data: slice.Data, Len: slice.Len}
-	return *(*string)(unsafe.Pointer(&hdr))
+	return *(*string)(unsafe.Pointer(&b))
 }
 
 func BenchmarkMarshal(b *testing.B) {


### PR DESCRIPTION
Fixes https://github.com/capnproto/go-capnproto2/issues/185.

Benchmarks appear unaffected:

Before

```
BenchmarkTextMovementBetweenSegments-8              3560            294538 ns/op             336 B/op          4 allocs/op
BenchmarkMarshal-8                               2444696               505.8 ns/op           264 B/op          3 allocs/op
BenchmarkUnmarshal-8                             2159962               546.9 ns/op           192 B/op          3 allocs/op
BenchmarkUnmarshal_Reuse-8                       3018286               400.3 ns/op             0 B/op          0 allocs/op
BenchmarkDecode-8                                    349           3509860 ns/op         273.52 MB/s     2880309 B/op      40002 allocs/op
BenchmarkDecode_Reuse-8                              747           1591190 ns/op         603.32 MB/s         400 B/op          3 allocs/op
BenchmarkGrowth_SingleSegment-8                      162           7450082 ns/op         140.75 MB/s     4343128 B/op         10 allocs/op
BenchmarkGrowth_MultiSegment-8                       100          10165517 ns/op         103.15 MB/s     1648600 B/op         21 allocs/op
BenchmarkSmallMessage_SingleSegment-8            1720398               787.7 ns/op        91.41 MB/s        1352 B/op          5 allocs/op
BenchmarkSmallMessage_MultiSegment-8             2121964               561.8 ns/op       128.16 MB/s        1216 B/op          4 allocs/op
```

After

```
BenchmarkTextMovementBetweenSegments-8              4106            327906 ns/op             336 B/op          4 allocs/op
BenchmarkMarshal-8                               2297775               505.6 ns/op           264 B/op          3 allocs/op
BenchmarkUnmarshal-8                             2256856               532.1 ns/op           192 B/op          3 allocs/op
BenchmarkUnmarshal_Reuse-8                       3046434               385.7 ns/op             0 B/op          0 allocs/op
BenchmarkDecode-8                                    360           3294106 ns/op         291.43 MB/s     2880312 B/op      40002 allocs/op
BenchmarkDecode_Reuse-8                              708           1671720 ns/op         574.26 MB/s         400 B/op          3 allocs/op
BenchmarkGrowth_SingleSegment-8                      153           7366270 ns/op         142.35 MB/s     4343126 B/op         10 allocs/op
BenchmarkGrowth_MultiSegment-8                       100          10015142 ns/op         104.70 MB/s     1648598 B/op         21 allocs/op
BenchmarkSmallMessage_SingleSegment-8            1688142               705.4 ns/op       102.07 MB/s        1352 B/op          5 allocs/op
BenchmarkSmallMessage_MultiSegment-8             1987764               607.4 ns/op       118.54 MB/s        1216 B/op          4 allocs/op
```