### PR TITLE
Add some helpers for acquiring locks

### DIFF
--- a/capability.go
+++ b/capability.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	"capnproto.org/go/capnp/v3/flowcontrol"
+	"capnproto.org/go/capnp/v3/internal/syncutil"
 )
 
 // An Interface is a reference to a client in a message's capability table.
@@ -193,12 +194,12 @@ func (c *Client) startCall() (hook ClientHook, resolved, released bool, finish f
 	c.h.mu.Unlock()
 	savedHook := c.h
 	return savedHook.ClientHook, savedHook.isResolved(), false, func() {
-		savedHook.mu.Lock()
-		savedHook.calls--
-		if savedHook.refs == 0 && savedHook.calls == 0 {
-			close(savedHook.done)
-		}
-		savedHook.mu.Unlock()
+		syncutil.With(&savedHook.mu, func() {
+			savedHook.calls--
+			if savedHook.refs == 0 && savedHook.calls == 0 {
+				close(savedHook.done)
+			}
+		})
 	}
 }
 

--- a/internal/syncutil/with.go
+++ b/internal/syncutil/with.go
@@ -1,0 +1,20 @@
+// misc. utilities for synchronization.
+package syncutil
+
+import (
+	"sync"
+)
+
+// Runs f while holding the lock
+func With(l sync.Locker, f func()) {
+	l.Lock()
+	defer l.Unlock()
+	f()
+}
+
+// Runs f while not holding the lock
+func Without(l sync.Locker, f func()) {
+	l.Unlock()
+	defer l.Lock()
+	f()
+}

--- a/rpc/answer.go
+++ b/rpc/answer.go
@@ -6,6 +6,7 @@ import (
 
 	"capnproto.org/go/capnp/v3"
 	"capnproto.org/go/capnp/v3/internal/errors"
+	"capnproto.org/go/capnp/v3/internal/syncutil"
 	rpccp "capnproto.org/go/capnp/v3/std/capnp/rpc"
 )
 
@@ -109,11 +110,11 @@ func (c *Conn) newReturn(ctx context.Context) (rpccp.Return, func() error, capnp
 // already returned.  The caller MUST NOT be holding onto ans.c.mu
 // or the sender lock.
 func (ans *answer) setPipelineCaller(pcall capnp.PipelineCaller) {
-	ans.c.mu.Lock()
-	if ans.flags&resultsReady == 0 {
-		ans.pcall = pcall
-	}
-	ans.c.mu.Unlock()
+	syncutil.With(&ans.c.mu, func() {
+		if ans.flags&resultsReady == 0 {
+			ans.pcall = pcall
+		}
+	})
 }
 
 // AllocResults allocates the results struct.
@@ -234,9 +235,9 @@ func (ans *answer) sendReturn(cstates []capnp.ClientState) (releaseList, error) 
 		return nil, nil
 	}
 	rl, err := ans.destroy()
-	ans.c.mu.Unlock()
-	ans.releaseMsg()
-	ans.c.mu.Lock()
+	syncutil.Without(&ans.c.mu, func() {
+		ans.releaseMsg()
+	})
 	return rl, err
 }
 
@@ -282,9 +283,9 @@ func (ans *answer) sendException(e error) releaseList {
 	// destroy will never return an error because sendException does
 	// create any exports.
 	rl, _ := ans.destroy()
-	ans.c.mu.Unlock()
-	ans.releaseMsg()
-	ans.c.mu.Lock()
+	syncutil.Without(&ans.c.mu, func() {
+		ans.releaseMsg()
+	})
 	return rl
 }
 

--- a/rpc/import.go
+++ b/rpc/import.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"capnproto.org/go/capnp/v3"
+	"capnproto.org/go/capnp/v3/internal/syncutil"
 	rpccp "capnproto.org/go/capnp/v3/std/capnp/rpc"
 )
 
