### PR TITLE
Remove unused contextImport constant.

### DIFF
--- a/capnpc-go/capnpc-go.go
+++ b/capnpc-go/capnpc-go.go
@@ -33,7 +33,6 @@ const (
 	textImport    = capnpImport + "/encoding/text"
 	schemasImport = capnpImport + "/schemas"
 	serverImport  = capnpImport + "/server"
-	contextImport = "golang.org/x/net/context"
 )
 
 // genoptions are parameters that control code generation.


### PR DESCRIPTION
Presumably, the uses of this were removed when we switched over to
importing context from the stdlib.