### PR TITLE
Cleanup: Stop passing around a superfluous []ClientState

### DIFF
--- a/rpc/export.go
+++ b/rpc/export.go
@@ -79,13 +79,13 @@ func (c *Conn) releaseExports(refs map[exportID]uint32) (releaseList, error) {
 // sendCap writes a capability descriptor, returning an export ID if
 // this vat is hosting the capability.  The caller must be holding
 // onto c.mu.
-func (c *Conn) sendCap(d rpccp.CapDescriptor, client *capnp.Client, state capnp.ClientState) (_ exportID, isExport bool) {
+func (c *Conn) sendCap(d rpccp.CapDescriptor, client *capnp.Client) (_ exportID, isExport bool) {
 	if !client.IsValid() {
 		d.SetNone()
 		return 0, false
 	}
 
-	if ic, ok := state.Brand.Value.(*importClient); ok && ic.c == c {
+	if ic, ok := client.State().Brand.Value.(*importClient); ok && ic.c == c {
 		if ent := c.imports[ic.id]; ent != nil && ent.generation == ic.generation {
 			d.SetReceiverHosted(uint32(ic.id))
 			return 0, false
@@ -124,10 +124,7 @@ func (c *Conn) sendCap(d rpccp.CapDescriptor, client *capnp.Client, state capnp.
 // reference counts added to the exports table.
 //
 // The caller must be holding onto c.mu.
-func (c *Conn) fillPayloadCapTable(payload rpccp.Payload, clients []*capnp.Client, states []capnp.ClientState) (map[exportID]uint32, error) {
-	if len(clients) != len(states) {
-		panic("states slice must be same size as cap table")
-	}
+func (c *Conn) fillPayloadCapTable(payload rpccp.Payload, clients []*capnp.Client) (map[exportID]uint32, error) {
 	if !payload.IsValid() || len(clients) == 0 {
 		return nil, nil
 	}
@@ -137,7 +134,7 @@ func (c *Conn) fillPayloadCapTable(payload rpccp.Payload, clients []*capnp.Clien
 	}
 	var refs map[exportID]uint32
 	for i, client := range clients {
-		id, isExport := c.sendCap(list.At(i), client, states[i])
+		id, isExport := c.sendCap(list.At(i), client)
 		if !isExport {
 			continue
 		}
@@ -153,18 +150,10 @@ func (c *Conn) fillPayloadCapTable(payload rpccp.Payload, clients []*capnp.Clien
 // message's capability table and sets the message's capability table
 // to nil.  The caller must not be holding onto any locks, since this
 // function can call application code (ClientHook.Brand).
-func extractCapTable(msg *capnp.Message) ([]*capnp.Client, []capnp.ClientState) {
-	if len(msg.CapTable) == 0 {
-		msg.CapTable = nil // in case msg.CapTable is a 0-length slice
-		return nil, nil
-	}
+func extractCapTable(msg *capnp.Message) []*capnp.Client {
 	ctab := msg.CapTable
 	msg.CapTable = nil
-	states := make([]capnp.ClientState, len(ctab))
-	for i, c := range ctab {
-		states[i] = c.State()
-	}
-	return ctab, states
+	return ctab
 }
 
 type embargoID uint32

--- a/rpc/import.go
+++ b/rpc/import.go
@@ -197,10 +197,10 @@ func (c *Conn) newImportCallMessage(msg rpccp.Message, imp importID, qid questio
 		m.CapTable = nil
 		return failedf("place arguments: %w", err)
 	}
-	clients, states := extractCapTable(m)
+	clients := extractCapTable(m)
 	c.mu.Lock()
 	// TODO(soon): save param refs
-	_, err = c.fillPayloadCapTable(payload, clients, states)
+	_, err = c.fillPayloadCapTable(payload, clients)
 	c.mu.Unlock()
 	releaseList(clients).release()
 	if err != nil {

--- a/rpc/question.go
+++ b/rpc/question.go
@@ -240,10 +240,10 @@ func (c *Conn) newPipelineCallMessage(msg rpccp.Message, tgt questionID, transfo
 		m.CapTable = nil
 		return failedf("place arguments: %w", err)
 	}
-	clients, states := extractCapTable(m)
+	clients := extractCapTable(m)
 	c.mu.Lock()
 	// TODO(soon): save param refs
-	_, err = c.fillPayloadCapTable(payload, clients, states)
+	_, err = c.fillPayloadCapTable(payload, clients)
 	c.mu.Unlock()
 	releaseList(clients).release()
 	if err != nil {

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -483,7 +483,6 @@ func (c *Conn) handleBootstrap(ctx context.Context, id answerID) error {
 	}
 	ret.SetAnswerId(uint32(id))
 	ret.SetReleaseParamCaps(false)
-	bootState := c.bootstrap.State()
 	c.mu.Lock()
 	ans := &answer{
 		c:          c,
@@ -507,7 +506,7 @@ func (c *Conn) handleBootstrap(ctx context.Context, id answerID) error {
 		rl.release()
 		return nil
 	}
-	rl, err := ans.sendReturn([]capnp.ClientState{bootState})
+	rl, err := ans.sendReturn()
 	c.unlockSender()
 	c.mu.Unlock()
 	rl.release()


### PR DESCRIPTION
This only actually gets used in sendCap(), but there we have a reference
to the corresponding client, so we can just call client.State() instead
of carrying around this parallel slice everywhere.