### PR TITLE
Support canonicalizing interface pointers.

### DIFF
--- a/canonical.go
+++ b/canonical.go
@@ -43,7 +43,8 @@ func canonicalPtr(dst *Segment, p Ptr) (Ptr, error) {
 		}
 		return ll.ToPtr(), nil
 	case interfacePtrType:
-		return Ptr{}, newError("cannot canonicalize interface")
+		iface := NewInterface(dst, p.Interface().Capability())
+		return iface.ToPtr(), nil
 	default:
 		panic("unreachable")
 	}

--- a/canonical_test.go
+++ b/canonical_test.go
@@ -82,6 +82,24 @@ func TestCanonicalize(t *testing.T) {
 		}
 	}
 	{
+		// pointer to interface
+		_, seg, _ := NewMessage(SingleSegment(nil))
+		s, _ := NewStruct(seg, ObjectSize{PointerCount: 2})
+		iface := NewInterface(seg, 1)
+		s.SetPtr(0, iface.ToPtr())
+		b, err := Canonicalize(s)
+		if err != nil {
+			t.Fatal("Canonicalize(pointer to interface):", err)
+		}
+		want := ([]byte{
+			0, 0, 0, 0, 0, 0, 1, 0,
+			3, 0, 0, 0, 1, 0, 0, 0,
+		})
+		if !bytes.Equal(b, want) {
+			t.Errorf("Canonicalize(pointer to interface) =\n%s\n; want\n%s", hex.Dump(b), hex.Dump(want))
+		}
+	}
+	{
 		// int list
 		_, seg, _ := NewMessage(SingleSegment(nil))
 		s, _ := NewStruct(seg, ObjectSize{PointerCount: 1})


### PR DESCRIPTION
This is consistent with what the C++ and Haskell implementations do;
rather than failing, simply copy the index.

---

I need this for something I'm working on where I separately serialize a `CapTable` to disk, and then store a canoniclized structure like:

```capnproto
struct Stored(T) {
  value @0 :T;
  caps @1 :List(StoredCap);
}
```

...such that upon reading back the data I can reconstruct the CapTable from the `caps` field -- but I need to be able to retain interface pointers inside `value` when canonicalizing.