### PR TITLE
Transport: don't require clearing the cap table.

### DIFF
--- a/rpc/answer.go
+++ b/rpc/answer.go
@@ -166,7 +166,7 @@ func (ans *answer) setBootstrap(c *capnp.Client) error {
 // The caller must NOT be holding onto ans.c.mu or the sender lock.
 func (ans *answer) Return(e error) {
 	if ans.results.IsValid() {
-		ans.resultCapTable = extractCapTable(ans.results.Message())
+		ans.resultCapTable = ans.results.Message().CapTable
 	}
 	ans.c.mu.Lock()
 	ans.c.lockSender()

--- a/rpc/export.go
+++ b/rpc/export.go
@@ -177,16 +177,6 @@ func (c *Conn) fillPayloadCapTable(payload rpccp.Payload, clients []*capnp.Clien
 	return refs, nil
 }
 
-// extractCapTable reads the state of all the capabilities in a
-// message's capability table and sets the message's capability table
-// to nil.  The caller must not be holding onto any locks, since this
-// function can call application code (ClientHook.Brand).
-func extractCapTable(msg *capnp.Message) []*capnp.Client {
-	ctab := msg.CapTable
-	msg.CapTable = nil
-	return ctab
-}
-
 type embargoID uint32
 
 type embargo struct {

--- a/rpc/import.go
+++ b/rpc/import.go
@@ -198,7 +198,7 @@ func (c *Conn) newImportCallMessage(msg rpccp.Message, imp importID, qid questio
 		m.CapTable = nil
 		return failedf("place arguments: %w", err)
 	}
-	clients := extractCapTable(m)
+	clients := m.CapTable
 	syncutil.With(&c.mu, func() {
 		// TODO(soon): save param refs
 		_, err = c.fillPayloadCapTable(payload, clients)

--- a/rpc/pipe_test.go
+++ b/rpc/pipe_test.go
@@ -63,9 +63,6 @@ func (p *pipe) NewMessage(ctx context.Context) (_ rpccp.Message, send func() err
 			panic("double send")
 		}
 		sent = true
-		if msg.CapTable != nil {
-			panic("send with non-nil CapTable")
-		}
 		refsMu.Lock()
 		refs++
 		refsMu.Unlock()
@@ -76,9 +73,6 @@ func (p *pipe) NewMessage(ctx context.Context) (_ rpccp.Message, send func() err
 					return
 				}
 				recvDone = true
-				if msg.CapTable != nil {
-					panic("received message released without clearing CapTable")
-				}
 				refsMu.Lock()
 				r := refs - 1
 				refs = r
@@ -117,11 +111,6 @@ func (p *pipe) NewMessage(ctx context.Context) (_ rpccp.Message, send func() err
 			return
 		}
 		sendDone = true
-		if !sent {
-			if msg.CapTable != nil {
-				panic("outgoing message released without clearing CapTable")
-			}
-		}
 		delete(p.msgs, caller)
 		refsMu.Lock()
 		r := refs - 1

--- a/rpc/question.go
+++ b/rpc/question.go
@@ -241,7 +241,7 @@ func (c *Conn) newPipelineCallMessage(msg rpccp.Message, tgt questionID, transfo
 		m.CapTable = nil
 		return failedf("place arguments: %w", err)
 	}
-	clients := extractCapTable(m)
+	clients := m.CapTable
 	syncutil.With(&c.mu, func() {
 		// TODO(soon): save param refs
 		_, err = c.fillPayloadCapTable(payload, clients)

--- a/rpc/transport.go
+++ b/rpc/transport.go
@@ -24,8 +24,7 @@ type Transport interface {
 	// deadline from ctx.
 	//
 	// Messages returned by NewMessage must have a nil CapTable.
-	// The caller may modify the CapTable before sending it, but the
-	// message's CapTable must be nil before it is sent or released.
+	// The caller may modify the CapTable as it pleases.
 	//
 	// The Arena in the returned message should be fast at allocating new
 	// segments.
@@ -38,8 +37,7 @@ type Transport interface {
 	// returned by RecvMessage.
 	//
 	// Messages returned by RecvMessage must have a nil CapTable.
-	// The caller may modify the CapTable, but the message's CapTable must
-	// be nil before it is released.
+	// The caller may modify the CapTable as it pleases.
 	//
 	// The Arena in the returned message should not fetch segments lazily;
 	// the Arena should be fast to access other segments.


### PR DESCRIPTION
This also changes the rpc subsystem to avoid clearing the cap table for
sent answers, which makes things easier to work with, per #216.

In particular, with this change #213 works as expected.

We could further clean things up by getting rid of `answer.resultCapTable` and just using `answer.results.Message().CapTable` everywhere. I have a patch locally that tries to do this, but it introduces a deadlock I haven't pinned down, so I'm submitting this without that for now.