@@ -105,33 +106,33 @@ func (ic *importClient) Send(ctx context.Context, s capnp.Send) (*capnp.Answer, 
 	// Create call message.
 	msg, send, release, err := ic.c.transport.NewMessage(ctx)
 	if err != nil {
-		ic.c.mu.Lock()
-		ic.c.questions[q.id] = nil
-		ic.c.questionID.remove(uint32(q.id))
-		ic.c.mu.Unlock()
+		syncutil.With(&ic.c.mu, func() {
+			ic.c.questions[q.id] = nil
+			ic.c.questionID.remove(uint32(q.id))
+		})
 		return capnp.ErrorAnswer(s.Method, failedf("create message: %w", err)), func() {}
 	}
-	ic.c.mu.Lock()
-	ic.c.unlockSender() // Can't be holding either lock while calling PlaceArgs.
-	ic.c.mu.Unlock()
+	syncutil.With(&ic.c.mu, func() {
+		ic.c.unlockSender() // Can't be holding either lock while calling PlaceArgs.
+	})
 	err = ic.c.newImportCallMessage(msg, ic.id, q.id, s)
 	if err != nil {
-		ic.c.mu.Lock()
-		ic.c.questions[q.id] = nil
-		ic.c.questionID.remove(uint32(q.id))
-		ic.c.lockSender()
-		ic.c.mu.Unlock()
+		syncutil.With(&ic.c.mu, func() {
+			ic.c.questions[q.id] = nil
+			ic.c.questionID.remove(uint32(q.id))
+			ic.c.lockSender()
+		})
 		release()
-		ic.c.mu.Lock()
-		ic.c.unlockSender()
-		ic.c.mu.Unlock()
+		syncutil.With(&ic.c.mu, func() {
+			ic.c.unlockSender()
+		})
 		return capnp.ErrorAnswer(s.Method, err), func() {}
 	}
 
 	// Send call.
-	ic.c.mu.Lock()
-	ic.c.lockSender()
-	ic.c.mu.Unlock()
+	syncutil.With(&ic.c.mu, func() {
+		ic.c.lockSender()
+	})
 	err = send()
 	release()
 
@@ -198,10 +199,10 @@ func (c *Conn) newImportCallMessage(msg rpccp.Message, imp importID, qid questio
 		return failedf("place arguments: %w", err)
 	}
 	clients, states := extractCapTable(m)
-	c.mu.Lock()
-	// TODO(soon): save param refs
-	_, err = c.fillPayloadCapTable(payload, clients, states)
-	c.mu.Unlock()
+	syncutil.With(&c.mu, func() {
+		// TODO(soon): save param refs
+		_, err = c.fillPayloadCapTable(payload, clients, states)
+	})
 	releaseList(clients).release()
 	if err != nil {
 		return annotate(err, "build call message")

--- a/rpc/question.go
+++ b/rpc/question.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"capnproto.org/go/capnp/v3"
+	"capnproto.org/go/capnp/v3/internal/syncutil"
 	rpccp "capnproto.org/go/capnp/v3/std/capnp/rpc"
 )
 
@@ -135,33 +136,33 @@ func (q *question) PipelineSend(ctx context.Context, transform []capnp.PipelineO
 	// Create call message.
 	msg, send, release, err := q.c.transport.NewMessage(ctx)
 	if err != nil {
-		q.c.mu.Lock()
-		q.c.questions[q2.id] = nil
-		q.c.questionID.remove(uint32(q2.id))
-		q.c.mu.Unlock()
+		syncutil.With(&q.c.mu, func() {
+			q.c.questions[q2.id] = nil
+			q.c.questionID.remove(uint32(q2.id))
+		})
 		return capnp.ErrorAnswer(s.Method, failedf("create message: %w", err)), func() {}
 	}
-	q.c.mu.Lock()
-	q.c.unlockSender() // Can't be holding either lock while calling PlaceArgs.
-	q.c.mu.Unlock()
+	syncutil.With(&q.c.mu, func() {
+		q.c.unlockSender() // Can't be holding either lock while calling PlaceArgs.
+	})
 	err = q.c.newPipelineCallMessage(msg, q.id, transform, q2.id, s)
 	if err != nil {
-		q.c.mu.Lock()
-		q.c.questions[q2.id] = nil
-		q.c.questionID.remove(uint32(q2.id))
-		q.c.lockSender()
-		q.c.mu.Unlock()
+		syncutil.With(&q.c.mu, func() {
+			q.c.questions[q2.id] = nil
+			q.c.questionID.remove(uint32(q2.id))
+			q.c.lockSender()
+		})
 		release()
-		q.c.mu.Lock()
-		q.c.unlockSender()
-		q.c.mu.Unlock()
+		syncutil.With(&q.c.mu, func() {
+			q.c.unlockSender()
+		})
 		return capnp.ErrorAnswer(s.Method, err), func() {}
 	}
 
 	// Send call.
-	q.c.mu.Lock()
-	q.c.lockSender()
-	q.c.mu.Unlock()
+	syncutil.With(&q.c.mu, func() {
+		q.c.lockSender()
+	})
 	err = send()
 	release()
 
@@ -241,10 +242,10 @@ func (c *Conn) newPipelineCallMessage(msg rpccp.Message, tgt questionID, transfo
 		return failedf("place arguments: %w", err)
 	}
 	clients, states := extractCapTable(m)
-	c.mu.Lock()
-	// TODO(soon): save param refs
-	_, err = c.fillPayloadCapTable(payload, clients, states)
-	c.mu.Unlock()
+	syncutil.With(&c.mu, func() {
+		// TODO(soon): save param refs
+		_, err = c.fillPayloadCapTable(payload, clients, states)
+	})
 	releaseList(clients).release()
 	if err != nil {
 		return annotate(err, "build call message")

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -9,6 +9,7 @@ import (
 
 	"capnproto.org/go/capnp/v3"
 	"capnproto.org/go/capnp/v3/internal/errors"
+	"capnproto.org/go/capnp/v3/internal/syncutil"
 	rpccp "capnproto.org/go/capnp/v3/std/capnp/rpc"
 )
 
@@ -281,9 +282,9 @@ func (c *Conn) shutdown(abortErr error) error {
 	}
 
 	// Wait for work to stop.
-	c.mu.Unlock()
-	c.tasks.Wait()
-	c.mu.Lock()
+	syncutil.Without(&c.mu, func() {
+		c.tasks.Wait()
+	})
 
 	// Clear all tables, releasing exported clients and unfinished answers.
 	exports := c.exports
@@ -474,10 +475,10 @@ func (c *Conn) handleBootstrap(ctx context.Context, id answerID) error {
 	ret, send, release, err := c.newReturn(ctx)
 	if err != nil {
 		err = annotate(err, "incoming bootstrap")
-		c.mu.Lock()
-		c.answers[id] = errorAnswer(c, id, err)
-		c.unlockSender()
-		c.mu.Unlock()
+		syncutil.With(&c.mu, func() {
+			c.answers[id] = errorAnswer(c, id, err)
+			c.unlockSender()
+		})
 		c.report(err)
 		return nil
 	}
@@ -524,18 +525,19 @@ func (c *Conn) handleCall(ctx context.Context, call rpccp.Call, releaseCall capn
 	if call.SendResultsTo().Which() != rpccp.Call_sendResultsTo_Which_caller {
 		// TODO(someday): handle SendResultsTo.yourself
 		c.report(failedf("incoming call: results destination is not caller"))
-		c.mu.Lock()
-		err := c.sendMessage(ctx, func(m rpccp.Message) error {
-			mm, err := m.NewUnimplemented()
-			if err != nil {
-				return err
-			}
-			if err := mm.SetCall(call); err != nil {
-				return err
-			}
-			return nil
+		var err error
+		syncutil.With(&c.mu, func() {
+			err = c.sendMessage(ctx, func(m rpccp.Message) error {
+				mm, err := m.NewUnimplemented()
+				if err != nil {
+					return err
+				}
+				if err := mm.SetCall(call); err != nil {
+					return err
+				}
+				return nil
+			})
 		})
-		c.mu.Unlock()
 		releaseCall()
 		if err != nil {
 			c.report(annotate(err, "incoming call: send unimplemented"))
@@ -563,10 +565,10 @@ func (c *Conn) handleCall(ctx context.Context, call rpccp.Call, releaseCall capn
 	ret, send, releaseRet, err := c.newReturn(ctx)
 	if err != nil {
 		err = annotate(err, "incoming call")
-		c.mu.Lock()
-		c.answers[id] = errorAnswer(c, id, err)
-		c.unlockSender()
-		c.mu.Unlock()
+		syncutil.With(&c.mu, func() {
+			c.answers[id] = errorAnswer(c, id, err)
+			c.unlockSender()
+		})
 		c.report(err)
 		clearCapTable(call.Message())
 		releaseCall()
@@ -614,9 +616,9 @@ func (c *Conn) handleCall(ctx context.Context, call rpccp.Call, releaseCall capn
 			ans.releaseMsg = nil
 			c.mu.Unlock()
 			releaseRet()
-			c.mu.Lock()
-			c.unlockSender()
-			c.mu.Unlock()
+			syncutil.With(&c.mu, func() {
+				c.unlockSender()
+			})
 			clearCapTable(call.Message())
 			releaseCall()
 			return failedf("incoming call: unknown export ID %d", id)
@@ -645,9 +647,9 @@ func (c *Conn) handleCall(ctx context.Context, call rpccp.Call, releaseCall capn
 			ans.releaseMsg = nil
 			c.mu.Unlock()
 			releaseRet()
-			c.mu.Lock()
-			c.unlockSender()
-			c.mu.Unlock()
+			syncutil.With(&c.mu, func() {
+				c.unlockSender()
+			})
 			clearCapTable(call.Message())
 			releaseCall()
 			return failedf("incoming call: use of unknown or finished answer ID %d for promised answer target", p.target.promisedAnswer)
@@ -848,11 +850,11 @@ func (c *Conn) handleReturn(ctx context.Context, ret rpccp.Return, releaseRet ca
 			c.mu.Unlock()
 			releaseRet()
 			<-q.finishMsgSend
-			c.mu.Lock()
-			if q.flags&finishSent != 0 {
-				c.questionID.remove(uint32(qid))
-			}
-			c.mu.Unlock()
+			syncutil.With(&c.mu, func() {
+				if q.flags&finishSent != 0 {
+					c.questionID.remove(uint32(qid))
+				}
+			})
 		}
 		return nil
 	}
@@ -863,40 +865,40 @@ func (c *Conn) handleReturn(ctx context.Context, ret rpccp.Return, releaseRet ca
 	switch {
 	case q.bootstrapPromise != nil && pr.err == nil:
 		q.release = func() {}
-		c.mu.Unlock()
-		q.p.Fulfill(pr.result)
-		q.bootstrapPromise.Fulfill(q.p.Answer().Client())
-		q.p.ReleaseClients()
-		clearCapTable(pr.result.Message())
-		releaseRet()
-		c.mu.Lock()
+		syncutil.Without(&c.mu, func() {
+			q.p.Fulfill(pr.result)
+			q.bootstrapPromise.Fulfill(q.p.Answer().Client())
+			q.p.ReleaseClients()
+			clearCapTable(pr.result.Message())
+			releaseRet()
+		})
 	case q.bootstrapPromise != nil && pr.err != nil:
 		// TODO(someday): send unimplemented message back to remote if
 		// pr.unimplemented == true.
 		q.release = func() {}
-		c.mu.Unlock()
-		q.p.Reject(pr.err)
-		q.bootstrapPromise.Fulfill(q.p.Answer().Client())
-		q.p.ReleaseClients()
-		releaseRet()
-		c.mu.Lock()
+		syncutil.Without(&c.mu, func() {
+			q.p.Reject(pr.err)
+			q.bootstrapPromise.Fulfill(q.p.Answer().Client())
+			q.p.ReleaseClients()
+			releaseRet()
+		})
 	case q.bootstrapPromise == nil && pr.err != nil:
 		// TODO(someday): send unimplemented message back to remote if
 		// pr.unimplemented == true.
 		q.release = func() {}
-		c.mu.Unlock()
-		q.p.Reject(pr.err)
-		releaseRet()
-		c.mu.Lock()
+		syncutil.Without(&c.mu, func() {
+			q.p.Reject(pr.err)
+			releaseRet()
+		})
 	default:
 		m := ret.Message()
 		q.release = func() {
 			clearCapTable(m)
 			releaseRet()
 		}
-		c.mu.Unlock()
-		q.p.Fulfill(pr.result)
-		c.mu.Lock()
+		syncutil.Without(&c.mu, func() {
+			q.p.Fulfill(pr.result)
+		})
 	}
 	if err := c.tryLockSender(ctx); err != nil {
 		close(q.finishMsgSend)
@@ -933,20 +935,20 @@ func (c *Conn) handleReturn(ctx context.Context, ret rpccp.Return, releaseRet ca
 	{
 		msg, send, release, err := c.transport.NewMessage(ctx)
 		if err != nil {
-			c.mu.Lock()
-			c.unlockSender()
-			close(q.finishMsgSend)
-			c.mu.Unlock()
+			syncutil.With(&c.mu, func() {
+				c.unlockSender()
+				close(q.finishMsgSend)
+			})
 			c.report(annotate(err, "incoming return: send finish"))
 			return nil
 		}
 		fin, err := msg.NewFinish()
 		if err != nil {
 			release()
-			c.mu.Lock()
-			c.unlockSender()
-			close(q.finishMsgSend)
-			c.mu.Unlock()
+			syncutil.With(&c.mu, func() {
+				c.unlockSender()
+				close(q.finishMsgSend)
+			})
 			c.report(failedf("incoming return: send finish: build message: %w", err))
 			return nil
 		}
@@ -955,21 +957,21 @@ func (c *Conn) handleReturn(ctx context.Context, ret rpccp.Return, releaseRet ca
 		err = send()
 		release()
 		if err != nil {
-			c.mu.Lock()
-			c.unlockSender()
-			close(q.finishMsgSend)
-			c.mu.Unlock()
+			syncutil.With(&c.mu, func() {
+				c.unlockSender()
+				close(q.finishMsgSend)
+			})
 			c.report(failedf("incoming return: send finish: build message: %w", err))
 			return nil
 		}
 	}
 
-	c.mu.Lock()
-	c.unlockSender()
-	q.flags |= finishSent
-	c.questionID.remove(uint32(qid))
-	close(q.finishMsgSend)
-	c.mu.Unlock()
+	syncutil.With(&c.mu, func() {
+		c.unlockSender()
+		q.flags |= finishSent
+		c.questionID.remove(uint32(qid))
+		close(q.finishMsgSend)
+	})
 	return nil
 }
 
@@ -1061,9 +1063,9 @@ func (c *Conn) handleFinish(ctx context.Context, id answerID, releaseResultCaps 
 	rl, err := ans.destroy()
 	if ans.releaseMsg != nil {
 		c.lockSender()
-		c.mu.Unlock()
-		ans.releaseMsg()
-		c.mu.Lock()
+		syncutil.Without(&c.mu, func() {
+			ans.releaseMsg()
+		})
 		c.unlockSender()
 	}
 	c.mu.Unlock()
@@ -1257,18 +1259,19 @@ func (c *Conn) handleDisembargo(ctx context.Context, d rpccp.Disembargo) error {
 		}
 	default:
 		c.report(failedf("incoming disembargo: context %v not implemented", d.Context().Which()))
-		c.mu.Lock()
-		err := c.sendMessage(ctx, func(msg rpccp.Message) error {
-			mm, err := msg.NewUnimplemented()
-			if err != nil {
-				return err
-			}
-			if err := mm.SetDisembargo(d); err != nil {
-				return err
-			}
-			return nil
+		var err error
+		syncutil.With(&c.mu, func() {
+			err = c.sendMessage(ctx, func(msg rpccp.Message) error {
+				mm, err := msg.NewUnimplemented()
+				if err != nil {
+					return err
+				}
+				if err := mm.SetDisembargo(d); err != nil {
+					return err
+				}
+				return nil
+			})
 		})
-		c.mu.Unlock()
 		if err != nil {
 			c.report(annotate(err, "incoming disembargo: send unimplemented"))
 		}
@@ -1278,11 +1281,12 @@ func (c *Conn) handleDisembargo(ctx context.Context, d rpccp.Disembargo) error {
 
 func (c *Conn) handleUnknownMessage(ctx context.Context, recv rpccp.Message) error {
 	c.report(failedf("unknown message type %v from remote", recv.Which()))
-	c.mu.Lock()
-	err := c.sendMessage(ctx, func(msg rpccp.Message) error {
-		return msg.SetUnimplemented(recv)
+	var err error
+	syncutil.With(&c.mu, func() {
+		err = c.sendMessage(ctx, func(msg rpccp.Message) error {
+			return msg.SetUnimplemented(recv)
+		})
 	})
-	c.mu.Unlock()
 	if err != nil {
 		c.report(annotate(err, "send unimplemented"))
 	}
@@ -1373,9 +1377,9 @@ func (c *Conn) lockSender() {
 		if s == nil {
 			break
 		}
-		c.mu.Unlock()
-		<-s
-		c.mu.Lock()
+		syncutil.Without(&c.mu, func() {
+			<-s
+		})
 	}
 	c.sendCond = make(chan struct{})
 }


### PR DESCRIPTION
This adds a couple helpers "With" and "Without", which  make it easier
to follow where the boundaries of critical sections (and the holes in
them) are, when the helpers are applicable.

This is especially helpful in that using it consistently means places
where the lock management is *not* just a simple straight-line critical
section stand out.