### PR TITLE
Minor formatting change in comment

### DIFF
--- a/answer.go
+++ b/answer.go
@@ -35,7 +35,7 @@ type Promise struct {
 	//	  other promise to transition out of the pending join state.  Next
 	//	  state is joined or resolved, since the other promise could be
 	//	  resolved while this promise is in this state.
-	//  - Joined.  Join has finished.
+	//	- Joined.  Join has finished.
 
 	// mu protects the fields below.  When acquiring multiple Promise.mu
 	// mutexes, they must be acquired in traversal order (i.e. p, then


### PR DESCRIPTION
...let's line this up with the rest of them.

---

This looks a lot more dramatic in my editor; the old version used two spaces whereas everything else (and the new version) uses a tab. It looks like GitHub's diffs choose a very different tab size than I have set locally, so this is more subtle.

Anyway, just a minor thing I encountered while picking through the source for other reasons.