### PR TITLE
Support arbitrary client metadata, avoid linear seach in sendCap.

### DIFF
--- a/capability.go
+++ b/capability.go
@@ -464,6 +464,9 @@ type ClientState struct {
 	// Arbitrary metadata. Note that, if a Client is a promise,
 	// when it resolves its metadata will be replaced with that
 	// of its resolution.
+	//
+	// TODO: this might change before the v3 API is stabilized;
+	// we are not sure the above is the correct semantics.
 	Metadata *Metadata
 }
 

--- a/capability.go
+++ b/capability.go
@@ -139,8 +139,8 @@ func NewClient(hook ClientHook) *Client {
 		done:       make(chan struct{}),
 		refs:       1,
 		resolved:   newClosedSignal(),
+		metadata:   *NewMetadata(),
 	}
-	(&h.metadata).init()
 	h.resolvedHook = h
 	c := &Client{h: h}
 	if clientLeakFunc != nil {
@@ -167,8 +167,8 @@ func NewPromisedClient(hook ClientHook) (*Client, *ClientPromise) {
 		done:       make(chan struct{}),
 		refs:       1,
 		resolved:   make(chan struct{}),
+		metadata:   *NewMetadata(),
 	}
-	(&h.metadata).init()
 	c := &Client{h: h}
 	if clientLeakFunc != nil {
 		c.creatorFunc = 2
@@ -854,8 +854,8 @@ func ErrorClient(e error) *Client {
 		done:       make(chan struct{}),
 		refs:       1,
 		resolved:   newClosedSignal(),
+		metadata:   *NewMetadata(),
 	}
-	(&h.metadata).init()
 	h.resolvedHook = h
 	return &Client{h: h}
 }

--- a/metadata.go
+++ b/metadata.go
@@ -8,8 +8,8 @@ import (
 // sync.Locker; it is used by the rpc system to attach bookkeeping
 // information to Clients.
 //
-// The zero value is not meaningful, and once initialized the Metadata
-// must not be copied.
+// The zero value is not meaningful, and the Metadata must not be copied
+// after its first use.
 type Metadata struct {
 	mu     sync.Mutex
 	values map[interface{}]interface{}
@@ -44,16 +44,7 @@ func (m *Metadata) Delete(key interface{}) {
 
 // Allocate and return a freshly initialized Metadata.
 func NewMetadata() *Metadata {
-	ret := &Metadata{}
-	ret.init()
-	return ret
-}
-
-// Initialize the metadata. This must be called exactly once before
-// using it.
-func (m *Metadata) init() {
-	if m.values != nil {
-		panic("called Metadata.init() twice")
+	return &Metadata{
+		values: make(map[interface{}]interface{}),
 	}
-	m.values = make(map[interface{}]interface{})
 }

--- a/metadata.go
+++ b/metadata.go
@@ -1,0 +1,59 @@
+package capnp
+
+import (
+	"sync"
+)
+
+// Metadata is a morally a map[interface{}]interface{} which implements
+// sync.Locker; it is used by the rpc system to attach bookkeeping
+// information to Clients.
+//
+// The zero value is not meaningful, and once initialized the Metadata
+// must not be copied.
+type Metadata struct {
+	mu     sync.Mutex
+	values map[interface{}]interface{}
+}
+
+// Lock the metadata map.
+func (m *Metadata) Lock() {
+	m.mu.Lock()
+}
+
+// Unlock the metadata map.
+func (m *Metadata) Unlock() {
+	m.mu.Unlock()
+}
+
+// Look up key in the map. Returns the value, and a boolean which is
+// false if the key was not present.
+func (m *Metadata) Get(key interface{}) (value interface{}, ok bool) {
+	value, ok = m.values[key]
+	return
+}
+
+// Insert the key, value pair into the map.
+func (m *Metadata) Put(key, value interface{}) {
+	m.values[key] = value
+}
+
+// Delete the key from the map.
+func (m *Metadata) Delete(key interface{}) {
+	delete(m.values, key)
+}
+
+// Allocate and return a freshly initialized Metadata.
+func NewMetadata() *Metadata {
+	ret := &Metadata{}
+	ret.init()
+	return ret
+}
+
+// Initialize the metadata. This must be called exactly once before
+// using it.
+func (m *Metadata) init() {
+	if m.values != nil {
+		panic("called Metadata.init() twice")
+	}
+	m.values = make(map[interface{}]interface{})
+}

--- a/rpc/export.go
+++ b/rpc/export.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"capnproto.org/go/capnp/v3"
+	"capnproto.org/go/capnp/v3/internal/syncutil"
 	rpccp "capnproto.org/go/capnp/v3/std/capnp/rpc"
 )
 
@@ -65,9 +66,9 @@ func (c *Conn) releaseExport(id exportID, count uint32) (*capnp.Client, error) {
 		c.exports[id] = nil
 		c.exportID.remove(uint32(id))
 		metadata := client.State().Metadata
-		metadata.Lock()
-		defer metadata.Unlock()
-		c.clearExportID(metadata)
+		syncutil.With(metadata, func() {
+			c.clearExportID(metadata)
+		})
 		return client, nil
 	case count > ent.wireRefs:
 		return nil, failedf("export ID %d released too many references", id)

--- a/rpc/export.go
+++ b/rpc/export.go
@@ -112,7 +112,8 @@ func (c *Conn) sendCap(d rpccp.CapDescriptor, client *capnp.Client) (_ exportID,
 		return 0, false
 	}
 
-	if ic, ok := client.State().Brand.Value.(*importClient); ok && ic.c == c {
+	state := client.State()
+	if ic, ok := state.Brand.Value.(*importClient); ok && ic.c == c {
 		if ent := c.imports[ic.id]; ent != nil && ent.generation == ic.generation {
 			d.SetReceiverHosted(uint32(ic.id))
 			return 0, false

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -302,9 +302,9 @@ func (c *Conn) shutdown(abortErr error) error {
 	for _, e := range exports {
 		if e != nil {
 			metadata := e.client.State().Metadata
-			metadata.Lock()
-			c.clearExportID(metadata)
-			metadata.Unlock()
+			syncutil.With(metadata, func() {
+				c.clearExportID(metadata)
+			})
 			e.client.Release()
 		}
 	}

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -300,6 +300,10 @@ func (c *Conn) shutdown(abortErr error) error {
 	c.bootstrap = nil
 	for _, e := range exports {
 		if e != nil {
+			metadata := e.client.State().Metadata
+			metadata.Lock()
+			c.clearExportID(metadata)
+			metadata.Unlock()
 			e.client.Release()
 		}
 	}


### PR DESCRIPTION
This solves an issue I discovered where sendCap() does a linear search
on the exports table for each sent capability.

After a long discussion with Louis over matrix, we concluded that adding
a metadata object for clients was the best solution; there's a general
design awkwardness right now where the rpc system needs to be able to
inspect the client in various ways, but Client is defined in the main
package and tries to encapsulate its implementation details. To some
degree we are able to use Brand(), but this gets awkward quickly,
because:

1. ClientHook is an openly implementable interface, so we don't know
   all the posibilities in the rpc code.
2. As I've been working on supporting receiverAnswer, I've found
   pinning down all the implementations I defined in the library that
   need to be worried about is challenging.
3. Some of these implementations aren't even exported, or just return
   nil from Brand().

The Metadata object lets the rpc system manage the bookkeeping
information independently of the internals of a client.

I expect to use this for more in the future, but for now this lets
us avoid the linear search by just storing the export id for each
connection in the client's metadata.