### PR TITLE
Add new internal/mpsc package.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,6 @@ go 1.16
 
 require (
 	github.com/kylelemons/godebug v1.1.0
+	github.com/stretchr/testify v1.7.0 // indirect
 	github.com/tinylib/msgp v1.1.5
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,14 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/philhofer/fwd v1.1.1 h1:GdGcTjf5RNAxwS4QLsiMzJYj5KEvPJD3Abr261yRQXQ=
 github.com/philhofer/fwd v1.1.1/go.mod h1:gk3iGcWd9+svBvR0sR+KPcfE+RNWozjowpeBVG3ZVNU=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/tinylib/msgp v1.1.5 h1:2gXmtWueD2HefZHQe1QOy9HVzmFrLOVvsXwXBQ0ayy0=
 github.com/tinylib/msgp v1.1.5/go.mod h1:eQsjooMTnV42mHu917E26IogZ2930nFyBQdofk10Udg=
 github.com/ttacon/chalk v0.0.0-20160626202418-22c06c80ed31/go.mod h1:onvgF043R+lC5RZ8IT9rBXDaEDnpnw/Cl+HFiw+v/7Q=
@@ -26,3 +33,6 @@ golang.org/x/tools v0.0.0-20201022035929-9cf592e881e9/go.mod h1:emZCQorbCU4vsT4f
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/mpsc/mpsc.go
+++ b/internal/mpsc/mpsc.go
@@ -1,0 +1,148 @@
+// Package mpsc implements a multiple-producer, single-consumer queue.
+package mpsc
+
+import (
+	"context"
+)
+
+// A multiple-producer, single-consumer queue. Create one with New(),
+// and send from many gorotuines with Tx.Send(). Only one gorotuine may
+// call Rx.Recv().
+type Queue struct {
+	Tx
+	Rx
+}
+
+// The receive end of a Queue.
+type Rx struct {
+	// The head of the list. If the list is empty, this will be
+	// non-nil but have a locked mu field.
+	head *node
+}
+
+// The send/transmit end of a Queue.
+type Tx struct {
+	// Mutex which must be held by senders. A goroutine must hold this
+	// lock to manipulate `tail`.
+	mu mutex
+
+	// Pointer to the tail of the list. This will have a locked mu,
+	// and zero values for other fields.
+	tail *node
+}
+
+// Alias for interface{}, the values in the queue. TODO: once Go
+// supports generics, get rid of this and make Queue generic in the
+// type of the values.
+type Value interface{}
+
+// A node in the linked linst that makes up the queue internally.
+type node struct {
+	// A mutex which guards the other fields in the node.
+	// Nodes start out with this locked, and then we unlock it
+	// after filling in the other fields.
+	mu mutex
+
+	// The next node in the list, if any. Must be non-nil if
+	// mu is unlocked:
+	next *node
+
+	// The value in this node:
+	value Value
+}
+
+// Create a new node, with a locked mutex and zero values for
+// the other fields.
+func newNode() *node {
+	return &node{mu: newLockedMutex()}
+}
+
+// Create a new, initially empty Queue.
+func New() *Queue {
+	node := newNode()
+	return &Queue{
+		Tx: Tx{
+			tail: node,
+			mu:   newUnlockedMutex(),
+		},
+		Rx: Rx{head: node},
+	}
+}
+
+// Send a message on the queue.
+func (tx *Tx) Send(v Value) {
+	newTail := newNode()
+
+	tx.mu.lock()
+
+	oldTail := tx.tail
+	oldTail.next = newTail
+	oldTail.value = v
+	tx.tail = newTail
+	oldTail.mu.unlock()
+
+	tx.mu.unlock()
+}
+
+// Receive a message from the queue. Blocks if the queue is empty.
+// If the context ends before the receive happens, this returns
+// ctx.Err().
+func (rx *Rx) Recv(ctx context.Context) (Value, error) {
+	select {
+	case <-rx.head.mu:
+		return rx.doRecv(), nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+// Try to receive a message from the queue. If successful, ok will be true.
+// If the queue is empty, this will return immediately with ok = false.
+func (rx *Rx) TryRecv() (v Value, ok bool) {
+	select {
+	case <-rx.head.mu:
+		return rx.doRecv(), true
+	default:
+		return nil, false
+	}
+}
+
+// Helper for shared logic between Recv and TryRecv. Must be holding
+// rx.head.mu.
+func (rx *Rx) doRecv() Value {
+	ret := rx.head.value
+	rx.head = rx.head.next
+	return ret
+}
+
+// mutex based around on channel with buffer size 1.
+//
+// Locking & unlocking operations are just channel receive/send respectively,
+// which allows the caller to lock/unlock the mutex as part of a select.
+// We also provide lock/unlock methods for convenience.
+//
+// TODO: maybe pull this out into its own package, if we find ourselves
+// wanting to use it elsewhere.
+type mutex chan struct{}
+
+// Return a new, locked mutex.
+func newLockedMutex() mutex {
+	return make(mutex, 1)
+}
+
+// Return a new, unlocked mutex
+func newUnlockedMutex() mutex {
+	ret := newLockedMutex()
+	ret.unlock()
+	return ret
+}
+
+// Lock the mutex. Blocks if it is already locked.
+func (m mutex) lock() {
+	<-m
+}
+
+// Unlock the mutex.
+func (m mutex) unlock() {
+	m <- struct{}{}
+}

--- a/internal/mpsc/mpsc_test.go
+++ b/internal/mpsc/mpsc_test.go
@@ -1,0 +1,114 @@
+package mpsc
+
+import (
+	"context"
+	"math/rand"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTryRecvEmpty(t *testing.T) {
+	t.Parallel()
+	q := New()
+	v, ok := q.TryRecv()
+	assert.False(t, ok, "TryRecv() on an empty queue succeeded; recevied: ", v)
+}
+
+func TestRecvEmpty(t *testing.T) {
+	t.Parallel()
+	q := New()
+
+	// Recv() on an empty queue should block until the context is canceled.
+	ctx, _ := context.WithTimeout(context.Background(), time.Millisecond*10)
+
+	v, err := q.Recv(ctx)
+	assert.Equal(t, ctx.Err(), err, "Returned error is not ctx.Err()")
+	assert.NotNil(t, err, "Returned error is nil.")
+	assert.Nil(t, v, "Return value is not nil.")
+}
+
+func TestSendOne(t *testing.T) {
+	t.Parallel()
+	q := New()
+	want := Value(1)
+	q.Send(want)
+	got, err := q.Recv(context.Background())
+	assert.Nil(t, err, "Non-nil error from Recv()")
+	assert.Equal(t, want, got, "Sent and received different values.")
+}
+
+func TestSendManySequential(t *testing.T) {
+	t.Parallel()
+
+	inputs := []int{}
+	outputs := []int{}
+	for i := 0; i < 100; i++ {
+		inputs = append(inputs, i)
+	}
+
+	ctx := context.Background()
+
+	q := New()
+
+	for _, v := range inputs {
+		q.Send(v)
+	}
+
+	for len(outputs) != len(inputs) {
+		v, err := q.Recv(ctx)
+		assert.Nil(t, err, "Non-nil error from Recv()")
+		outputs = append(outputs, v.(int))
+	}
+	assert.Equal(t, inputs, outputs, "Received sequence was different from sent.")
+
+	v, ok := q.TryRecv()
+	assert.False(t, ok, "Recieved more values than expected: ", v)
+}
+
+func TestSendManyConcurrent(t *testing.T) {
+	t.Parallel()
+
+	q := New()
+
+	for i := 0; i < 100; i += 10 {
+		for j := 0; j < 10; j++ {
+			value := i + j
+			delay := time.Duration(rand.Float64() * 100 * float64(time.Millisecond))
+			go func() {
+				// Sleep a random amount of time before proceeding, rather
+				// than relying on the scheduler to give us good test coverage.
+				//
+				// But, also, we spawn more than one goroutine with the same
+				// delay, so that we'll get some goroutines scheduled close to
+				// one another.
+				time.Sleep(delay)
+				q.Send(value)
+			}()
+		}
+	}
+
+	expected := []int{}
+	actual := []int{}
+	for i := 0; i < 100; i++ {
+		expected = append(expected, i)
+	}
+
+	ctx := context.Background()
+	for i := 0; i < 100; i++ {
+		v, err := q.Recv(ctx)
+		assert.Nil(t, err, "Failed to receive from queue: ", err)
+		actual = append(actual, v.(int))
+	}
+	// Values come out in random order, so sort them:
+	sort.Slice(actual, func(i, j int) bool {
+		return actual[i] < actual[j]
+	})
+
+	assert.Equal(t, expected, actual, "Different values came out of the queue than went in.")
+
+	v, ok := q.TryRecv()
+	assert.False(t, ok, "Recieved more values than expected: ", v)
+}


### PR DESCRIPTION
Per discussion on matrix, we will need an unbounded queue implementation
to go forward with the deadlock fixes. Not currently hooked up to
anything, but the plan would be:

- Spawn a new goroutine per connection, which reads from the queue and
  writes messages to the transport until its context is canceled.
- Everywhere we currently call sendMessage(), instead insert something
  into this queue.

Note that the elements of the queue will not just be *capnp.Message,
becuase of the way the transport works; they may have to be callbacks or
somesuch.

---

@lthibault, note that since we agreed to go ahead with the testing library from #187, I decided to use it here as well, so these are going to conflict due to the double-add, but the conflicts will be easy to solve.