### PR TITLE
Fix linter warning due to discarded CancelFunc in mpsc_test

### DIFF
--- a/internal/mpsc/mpsc_test.go
+++ b/internal/mpsc/mpsc_test.go
@@ -22,7 +22,8 @@ func TestRecvEmpty(t *testing.T) {
 	q := New[int]()
 
 	// Recv() on an empty queue should block until the context is canceled.
-	ctx, _ := context.WithTimeout(context.Background(), time.Millisecond*10)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*10)
+	defer cancel()
 
 	v, err := q.Recv(ctx)
 	assert.Equal(t, ctx.Err(), err, "Returned error is not ctx.Err()")


### PR DESCRIPTION
My linter complains when `context.CancelFunc` return values (e.g. from `WithTimeout`) are discarded without being called.  This PR fixes such an issue in `TestRecvEmpty`.