### PR TITLE
Fix a bug where we were calling annotate() on the wrong error.

### DIFF
--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -586,7 +586,7 @@ func (c *Conn) handleCall(ctx context.Context, call rpccp.Call, releaseCall capn
 	}
 	c.answers[id] = ans
 	if parseErr != nil {
-		parseErr = annotate(err, "incoming call")
+		parseErr = annotate(parseErr, "incoming call")
 		rl := ans.sendException(parseErr)
 		c.unlockSender()
 		c.mu.Unlock()


### PR DESCRIPTION
This was manifesting as a panic, since the other error was nil.

---

Triggering this requires sending a call message that is invalid in some way; in my case I was invoking a method on a capability that had already been freed. I have a feeling that there are probably other codepaths like this that just never get executed if there are no application level bugs, and we should probably try to shore up test coverage in those cases.