### PR TITLE
Lintfix.  Explicitly assign value to `List` field in `StructList`.

### DIFF
--- a/capnpc-go/templates/structList
+++ b/capnpc-go/templates/structList
@@ -4,5 +4,5 @@ type {{.Node.Name}}_List = {{.G.Capnp}}.StructList[{{.Node.Name}}]
 // New{{.Node.Name}} creates a new list of {{.Node.Name}}.
 func New{{.Node.Name}}_List(s *{{.G.Capnp}}.Segment, sz int32) ({{.Node.Name}}_List, error) {
 	l, err := {{.G.Capnp}}.NewCompositeList(s, {{.G.ObjectSize .Node}}, sz)
-	return {{.G.Capnp}}.StructList[{{.Node.Name}}]{l}, err
+	return {{.G.Capnp}}.StructList[{{.Node.Name}}]{List: l}, err
 }

--- a/internal/aircraftlib/aircraft.capnp.go
+++ b/internal/aircraftlib/aircraft.capnp.go
@@ -78,7 +78,7 @@ type Zdate_List = capnp.StructList[Zdate]
 // NewZdate creates a new list of Zdate.
 func NewZdate_List(s *capnp.Segment, sz int32) (Zdate_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 8, PointerCount: 0}, sz)
-	return capnp.StructList[Zdate]{l}, err
+	return capnp.StructList[Zdate]{List: l}, err
 }
 
 // Zdate_Future is a wrapper for a Zdate promised by a client call.
@@ -133,7 +133,7 @@ type Zdata_List = capnp.StructList[Zdata]
 // NewZdata creates a new list of Zdata.
 func NewZdata_List(s *capnp.Segment, sz int32) (Zdata_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 0, PointerCount: 1}, sz)
-	return capnp.StructList[Zdata]{l}, err
+	return capnp.StructList[Zdata]{List: l}, err
 }
 
 // Zdata_Future is a wrapper for a Zdata promised by a client call.
@@ -318,7 +318,7 @@ type PlaneBase_List = capnp.StructList[PlaneBase]
 // NewPlaneBase creates a new list of PlaneBase.
 func NewPlaneBase_List(s *capnp.Segment, sz int32) (PlaneBase_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 32, PointerCount: 2}, sz)
-	return capnp.StructList[PlaneBase]{l}, err
+	return capnp.StructList[PlaneBase]{List: l}, err
 }
 
 // PlaneBase_Future is a wrapper for a PlaneBase promised by a client call.
@@ -384,7 +384,7 @@ type B737_List = capnp.StructList[B737]
 // NewB737 creates a new list of B737.
 func NewB737_List(s *capnp.Segment, sz int32) (B737_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 0, PointerCount: 1}, sz)
-	return capnp.StructList[B737]{l}, err
+	return capnp.StructList[B737]{List: l}, err
 }
 
 // B737_Future is a wrapper for a B737 promised by a client call.
@@ -454,7 +454,7 @@ type A320_List = capnp.StructList[A320]
 // NewA320 creates a new list of A320.
 func NewA320_List(s *capnp.Segment, sz int32) (A320_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 0, PointerCount: 1}, sz)
-	return capnp.StructList[A320]{l}, err
+	return capnp.StructList[A320]{List: l}, err
 }
 
 // A320_Future is a wrapper for a A320 promised by a client call.
@@ -524,7 +524,7 @@ type F16_List = capnp.StructList[F16]
 // NewF16 creates a new list of F16.
 func NewF16_List(s *capnp.Segment, sz int32) (F16_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 0, PointerCount: 1}, sz)
-	return capnp.StructList[F16]{l}, err
+	return capnp.StructList[F16]{List: l}, err
 }
 
 // F16_Future is a wrapper for a F16 promised by a client call.
@@ -666,7 +666,7 @@ type Regression_List = capnp.StructList[Regression]
 // NewRegression creates a new list of Regression.
 func NewRegression_List(s *capnp.Segment, sz int32) (Regression_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 24, PointerCount: 3}, sz)
-	return capnp.StructList[Regression]{l}, err
+	return capnp.StructList[Regression]{List: l}, err
 }
 
 // Regression_Future is a wrapper for a Regression promised by a client call.
@@ -840,7 +840,7 @@ type Aircraft_List = capnp.StructList[Aircraft]
 // NewAircraft creates a new list of Aircraft.
 func NewAircraft_List(s *capnp.Segment, sz int32) (Aircraft_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 8, PointerCount: 1}, sz)
-	return capnp.StructList[Aircraft]{l}, err
+	return capnp.StructList[Aircraft]{List: l}, err
 }
 
 // Aircraft_Future is a wrapper for a Aircraft promised by a client call.
@@ -2270,7 +2270,7 @@ type Z_List = capnp.StructList[Z]
 // NewZ creates a new list of Z.
 func NewZ_List(s *capnp.Segment, sz int32) (Z_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 24, PointerCount: 1}, sz)
-	return capnp.StructList[Z]{l}, err
+	return capnp.StructList[Z]{List: l}, err
 }
 
 // Z_Future is a wrapper for a Z promised by a client call.
@@ -2452,7 +2452,7 @@ type Counter_List = capnp.StructList[Counter]
 // NewCounter creates a new list of Counter.
 func NewCounter_List(s *capnp.Segment, sz int32) (Counter_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 8, PointerCount: 3}, sz)
-	return capnp.StructList[Counter]{l}, err
+	return capnp.StructList[Counter]{List: l}, err
 }
 
 // Counter_Future is a wrapper for a Counter promised by a client call.
@@ -2518,7 +2518,7 @@ type Bag_List = capnp.StructList[Bag]
 // NewBag creates a new list of Bag.
 func NewBag_List(s *capnp.Segment, sz int32) (Bag_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 0, PointerCount: 1}, sz)
-	return capnp.StructList[Bag]{l}, err
+	return capnp.StructList[Bag]{List: l}, err
 }
 
 // Bag_Future is a wrapper for a Bag promised by a client call.
@@ -2588,7 +2588,7 @@ type Zserver_List = capnp.StructList[Zserver]
 // NewZserver creates a new list of Zserver.
 func NewZserver_List(s *capnp.Segment, sz int32) (Zserver_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 0, PointerCount: 1}, sz)
-	return capnp.StructList[Zserver]{l}, err
+	return capnp.StructList[Zserver]{List: l}, err
 }
 
 // Zserver_Future is a wrapper for a Zserver promised by a client call.
@@ -2672,7 +2672,7 @@ type Zjob_List = capnp.StructList[Zjob]
 // NewZjob creates a new list of Zjob.
 func NewZjob_List(s *capnp.Segment, sz int32) (Zjob_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 0, PointerCount: 2}, sz)
-	return capnp.StructList[Zjob]{l}, err
+	return capnp.StructList[Zjob]{List: l}, err
 }
 
 // Zjob_Future is a wrapper for a Zjob promised by a client call.
@@ -2714,7 +2714,7 @@ type VerEmpty_List = capnp.StructList[VerEmpty]
 // NewVerEmpty creates a new list of VerEmpty.
 func NewVerEmpty_List(s *capnp.Segment, sz int32) (VerEmpty_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 0, PointerCount: 0}, sz)
-	return capnp.StructList[VerEmpty]{l}, err
+	return capnp.StructList[VerEmpty]{List: l}, err
 }
 
 // VerEmpty_Future is a wrapper for a VerEmpty promised by a client call.
@@ -2764,7 +2764,7 @@ type VerOneData_List = capnp.StructList[VerOneData]
 // NewVerOneData creates a new list of VerOneData.
 func NewVerOneData_List(s *capnp.Segment, sz int32) (VerOneData_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 8, PointerCount: 0}, sz)
-	return capnp.StructList[VerOneData]{l}, err
+	return capnp.StructList[VerOneData]{List: l}, err
 }
 
 // VerOneData_Future is a wrapper for a VerOneData promised by a client call.
@@ -2822,7 +2822,7 @@ type VerTwoData_List = capnp.StructList[VerTwoData]
 // NewVerTwoData creates a new list of VerTwoData.
 func NewVerTwoData_List(s *capnp.Segment, sz int32) (VerTwoData_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 16, PointerCount: 0}, sz)
-	return capnp.StructList[VerTwoData]{l}, err
+	return capnp.StructList[VerTwoData]{List: l}, err
 }
 
 // VerTwoData_Future is a wrapper for a VerTwoData promised by a client call.
@@ -2888,7 +2888,7 @@ type VerOnePtr_List = capnp.StructList[VerOnePtr]
 // NewVerOnePtr creates a new list of VerOnePtr.
 func NewVerOnePtr_List(s *capnp.Segment, sz int32) (VerOnePtr_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 0, PointerCount: 1}, sz)
-	return capnp.StructList[VerOnePtr]{l}, err
+	return capnp.StructList[VerOnePtr]{List: l}, err
 }
 
 // VerOnePtr_Future is a wrapper for a VerOnePtr promised by a client call.
@@ -2982,7 +2982,7 @@ type VerTwoPtr_List = capnp.StructList[VerTwoPtr]
 // NewVerTwoPtr creates a new list of VerTwoPtr.
 func NewVerTwoPtr_List(s *capnp.Segment, sz int32) (VerTwoPtr_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 0, PointerCount: 2}, sz)
-	return capnp.StructList[VerTwoPtr]{l}, err
+	return capnp.StructList[VerTwoPtr]{List: l}, err
 }
 
 // VerTwoPtr_Future is a wrapper for a VerTwoPtr promised by a client call.
@@ -3096,7 +3096,7 @@ type VerTwoDataTwoPtr_List = capnp.StructList[VerTwoDataTwoPtr]
 // NewVerTwoDataTwoPtr creates a new list of VerTwoDataTwoPtr.
 func NewVerTwoDataTwoPtr_List(s *capnp.Segment, sz int32) (VerTwoDataTwoPtr_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 16, PointerCount: 2}, sz)
-	return capnp.StructList[VerTwoDataTwoPtr]{l}, err
+	return capnp.StructList[VerTwoDataTwoPtr]{List: l}, err
 }
 
 // VerTwoDataTwoPtr_Future is a wrapper for a VerTwoDataTwoPtr promised by a client call.
@@ -3170,7 +3170,7 @@ type HoldsVerEmptyList_List = capnp.StructList[HoldsVerEmptyList]
 // NewHoldsVerEmptyList creates a new list of HoldsVerEmptyList.
 func NewHoldsVerEmptyList_List(s *capnp.Segment, sz int32) (HoldsVerEmptyList_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 0, PointerCount: 1}, sz)
-	return capnp.StructList[HoldsVerEmptyList]{l}, err
+	return capnp.StructList[HoldsVerEmptyList]{List: l}, err
 }
 
 // HoldsVerEmptyList_Future is a wrapper for a HoldsVerEmptyList promised by a client call.
@@ -3236,7 +3236,7 @@ type HoldsVerOneDataList_List = capnp.StructList[HoldsVerOneDataList]
 // NewHoldsVerOneDataList creates a new list of HoldsVerOneDataList.
 func NewHoldsVerOneDataList_List(s *capnp.Segment, sz int32) (HoldsVerOneDataList_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 0, PointerCount: 1}, sz)
-	return capnp.StructList[HoldsVerOneDataList]{l}, err
+	return capnp.StructList[HoldsVerOneDataList]{List: l}, err
 }
 
 // HoldsVerOneDataList_Future is a wrapper for a HoldsVerOneDataList promised by a client call.
@@ -3302,7 +3302,7 @@ type HoldsVerTwoDataList_List = capnp.StructList[HoldsVerTwoDataList]
 // NewHoldsVerTwoDataList creates a new list of HoldsVerTwoDataList.
 func NewHoldsVerTwoDataList_List(s *capnp.Segment, sz int32) (HoldsVerTwoDataList_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 0, PointerCount: 1}, sz)
-	return capnp.StructList[HoldsVerTwoDataList]{l}, err
+	return capnp.StructList[HoldsVerTwoDataList]{List: l}, err
 }
 
 // HoldsVerTwoDataList_Future is a wrapper for a HoldsVerTwoDataList promised by a client call.
@@ -3368,7 +3368,7 @@ type HoldsVerOnePtrList_List = capnp.StructList[HoldsVerOnePtrList]
 // NewHoldsVerOnePtrList creates a new list of HoldsVerOnePtrList.
 func NewHoldsVerOnePtrList_List(s *capnp.Segment, sz int32) (HoldsVerOnePtrList_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 0, PointerCount: 1}, sz)
-	return capnp.StructList[HoldsVerOnePtrList]{l}, err
+	return capnp.StructList[HoldsVerOnePtrList]{List: l}, err
 }
 
 // HoldsVerOnePtrList_Future is a wrapper for a HoldsVerOnePtrList promised by a client call.
@@ -3434,7 +3434,7 @@ type HoldsVerTwoPtrList_List = capnp.StructList[HoldsVerTwoPtrList]
 // NewHoldsVerTwoPtrList creates a new list of HoldsVerTwoPtrList.
 func NewHoldsVerTwoPtrList_List(s *capnp.Segment, sz int32) (HoldsVerTwoPtrList_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 0, PointerCount: 1}, sz)
-	return capnp.StructList[HoldsVerTwoPtrList]{l}, err
+	return capnp.StructList[HoldsVerTwoPtrList]{List: l}, err
 }
 
 // HoldsVerTwoPtrList_Future is a wrapper for a HoldsVerTwoPtrList promised by a client call.
@@ -3500,7 +3500,7 @@ type HoldsVerTwoTwoList_List = capnp.StructList[HoldsVerTwoTwoList]
 // NewHoldsVerTwoTwoList creates a new list of HoldsVerTwoTwoList.
 func NewHoldsVerTwoTwoList_List(s *capnp.Segment, sz int32) (HoldsVerTwoTwoList_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 0, PointerCount: 1}, sz)
-	return capnp.StructList[HoldsVerTwoTwoList]{l}, err
+	return capnp.StructList[HoldsVerTwoTwoList]{List: l}, err
 }
 
 // HoldsVerTwoTwoList_Future is a wrapper for a HoldsVerTwoTwoList promised by a client call.
@@ -3566,7 +3566,7 @@ type HoldsVerTwoTwoPlus_List = capnp.StructList[HoldsVerTwoTwoPlus]
 // NewHoldsVerTwoTwoPlus creates a new list of HoldsVerTwoTwoPlus.
 func NewHoldsVerTwoTwoPlus_List(s *capnp.Segment, sz int32) (HoldsVerTwoTwoPlus_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 0, PointerCount: 1}, sz)
-	return capnp.StructList[HoldsVerTwoTwoPlus]{l}, err
+	return capnp.StructList[HoldsVerTwoTwoPlus]{List: l}, err
 }
 
 // HoldsVerTwoTwoPlus_Future is a wrapper for a HoldsVerTwoTwoPlus promised by a client call.
@@ -3704,7 +3704,7 @@ type VerTwoTwoPlus_List = capnp.StructList[VerTwoTwoPlus]
 // NewVerTwoTwoPlus creates a new list of VerTwoTwoPlus.
 func NewVerTwoTwoPlus_List(s *capnp.Segment, sz int32) (VerTwoTwoPlus_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 24, PointerCount: 3}, sz)
-	return capnp.StructList[VerTwoTwoPlus]{l}, err
+	return capnp.StructList[VerTwoTwoPlus]{List: l}, err
 }
 
 // VerTwoTwoPlus_Future is a wrapper for a VerTwoTwoPlus promised by a client call.
@@ -3820,7 +3820,7 @@ type HoldsText_List = capnp.StructList[HoldsText]
 // NewHoldsText creates a new list of HoldsText.
 func NewHoldsText_List(s *capnp.Segment, sz int32) (HoldsText_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 0, PointerCount: 3}, sz)
-	return capnp.StructList[HoldsText]{l}, err
+	return capnp.StructList[HoldsText]{List: l}, err
 }
 
 // HoldsText_Future is a wrapper for a HoldsText promised by a client call.
@@ -3886,7 +3886,7 @@ type WrapEmpty_List = capnp.StructList[WrapEmpty]
 // NewWrapEmpty creates a new list of WrapEmpty.
 func NewWrapEmpty_List(s *capnp.Segment, sz int32) (WrapEmpty_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 0, PointerCount: 1}, sz)
-	return capnp.StructList[WrapEmpty]{l}, err
+	return capnp.StructList[WrapEmpty]{List: l}, err
 }
 
 // WrapEmpty_Future is a wrapper for a WrapEmpty promised by a client call.
@@ -3956,7 +3956,7 @@ type Wrap2x2_List = capnp.StructList[Wrap2x2]
 // NewWrap2x2 creates a new list of Wrap2x2.
 func NewWrap2x2_List(s *capnp.Segment, sz int32) (Wrap2x2_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 0, PointerCount: 1}, sz)
-	return capnp.StructList[Wrap2x2]{l}, err
+	return capnp.StructList[Wrap2x2]{List: l}, err
 }
 
 // Wrap2x2_Future is a wrapper for a Wrap2x2 promised by a client call.
@@ -4026,7 +4026,7 @@ type Wrap2x2plus_List = capnp.StructList[Wrap2x2plus]
 // NewWrap2x2plus creates a new list of Wrap2x2plus.
 func NewWrap2x2plus_List(s *capnp.Segment, sz int32) (Wrap2x2plus_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 0, PointerCount: 1}, sz)
-	return capnp.StructList[Wrap2x2plus]{l}, err
+	return capnp.StructList[Wrap2x2plus]{List: l}, err
 }
 
 // Wrap2x2plus_Future is a wrapper for a Wrap2x2plus promised by a client call.
@@ -4103,7 +4103,7 @@ type VoidUnion_List = capnp.StructList[VoidUnion]
 // NewVoidUnion creates a new list of VoidUnion.
 func NewVoidUnion_List(s *capnp.Segment, sz int32) (VoidUnion_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 8, PointerCount: 0}, sz)
-	return capnp.StructList[VoidUnion]{l}, err
+	return capnp.StructList[VoidUnion]{List: l}, err
 }
 
 // VoidUnion_Future is a wrapper for a VoidUnion promised by a client call.
@@ -4169,7 +4169,7 @@ type Nester1Capn_List = capnp.StructList[Nester1Capn]
 // NewNester1Capn creates a new list of Nester1Capn.
 func NewNester1Capn_List(s *capnp.Segment, sz int32) (Nester1Capn_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 0, PointerCount: 1}, sz)
-	return capnp.StructList[Nester1Capn]{l}, err
+	return capnp.StructList[Nester1Capn]{List: l}, err
 }
 
 // Nester1Capn_Future is a wrapper for a Nester1Capn promised by a client call.
@@ -4235,7 +4235,7 @@ type RWTestCapn_List = capnp.StructList[RWTestCapn]
 // NewRWTestCapn creates a new list of RWTestCapn.
 func NewRWTestCapn_List(s *capnp.Segment, sz int32) (RWTestCapn_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 0, PointerCount: 1}, sz)
-	return capnp.StructList[RWTestCapn]{l}, err
+	return capnp.StructList[RWTestCapn]{List: l}, err
 }
 
 // RWTestCapn_Future is a wrapper for a RWTestCapn promised by a client call.
@@ -4301,7 +4301,7 @@ type ListStructCapn_List = capnp.StructList[ListStructCapn]
 // NewListStructCapn creates a new list of ListStructCapn.
 func NewListStructCapn_List(s *capnp.Segment, sz int32) (ListStructCapn_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 0, PointerCount: 1}, sz)
-	return capnp.StructList[ListStructCapn]{l}, err
+	return capnp.StructList[ListStructCapn]{List: l}, err
 }
 
 // ListStructCapn_Future is a wrapper for a ListStructCapn promised by a client call.
@@ -4449,7 +4449,7 @@ type Echo_echo_Params_List = capnp.StructList[Echo_echo_Params]
 // NewEcho_echo_Params creates a new list of Echo_echo_Params.
 func NewEcho_echo_Params_List(s *capnp.Segment, sz int32) (Echo_echo_Params_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 0, PointerCount: 1}, sz)
-	return capnp.StructList[Echo_echo_Params]{l}, err
+	return capnp.StructList[Echo_echo_Params]{List: l}, err
 }
 
 // Echo_echo_Params_Future is a wrapper for a Echo_echo_Params promised by a client call.
@@ -4509,7 +4509,7 @@ type Echo_echo_Results_List = capnp.StructList[Echo_echo_Results]
 // NewEcho_echo_Results creates a new list of Echo_echo_Results.
 func NewEcho_echo_Results_List(s *capnp.Segment, sz int32) (Echo_echo_Results_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 0, PointerCount: 1}, sz)
-	return capnp.StructList[Echo_echo_Results]{l}, err
+	return capnp.StructList[Echo_echo_Results]{List: l}, err
 }
 
 // Echo_echo_Results_Future is a wrapper for a Echo_echo_Results promised by a client call.
@@ -4575,7 +4575,7 @@ type Hoth_List = capnp.StructList[Hoth]
 // NewHoth creates a new list of Hoth.
 func NewHoth_List(s *capnp.Segment, sz int32) (Hoth_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 0, PointerCount: 1}, sz)
-	return capnp.StructList[Hoth]{l}, err
+	return capnp.StructList[Hoth]{List: l}, err
 }
 
 // Hoth_Future is a wrapper for a Hoth promised by a client call.
@@ -4639,7 +4639,7 @@ type EchoBase_List = capnp.StructList[EchoBase]
 // NewEchoBase creates a new list of EchoBase.
 func NewEchoBase_List(s *capnp.Segment, sz int32) (EchoBase_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 0, PointerCount: 1}, sz)
-	return capnp.StructList[EchoBase]{l}, err
+	return capnp.StructList[EchoBase]{List: l}, err
 }
 
 // EchoBase_Future is a wrapper for a EchoBase promised by a client call.
@@ -4737,7 +4737,7 @@ type StackingRoot_List = capnp.StructList[StackingRoot]
 // NewStackingRoot creates a new list of StackingRoot.
 func NewStackingRoot_List(s *capnp.Segment, sz int32) (StackingRoot_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 0, PointerCount: 2}, sz)
-	return capnp.StructList[StackingRoot]{l}, err
+	return capnp.StructList[StackingRoot]{List: l}, err
 }
 
 // StackingRoot_Future is a wrapper for a StackingRoot promised by a client call.
@@ -4819,7 +4819,7 @@ type StackingA_List = capnp.StructList[StackingA]
 // NewStackingA creates a new list of StackingA.
 func NewStackingA_List(s *capnp.Segment, sz int32) (StackingA_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 8, PointerCount: 1}, sz)
-	return capnp.StructList[StackingA]{l}, err
+	return capnp.StructList[StackingA]{List: l}, err
 }
 
 // StackingA_Future is a wrapper for a StackingA promised by a client call.
@@ -4873,7 +4873,7 @@ type StackingB_List = capnp.StructList[StackingB]
 // NewStackingB creates a new list of StackingB.
 func NewStackingB_List(s *capnp.Segment, sz int32) (StackingB_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 8, PointerCount: 0}, sz)
-	return capnp.StructList[StackingB]{l}, err
+	return capnp.StructList[StackingB]{List: l}, err
 }
 
 // StackingB_Future is a wrapper for a StackingB promised by a client call.
@@ -5003,7 +5003,7 @@ type CallSequence_getNumber_Params_List = capnp.StructList[CallSequence_getNumbe
 // NewCallSequence_getNumber_Params creates a new list of CallSequence_getNumber_Params.
 func NewCallSequence_getNumber_Params_List(s *capnp.Segment, sz int32) (CallSequence_getNumber_Params_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 0, PointerCount: 0}, sz)
-	return capnp.StructList[CallSequence_getNumber_Params]{l}, err
+	return capnp.StructList[CallSequence_getNumber_Params]{List: l}, err
 }
 
 // CallSequence_getNumber_Params_Future is a wrapper for a CallSequence_getNumber_Params promised by a client call.
@@ -5053,7 +5053,7 @@ type CallSequence_getNumber_Results_List = capnp.StructList[CallSequence_getNumb
 // NewCallSequence_getNumber_Results creates a new list of CallSequence_getNumber_Results.
 func NewCallSequence_getNumber_Results_List(s *capnp.Segment, sz int32) (CallSequence_getNumber_Results_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 8, PointerCount: 0}, sz)
-	return capnp.StructList[CallSequence_getNumber_Results]{l}, err
+	return capnp.StructList[CallSequence_getNumber_Results]{List: l}, err
 }
 
 // CallSequence_getNumber_Results_Future is a wrapper for a CallSequence_getNumber_Results promised by a client call.
@@ -5213,7 +5213,7 @@ type Pipeliner_newPipeliner_Params_List = capnp.StructList[Pipeliner_newPipeline
 // NewPipeliner_newPipeliner_Params creates a new list of Pipeliner_newPipeliner_Params.
 func NewPipeliner_newPipeliner_Params_List(s *capnp.Segment, sz int32) (Pipeliner_newPipeliner_Params_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 0, PointerCount: 0}, sz)
-	return capnp.StructList[Pipeliner_newPipeliner_Params]{l}, err
+	return capnp.StructList[Pipeliner_newPipeliner_Params]{List: l}, err
 }
 
 // Pipeliner_newPipeliner_Params_Future is a wrapper for a Pipeliner_newPipeliner_Params promised by a client call.
@@ -5285,7 +5285,7 @@ type Pipeliner_newPipeliner_Results_List = capnp.StructList[Pipeliner_newPipelin
 // NewPipeliner_newPipeliner_Results creates a new list of Pipeliner_newPipeliner_Results.
 func NewPipeliner_newPipeliner_Results_List(s *capnp.Segment, sz int32) (Pipeliner_newPipeliner_Results_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 0, PointerCount: 2}, sz)
-	return capnp.StructList[Pipeliner_newPipeliner_Results]{l}, err
+	return capnp.StructList[Pipeliner_newPipeliner_Results]{List: l}, err
 }
 
 // Pipeliner_newPipeliner_Results_Future is a wrapper for a Pipeliner_newPipeliner_Results promised by a client call.
@@ -5393,7 +5393,7 @@ type Defaults_List = capnp.StructList[Defaults]
 // NewDefaults creates a new list of Defaults.
 func NewDefaults_List(s *capnp.Segment, sz int32) (Defaults_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 16, PointerCount: 2}, sz)
-	return capnp.StructList[Defaults]{l}, err
+	return capnp.StructList[Defaults]{List: l}, err
 }
 
 // Defaults_Future is a wrapper for a Defaults promised by a client call.
@@ -5503,7 +5503,7 @@ type BenchmarkA_List = capnp.StructList[BenchmarkA]
 // NewBenchmarkA creates a new list of BenchmarkA.
 func NewBenchmarkA_List(s *capnp.Segment, sz int32) (BenchmarkA_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 24, PointerCount: 2}, sz)
-	return capnp.StructList[BenchmarkA]{l}, err
+	return capnp.StructList[BenchmarkA]{List: l}, err
 }
 
 // BenchmarkA_Future is a wrapper for a BenchmarkA promised by a client call.
@@ -5569,7 +5569,7 @@ type AllocBenchmark_List = capnp.StructList[AllocBenchmark]
 // NewAllocBenchmark creates a new list of AllocBenchmark.
 func NewAllocBenchmark_List(s *capnp.Segment, sz int32) (AllocBenchmark_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 0, PointerCount: 1}, sz)
-	return capnp.StructList[AllocBenchmark]{l}, err
+	return capnp.StructList[AllocBenchmark]{List: l}, err
 }
 
 // AllocBenchmark_Future is a wrapper for a AllocBenchmark promised by a client call.
@@ -5629,7 +5629,7 @@ type AllocBenchmark_Field_List = capnp.StructList[AllocBenchmark_Field]
 // NewAllocBenchmark_Field creates a new list of AllocBenchmark_Field.
 func NewAllocBenchmark_Field_List(s *capnp.Segment, sz int32) (AllocBenchmark_Field_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 0, PointerCount: 1}, sz)
-	return capnp.StructList[AllocBenchmark_Field]{l}, err
+	return capnp.StructList[AllocBenchmark_Field]{List: l}, err
 }
 
 // AllocBenchmark_Field_Future is a wrapper for a AllocBenchmark_Field promised by a client call.

--- a/internal/demo/books/books.capnp.go
+++ b/internal/demo/books/books.capnp.go
@@ -65,7 +65,7 @@ type Book_List = capnp.StructList[Book]
 // NewBook creates a new list of Book.
 func NewBook_List(s *capnp.Segment, sz int32) (Book_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 8, PointerCount: 1}, sz)
-	return capnp.StructList[Book]{l}, err
+	return capnp.StructList[Book]{List: l}, err
 }
 
 // Book_Future is a wrapper for a Book promised by a client call.

--- a/internal/schema/schema.capnp.go
+++ b/internal/schema/schema.capnp.go
@@ -546,7 +546,7 @@ type Node_List = capnp.StructList[Node]
 // NewNode creates a new list of Node.
 func NewNode_List(s *capnp.Segment, sz int32) (Node_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 40, PointerCount: 6}, sz)
-	return capnp.StructList[Node]{l}, err
+	return capnp.StructList[Node]{List: l}, err
 }
 
 type Node_Parameter struct{ capnp.Struct }
@@ -593,7 +593,7 @@ type Node_Parameter_List = capnp.StructList[Node_Parameter]
 // NewNode_Parameter creates a new list of Node_Parameter.
 func NewNode_Parameter_List(s *capnp.Segment, sz int32) (Node_Parameter_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 0, PointerCount: 1}, sz)
-	return capnp.StructList[Node_Parameter]{l}, err
+	return capnp.StructList[Node_Parameter]{List: l}, err
 }
 
 type Node_NestedNode struct{ capnp.Struct }
@@ -648,7 +648,7 @@ type Node_NestedNode_List = capnp.StructList[Node_NestedNode]
 // NewNode_NestedNode creates a new list of Node_NestedNode.
 func NewNode_NestedNode_List(s *capnp.Segment, sz int32) (Node_NestedNode_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 8, PointerCount: 1}, sz)
-	return capnp.StructList[Node_NestedNode]{l}, err
+	return capnp.StructList[Node_NestedNode]{List: l}, err
 }
 
 type Node_SourceInfo struct{ capnp.Struct }
@@ -727,7 +727,7 @@ type Node_SourceInfo_List = capnp.StructList[Node_SourceInfo]
 // NewNode_SourceInfo creates a new list of Node_SourceInfo.
 func NewNode_SourceInfo_List(s *capnp.Segment, sz int32) (Node_SourceInfo_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 8, PointerCount: 2}, sz)
-	return capnp.StructList[Node_SourceInfo]{l}, err
+	return capnp.StructList[Node_SourceInfo]{List: l}, err
 }
 
 type Node_SourceInfo_Member struct{ capnp.Struct }
@@ -774,7 +774,7 @@ type Node_SourceInfo_Member_List = capnp.StructList[Node_SourceInfo_Member]
 // NewNode_SourceInfo_Member creates a new list of Node_SourceInfo_Member.
 func NewNode_SourceInfo_Member_List(s *capnp.Segment, sz int32) (Node_SourceInfo_Member_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 0, PointerCount: 1}, sz)
-	return capnp.StructList[Node_SourceInfo_Member]{l}, err
+	return capnp.StructList[Node_SourceInfo_Member]{List: l}, err
 }
 
 type Field struct{ capnp.Struct }
@@ -1010,7 +1010,7 @@ type Field_List = capnp.StructList[Field]
 // NewField creates a new list of Field.
 func NewField_List(s *capnp.Segment, sz int32) (Field_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 24, PointerCount: 4}, sz)
-	return capnp.StructList[Field]{l}, err
+	return capnp.StructList[Field]{List: l}, err
 }
 
 type Enumerant struct{ capnp.Struct }
@@ -1089,7 +1089,7 @@ type Enumerant_List = capnp.StructList[Enumerant]
 // NewEnumerant creates a new list of Enumerant.
 func NewEnumerant_List(s *capnp.Segment, sz int32) (Enumerant_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 8, PointerCount: 2}, sz)
-	return capnp.StructList[Enumerant]{l}, err
+	return capnp.StructList[Enumerant]{List: l}, err
 }
 
 type Superclass struct{ capnp.Struct }
@@ -1150,7 +1150,7 @@ type Superclass_List = capnp.StructList[Superclass]
 // NewSuperclass creates a new list of Superclass.
 func NewSuperclass_List(s *capnp.Segment, sz int32) (Superclass_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 8, PointerCount: 1}, sz)
-	return capnp.StructList[Superclass]{l}, err
+	return capnp.StructList[Superclass]{List: l}, err
 }
 
 type Method struct{ capnp.Struct }
@@ -1317,7 +1317,7 @@ type Method_List = capnp.StructList[Method]
 // NewMethod creates a new list of Method.
 func NewMethod_List(s *capnp.Segment, sz int32) (Method_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 24, PointerCount: 5}, sz)
-	return capnp.StructList[Method]{l}, err
+	return capnp.StructList[Method]{List: l}, err
 }
 
 type Type struct{ capnp.Struct }
@@ -1765,7 +1765,7 @@ type Type_List = capnp.StructList[Type]
 // NewType creates a new list of Type.
 func NewType_List(s *capnp.Segment, sz int32) (Type_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 24, PointerCount: 1}, sz)
-	return capnp.StructList[Type]{l}, err
+	return capnp.StructList[Type]{List: l}, err
 }
 
 type Brand struct{ capnp.Struct }
@@ -1818,7 +1818,7 @@ type Brand_List = capnp.StructList[Brand]
 // NewBrand creates a new list of Brand.
 func NewBrand_List(s *capnp.Segment, sz int32) (Brand_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 0, PointerCount: 1}, sz)
-	return capnp.StructList[Brand]{l}, err
+	return capnp.StructList[Brand]{List: l}, err
 }
 
 type Brand_Scope struct{ capnp.Struct }
@@ -1913,7 +1913,7 @@ type Brand_Scope_List = capnp.StructList[Brand_Scope]
 // NewBrand_Scope creates a new list of Brand_Scope.
 func NewBrand_Scope_List(s *capnp.Segment, sz int32) (Brand_Scope_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 16, PointerCount: 1}, sz)
-	return capnp.StructList[Brand_Scope]{l}, err
+	return capnp.StructList[Brand_Scope]{List: l}, err
 }
 
 type Brand_Binding struct{ capnp.Struct }
@@ -2000,7 +2000,7 @@ type Brand_Binding_List = capnp.StructList[Brand_Binding]
 // NewBrand_Binding creates a new list of Brand_Binding.
 func NewBrand_Binding_List(s *capnp.Segment, sz int32) (Brand_Binding_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 8, PointerCount: 1}, sz)
-	return capnp.StructList[Brand_Binding]{l}, err
+	return capnp.StructList[Brand_Binding]{List: l}, err
 }
 
 type Value struct{ capnp.Struct }
@@ -2357,7 +2357,7 @@ type Value_List = capnp.StructList[Value]
 // NewValue creates a new list of Value.
 func NewValue_List(s *capnp.Segment, sz int32) (Value_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 16, PointerCount: 1}, sz)
-	return capnp.StructList[Value]{l}, err
+	return capnp.StructList[Value]{List: l}, err
 }
 
 type Annotation struct{ capnp.Struct }
@@ -2442,7 +2442,7 @@ type Annotation_List = capnp.StructList[Annotation]
 // NewAnnotation creates a new list of Annotation.
 func NewAnnotation_List(s *capnp.Segment, sz int32) (Annotation_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 8, PointerCount: 2}, sz)
-	return capnp.StructList[Annotation]{l}, err
+	return capnp.StructList[Annotation]{List: l}, err
 }
 
 type ElementSize uint16
@@ -2569,7 +2569,7 @@ type CapnpVersion_List = capnp.StructList[CapnpVersion]
 // NewCapnpVersion creates a new list of CapnpVersion.
 func NewCapnpVersion_List(s *capnp.Segment, sz int32) (CapnpVersion_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 8, PointerCount: 0}, sz)
-	return capnp.StructList[CapnpVersion]{l}, err
+	return capnp.StructList[CapnpVersion]{List: l}, err
 }
 
 type CodeGeneratorRequest struct{ capnp.Struct }
@@ -2694,7 +2694,7 @@ type CodeGeneratorRequest_List = capnp.StructList[CodeGeneratorRequest]
 // NewCodeGeneratorRequest creates a new list of CodeGeneratorRequest.
 func NewCodeGeneratorRequest_List(s *capnp.Segment, sz int32) (CodeGeneratorRequest_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 0, PointerCount: 4}, sz)
-	return capnp.StructList[CodeGeneratorRequest]{l}, err
+	return capnp.StructList[CodeGeneratorRequest]{List: l}, err
 }
 
 type CodeGeneratorRequest_RequestedFile struct{ capnp.Struct }
@@ -2773,7 +2773,7 @@ type CodeGeneratorRequest_RequestedFile_List = capnp.StructList[CodeGeneratorReq
 // NewCodeGeneratorRequest_RequestedFile creates a new list of CodeGeneratorRequest_RequestedFile.
 func NewCodeGeneratorRequest_RequestedFile_List(s *capnp.Segment, sz int32) (CodeGeneratorRequest_RequestedFile_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 8, PointerCount: 2}, sz)
-	return capnp.StructList[CodeGeneratorRequest_RequestedFile]{l}, err
+	return capnp.StructList[CodeGeneratorRequest_RequestedFile]{List: l}, err
 }
 
 type CodeGeneratorRequest_RequestedFile_Import struct{ capnp.Struct }
@@ -2828,5 +2828,5 @@ type CodeGeneratorRequest_RequestedFile_Import_List = capnp.StructList[CodeGener
 // NewCodeGeneratorRequest_RequestedFile_Import creates a new list of CodeGeneratorRequest_RequestedFile_Import.
 func NewCodeGeneratorRequest_RequestedFile_Import_List(s *capnp.Segment, sz int32) (CodeGeneratorRequest_RequestedFile_Import_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 8, PointerCount: 1}, sz)
-	return capnp.StructList[CodeGeneratorRequest_RequestedFile_Import]{l}, err
+	return capnp.StructList[CodeGeneratorRequest_RequestedFile_Import]{List: l}, err
 }

--- a/rpc/internal/testcapnp/test.capnp.go
+++ b/rpc/internal/testcapnp/test.capnp.go
@@ -138,7 +138,7 @@ type PingPong_echoNum_Params_List = capnp.StructList[PingPong_echoNum_Params]
 // NewPingPong_echoNum_Params creates a new list of PingPong_echoNum_Params.
 func NewPingPong_echoNum_Params_List(s *capnp.Segment, sz int32) (PingPong_echoNum_Params_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 8, PointerCount: 0}, sz)
-	return capnp.StructList[PingPong_echoNum_Params]{l}, err
+	return capnp.StructList[PingPong_echoNum_Params]{List: l}, err
 }
 
 // PingPong_echoNum_Params_Future is a wrapper for a PingPong_echoNum_Params promised by a client call.
@@ -188,7 +188,7 @@ type PingPong_echoNum_Results_List = capnp.StructList[PingPong_echoNum_Results]
 // NewPingPong_echoNum_Results creates a new list of PingPong_echoNum_Results.
 func NewPingPong_echoNum_Results_List(s *capnp.Segment, sz int32) (PingPong_echoNum_Results_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 8, PointerCount: 0}, sz)
-	return capnp.StructList[PingPong_echoNum_Results]{l}, err
+	return capnp.StructList[PingPong_echoNum_Results]{List: l}, err
 }
 
 // PingPong_echoNum_Results_Future is a wrapper for a PingPong_echoNum_Results promised by a client call.
@@ -331,7 +331,7 @@ type StreamTest_push_Params_List = capnp.StructList[StreamTest_push_Params]
 // NewStreamTest_push_Params creates a new list of StreamTest_push_Params.
 func NewStreamTest_push_Params_List(s *capnp.Segment, sz int32) (StreamTest_push_Params_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 0, PointerCount: 1}, sz)
-	return capnp.StructList[StreamTest_push_Params]{l}, err
+	return capnp.StructList[StreamTest_push_Params]{List: l}, err
 }
 
 // StreamTest_push_Params_Future is a wrapper for a StreamTest_push_Params promised by a client call.
@@ -520,7 +520,7 @@ type CapArgsTest_call_Params_List = capnp.StructList[CapArgsTest_call_Params]
 // NewCapArgsTest_call_Params creates a new list of CapArgsTest_call_Params.
 func NewCapArgsTest_call_Params_List(s *capnp.Segment, sz int32) (CapArgsTest_call_Params_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 0, PointerCount: 1}, sz)
-	return capnp.StructList[CapArgsTest_call_Params]{l}, err
+	return capnp.StructList[CapArgsTest_call_Params]{List: l}, err
 }
 
 // CapArgsTest_call_Params_Future is a wrapper for a CapArgsTest_call_Params promised by a client call.
@@ -566,7 +566,7 @@ type CapArgsTest_call_Results_List = capnp.StructList[CapArgsTest_call_Results]
 // NewCapArgsTest_call_Results creates a new list of CapArgsTest_call_Results.
 func NewCapArgsTest_call_Results_List(s *capnp.Segment, sz int32) (CapArgsTest_call_Results_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 0, PointerCount: 0}, sz)
-	return capnp.StructList[CapArgsTest_call_Results]{l}, err
+	return capnp.StructList[CapArgsTest_call_Results]{List: l}, err
 }
 
 // CapArgsTest_call_Results_Future is a wrapper for a CapArgsTest_call_Results promised by a client call.
@@ -608,7 +608,7 @@ type CapArgsTest_self_Params_List = capnp.StructList[CapArgsTest_self_Params]
 // NewCapArgsTest_self_Params creates a new list of CapArgsTest_self_Params.
 func NewCapArgsTest_self_Params_List(s *capnp.Segment, sz int32) (CapArgsTest_self_Params_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 0, PointerCount: 0}, sz)
-	return capnp.StructList[CapArgsTest_self_Params]{l}, err
+	return capnp.StructList[CapArgsTest_self_Params]{List: l}, err
 }
 
 // CapArgsTest_self_Params_Future is a wrapper for a CapArgsTest_self_Params promised by a client call.
@@ -668,7 +668,7 @@ type CapArgsTest_self_Results_List = capnp.StructList[CapArgsTest_self_Results]
 // NewCapArgsTest_self_Results creates a new list of CapArgsTest_self_Results.
 func NewCapArgsTest_self_Results_List(s *capnp.Segment, sz int32) (CapArgsTest_self_Results_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 0, PointerCount: 1}, sz)
-	return capnp.StructList[CapArgsTest_self_Results]{l}, err
+	return capnp.StructList[CapArgsTest_self_Results]{List: l}, err
 }
 
 // CapArgsTest_self_Results_Future is a wrapper for a CapArgsTest_self_Results promised by a client call.

--- a/std/capnp/compat/json/json.capnp.go
+++ b/std/capnp/compat/json/json.capnp.go
@@ -234,7 +234,7 @@ type Value_List = capnp.StructList[Value]
 // NewValue creates a new list of Value.
 func NewValue_List(s *capnp.Segment, sz int32) (Value_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 16, PointerCount: 1}, sz)
-	return capnp.StructList[Value]{l}, err
+	return capnp.StructList[Value]{List: l}, err
 }
 
 // Value_Future is a wrapper for a Value promised by a client call.
@@ -322,7 +322,7 @@ type Value_Field_List = capnp.StructList[Value_Field]
 // NewValue_Field creates a new list of Value_Field.
 func NewValue_Field_List(s *capnp.Segment, sz int32) (Value_Field_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 0, PointerCount: 2}, sz)
-	return capnp.StructList[Value_Field]{l}, err
+	return capnp.StructList[Value_Field]{List: l}, err
 }
 
 // Value_Field_Future is a wrapper for a Value_Field promised by a client call.
@@ -410,7 +410,7 @@ type Value_Call_List = capnp.StructList[Value_Call]
 // NewValue_Call creates a new list of Value_Call.
 func NewValue_Call_List(s *capnp.Segment, sz int32) (Value_Call_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 0, PointerCount: 2}, sz)
-	return capnp.StructList[Value_Call]{l}, err
+	return capnp.StructList[Value_Call]{List: l}, err
 }
 
 // Value_Call_Future is a wrapper for a Value_Call promised by a client call.
@@ -470,7 +470,7 @@ type FlattenOptions_List = capnp.StructList[FlattenOptions]
 // NewFlattenOptions creates a new list of FlattenOptions.
 func NewFlattenOptions_List(s *capnp.Segment, sz int32) (FlattenOptions_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 0, PointerCount: 1}, sz)
-	return capnp.StructList[FlattenOptions]{l}, err
+	return capnp.StructList[FlattenOptions]{List: l}, err
 }
 
 // FlattenOptions_Future is a wrapper for a FlattenOptions promised by a client call.
@@ -548,7 +548,7 @@ type DiscriminatorOptions_List = capnp.StructList[DiscriminatorOptions]
 // NewDiscriminatorOptions creates a new list of DiscriminatorOptions.
 func NewDiscriminatorOptions_List(s *capnp.Segment, sz int32) (DiscriminatorOptions_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 0, PointerCount: 2}, sz)
-	return capnp.StructList[DiscriminatorOptions]{l}, err
+	return capnp.StructList[DiscriminatorOptions]{List: l}, err
 }
 
 // DiscriminatorOptions_Future is a wrapper for a DiscriminatorOptions promised by a client call.

--- a/std/capnp/persistent/persistent.capnp.go
+++ b/std/capnp/persistent/persistent.capnp.go
@@ -143,7 +143,7 @@ type Persistent_SaveParams_List = capnp.StructList[Persistent_SaveParams]
 // NewPersistent_SaveParams creates a new list of Persistent_SaveParams.
 func NewPersistent_SaveParams_List(s *capnp.Segment, sz int32) (Persistent_SaveParams_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 0, PointerCount: 1}, sz)
-	return capnp.StructList[Persistent_SaveParams]{l}, err
+	return capnp.StructList[Persistent_SaveParams]{List: l}, err
 }
 
 // Persistent_SaveParams_Future is a wrapper for a Persistent_SaveParams promised by a client call.
@@ -201,7 +201,7 @@ type Persistent_SaveResults_List = capnp.StructList[Persistent_SaveResults]
 // NewPersistent_SaveResults creates a new list of Persistent_SaveResults.
 func NewPersistent_SaveResults_List(s *capnp.Segment, sz int32) (Persistent_SaveResults_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 0, PointerCount: 1}, sz)
-	return capnp.StructList[Persistent_SaveResults]{l}, err
+	return capnp.StructList[Persistent_SaveResults]{List: l}, err
 }
 
 // Persistent_SaveResults_Future is a wrapper for a Persistent_SaveResults promised by a client call.

--- a/std/capnp/rpc/rpc.capnp.go
+++ b/std/capnp/rpc/rpc.capnp.go
@@ -519,7 +519,7 @@ type Message_List = capnp.StructList[Message]
 // NewMessage creates a new list of Message.
 func NewMessage_List(s *capnp.Segment, sz int32) (Message_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 8, PointerCount: 1}, sz)
-	return capnp.StructList[Message]{l}, err
+	return capnp.StructList[Message]{List: l}, err
 }
 
 // Message_Future is a wrapper for a Message promised by a client call.
@@ -637,7 +637,7 @@ type Bootstrap_List = capnp.StructList[Bootstrap]
 // NewBootstrap creates a new list of Bootstrap.
 func NewBootstrap_List(s *capnp.Segment, sz int32) (Bootstrap_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 8, PointerCount: 1}, sz)
-	return capnp.StructList[Bootstrap]{l}, err
+	return capnp.StructList[Bootstrap]{List: l}, err
 }
 
 // Bootstrap_Future is a wrapper for a Bootstrap promised by a client call.
@@ -819,7 +819,7 @@ type Call_List = capnp.StructList[Call]
 // NewCall creates a new list of Call.
 func NewCall_List(s *capnp.Segment, sz int32) (Call_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 24, PointerCount: 3}, sz)
-	return capnp.StructList[Call]{l}, err
+	return capnp.StructList[Call]{List: l}, err
 }
 
 // Call_Future is a wrapper for a Call promised by a client call.
@@ -1039,7 +1039,7 @@ type Return_List = capnp.StructList[Return]
 // NewReturn creates a new list of Return.
 func NewReturn_List(s *capnp.Segment, sz int32) (Return_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 16, PointerCount: 1}, sz)
-	return capnp.StructList[Return]{l}, err
+	return capnp.StructList[Return]{List: l}, err
 }
 
 // Return_Future is a wrapper for a Return promised by a client call.
@@ -1109,7 +1109,7 @@ type Finish_List = capnp.StructList[Finish]
 // NewFinish creates a new list of Finish.
 func NewFinish_List(s *capnp.Segment, sz int32) (Finish_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 8, PointerCount: 0}, sz)
-	return capnp.StructList[Finish]{l}, err
+	return capnp.StructList[Finish]{List: l}, err
 }
 
 // Finish_Future is a wrapper for a Finish promised by a client call.
@@ -1244,7 +1244,7 @@ type Resolve_List = capnp.StructList[Resolve]
 // NewResolve creates a new list of Resolve.
 func NewResolve_List(s *capnp.Segment, sz int32) (Resolve_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 8, PointerCount: 1}, sz)
-	return capnp.StructList[Resolve]{l}, err
+	return capnp.StructList[Resolve]{List: l}, err
 }
 
 // Resolve_Future is a wrapper for a Resolve promised by a client call.
@@ -1310,7 +1310,7 @@ type Release_List = capnp.StructList[Release]
 // NewRelease creates a new list of Release.
 func NewRelease_List(s *capnp.Segment, sz int32) (Release_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 8, PointerCount: 0}, sz)
-	return capnp.StructList[Release]{l}, err
+	return capnp.StructList[Release]{List: l}, err
 }
 
 // Release_Future is a wrapper for a Release promised by a client call.
@@ -1447,7 +1447,7 @@ type Disembargo_List = capnp.StructList[Disembargo]
 // NewDisembargo creates a new list of Disembargo.
 func NewDisembargo_List(s *capnp.Segment, sz int32) (Disembargo_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 8, PointerCount: 1}, sz)
-	return capnp.StructList[Disembargo]{l}, err
+	return capnp.StructList[Disembargo]{List: l}, err
 }
 
 // Disembargo_Future is a wrapper for a Disembargo promised by a client call.
@@ -1549,7 +1549,7 @@ type Provide_List = capnp.StructList[Provide]
 // NewProvide creates a new list of Provide.
 func NewProvide_List(s *capnp.Segment, sz int32) (Provide_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 8, PointerCount: 2}, sz)
-	return capnp.StructList[Provide]{l}, err
+	return capnp.StructList[Provide]{List: l}, err
 }
 
 // Provide_Future is a wrapper for a Provide promised by a client call.
@@ -1627,7 +1627,7 @@ type Accept_List = capnp.StructList[Accept]
 // NewAccept creates a new list of Accept.
 func NewAccept_List(s *capnp.Segment, sz int32) (Accept_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 8, PointerCount: 1}, sz)
-	return capnp.StructList[Accept]{l}, err
+	return capnp.StructList[Accept]{List: l}, err
 }
 
 // Accept_Future is a wrapper for a Accept promised by a client call.
@@ -1717,7 +1717,7 @@ type Join_List = capnp.StructList[Join]
 // NewJoin creates a new list of Join.
 func NewJoin_List(s *capnp.Segment, sz int32) (Join_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 8, PointerCount: 2}, sz)
-	return capnp.StructList[Join]{l}, err
+	return capnp.StructList[Join]{List: l}, err
 }
 
 // Join_Future is a wrapper for a Join promised by a client call.
@@ -1832,7 +1832,7 @@ type MessageTarget_List = capnp.StructList[MessageTarget]
 // NewMessageTarget creates a new list of MessageTarget.
 func NewMessageTarget_List(s *capnp.Segment, sz int32) (MessageTarget_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 8, PointerCount: 1}, sz)
-	return capnp.StructList[MessageTarget]{l}, err
+	return capnp.StructList[MessageTarget]{List: l}, err
 }
 
 // MessageTarget_Future is a wrapper for a MessageTarget promised by a client call.
@@ -1914,7 +1914,7 @@ type Payload_List = capnp.StructList[Payload]
 // NewPayload creates a new list of Payload.
 func NewPayload_List(s *capnp.Segment, sz int32) (Payload_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 0, PointerCount: 2}, sz)
-	return capnp.StructList[Payload]{l}, err
+	return capnp.StructList[Payload]{List: l}, err
 }
 
 // Payload_Future is a wrapper for a Payload promised by a client call.
@@ -2106,7 +2106,7 @@ type CapDescriptor_List = capnp.StructList[CapDescriptor]
 // NewCapDescriptor creates a new list of CapDescriptor.
 func NewCapDescriptor_List(s *capnp.Segment, sz int32) (CapDescriptor_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 8, PointerCount: 1}, sz)
-	return capnp.StructList[CapDescriptor]{l}, err
+	return capnp.StructList[CapDescriptor]{List: l}, err
 }
 
 // CapDescriptor_Future is a wrapper for a CapDescriptor promised by a client call.
@@ -2188,7 +2188,7 @@ type PromisedAnswer_List = capnp.StructList[PromisedAnswer]
 // NewPromisedAnswer creates a new list of PromisedAnswer.
 func NewPromisedAnswer_List(s *capnp.Segment, sz int32) (PromisedAnswer_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 8, PointerCount: 1}, sz)
-	return capnp.StructList[PromisedAnswer]{l}, err
+	return capnp.StructList[PromisedAnswer]{List: l}, err
 }
 
 // PromisedAnswer_Future is a wrapper for a PromisedAnswer promised by a client call.
@@ -2268,7 +2268,7 @@ type PromisedAnswer_Op_List = capnp.StructList[PromisedAnswer_Op]
 // NewPromisedAnswer_Op creates a new list of PromisedAnswer_Op.
 func NewPromisedAnswer_Op_List(s *capnp.Segment, sz int32) (PromisedAnswer_Op_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 8, PointerCount: 0}, sz)
-	return capnp.StructList[PromisedAnswer_Op]{l}, err
+	return capnp.StructList[PromisedAnswer_Op]{List: l}, err
 }
 
 // PromisedAnswer_Op_Future is a wrapper for a PromisedAnswer_Op promised by a client call.
@@ -2330,7 +2330,7 @@ type ThirdPartyCapDescriptor_List = capnp.StructList[ThirdPartyCapDescriptor]
 // NewThirdPartyCapDescriptor creates a new list of ThirdPartyCapDescriptor.
 func NewThirdPartyCapDescriptor_List(s *capnp.Segment, sz int32) (ThirdPartyCapDescriptor_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 8, PointerCount: 1}, sz)
-	return capnp.StructList[ThirdPartyCapDescriptor]{l}, err
+	return capnp.StructList[ThirdPartyCapDescriptor]{List: l}, err
 }
 
 // ThirdPartyCapDescriptor_Future is a wrapper for a ThirdPartyCapDescriptor promised by a client call.
@@ -2436,7 +2436,7 @@ type Exception_List = capnp.StructList[Exception]
 // NewException creates a new list of Exception.
 func NewException_List(s *capnp.Segment, sz int32) (Exception_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 8, PointerCount: 2}, sz)
-	return capnp.StructList[Exception]{l}, err
+	return capnp.StructList[Exception]{List: l}, err
 }
 
 // Exception_Future is a wrapper for a Exception promised by a client call.

--- a/std/capnp/rpctwoparty/rpc-twoparty.capnp.go
+++ b/std/capnp/rpctwoparty/rpc-twoparty.capnp.go
@@ -91,7 +91,7 @@ type VatId_List = capnp.StructList[VatId]
 // NewVatId creates a new list of VatId.
 func NewVatId_List(s *capnp.Segment, sz int32) (VatId_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 8, PointerCount: 0}, sz)
-	return capnp.StructList[VatId]{l}, err
+	return capnp.StructList[VatId]{List: l}, err
 }
 
 // VatId_Future is a wrapper for a VatId promised by a client call.
@@ -141,7 +141,7 @@ type ProvisionId_List = capnp.StructList[ProvisionId]
 // NewProvisionId creates a new list of ProvisionId.
 func NewProvisionId_List(s *capnp.Segment, sz int32) (ProvisionId_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 8, PointerCount: 0}, sz)
-	return capnp.StructList[ProvisionId]{l}, err
+	return capnp.StructList[ProvisionId]{List: l}, err
 }
 
 // ProvisionId_Future is a wrapper for a ProvisionId promised by a client call.
@@ -183,7 +183,7 @@ type RecipientId_List = capnp.StructList[RecipientId]
 // NewRecipientId creates a new list of RecipientId.
 func NewRecipientId_List(s *capnp.Segment, sz int32) (RecipientId_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 0, PointerCount: 0}, sz)
-	return capnp.StructList[RecipientId]{l}, err
+	return capnp.StructList[RecipientId]{List: l}, err
 }
 
 // RecipientId_Future is a wrapper for a RecipientId promised by a client call.
@@ -225,7 +225,7 @@ type ThirdPartyCapId_List = capnp.StructList[ThirdPartyCapId]
 // NewThirdPartyCapId creates a new list of ThirdPartyCapId.
 func NewThirdPartyCapId_List(s *capnp.Segment, sz int32) (ThirdPartyCapId_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 0, PointerCount: 0}, sz)
-	return capnp.StructList[ThirdPartyCapId]{l}, err
+	return capnp.StructList[ThirdPartyCapId]{List: l}, err
 }
 
 // ThirdPartyCapId_Future is a wrapper for a ThirdPartyCapId promised by a client call.
@@ -291,7 +291,7 @@ type JoinKeyPart_List = capnp.StructList[JoinKeyPart]
 // NewJoinKeyPart creates a new list of JoinKeyPart.
 func NewJoinKeyPart_List(s *capnp.Segment, sz int32) (JoinKeyPart_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 8, PointerCount: 0}, sz)
-	return capnp.StructList[JoinKeyPart]{l}, err
+	return capnp.StructList[JoinKeyPart]{List: l}, err
 }
 
 // JoinKeyPart_Future is a wrapper for a JoinKeyPart promised by a client call.
@@ -361,7 +361,7 @@ type JoinResult_List = capnp.StructList[JoinResult]
 // NewJoinResult creates a new list of JoinResult.
 func NewJoinResult_List(s *capnp.Segment, sz int32) (JoinResult_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 8, PointerCount: 1}, sz)
-	return capnp.StructList[JoinResult]{l}, err
+	return capnp.StructList[JoinResult]{List: l}, err
 }
 
 // JoinResult_Future is a wrapper for a JoinResult promised by a client call.

--- a/std/capnp/schema/schema.capnp.go
+++ b/std/capnp/schema/schema.capnp.go
@@ -553,7 +553,7 @@ type Node_List = capnp.StructList[Node]
 // NewNode creates a new list of Node.
 func NewNode_List(s *capnp.Segment, sz int32) (Node_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 40, PointerCount: 6}, sz)
-	return capnp.StructList[Node]{l}, err
+	return capnp.StructList[Node]{List: l}, err
 }
 
 // Node_Future is a wrapper for a Node promised by a client call.
@@ -675,7 +675,7 @@ type Node_Parameter_List = capnp.StructList[Node_Parameter]
 // NewNode_Parameter creates a new list of Node_Parameter.
 func NewNode_Parameter_List(s *capnp.Segment, sz int32) (Node_Parameter_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 0, PointerCount: 1}, sz)
-	return capnp.StructList[Node_Parameter]{l}, err
+	return capnp.StructList[Node_Parameter]{List: l}, err
 }
 
 // Node_Parameter_Future is a wrapper for a Node_Parameter promised by a client call.
@@ -743,7 +743,7 @@ type Node_NestedNode_List = capnp.StructList[Node_NestedNode]
 // NewNode_NestedNode creates a new list of Node_NestedNode.
 func NewNode_NestedNode_List(s *capnp.Segment, sz int32) (Node_NestedNode_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 8, PointerCount: 1}, sz)
-	return capnp.StructList[Node_NestedNode]{l}, err
+	return capnp.StructList[Node_NestedNode]{List: l}, err
 }
 
 // Node_NestedNode_Future is a wrapper for a Node_NestedNode promised by a client call.
@@ -835,7 +835,7 @@ type Node_SourceInfo_List = capnp.StructList[Node_SourceInfo]
 // NewNode_SourceInfo creates a new list of Node_SourceInfo.
 func NewNode_SourceInfo_List(s *capnp.Segment, sz int32) (Node_SourceInfo_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 8, PointerCount: 2}, sz)
-	return capnp.StructList[Node_SourceInfo]{l}, err
+	return capnp.StructList[Node_SourceInfo]{List: l}, err
 }
 
 // Node_SourceInfo_Future is a wrapper for a Node_SourceInfo promised by a client call.
@@ -895,7 +895,7 @@ type Node_SourceInfo_Member_List = capnp.StructList[Node_SourceInfo_Member]
 // NewNode_SourceInfo_Member creates a new list of Node_SourceInfo_Member.
 func NewNode_SourceInfo_Member_List(s *capnp.Segment, sz int32) (Node_SourceInfo_Member_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 0, PointerCount: 1}, sz)
-	return capnp.StructList[Node_SourceInfo_Member]{l}, err
+	return capnp.StructList[Node_SourceInfo_Member]{List: l}, err
 }
 
 // Node_SourceInfo_Member_Future is a wrapper for a Node_SourceInfo_Member promised by a client call.
@@ -1144,7 +1144,7 @@ type Field_List = capnp.StructList[Field]
 // NewField creates a new list of Field.
 func NewField_List(s *capnp.Segment, sz int32) (Field_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 24, PointerCount: 4}, sz)
-	return capnp.StructList[Field]{l}, err
+	return capnp.StructList[Field]{List: l}, err
 }
 
 // Field_Future is a wrapper for a Field promised by a client call.
@@ -1274,7 +1274,7 @@ type Enumerant_List = capnp.StructList[Enumerant]
 // NewEnumerant creates a new list of Enumerant.
 func NewEnumerant_List(s *capnp.Segment, sz int32) (Enumerant_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 8, PointerCount: 2}, sz)
-	return capnp.StructList[Enumerant]{l}, err
+	return capnp.StructList[Enumerant]{List: l}, err
 }
 
 // Enumerant_Future is a wrapper for a Enumerant promised by a client call.
@@ -1348,7 +1348,7 @@ type Superclass_List = capnp.StructList[Superclass]
 // NewSuperclass creates a new list of Superclass.
 func NewSuperclass_List(s *capnp.Segment, sz int32) (Superclass_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 8, PointerCount: 1}, sz)
-	return capnp.StructList[Superclass]{l}, err
+	return capnp.StructList[Superclass]{List: l}, err
 }
 
 // Superclass_Future is a wrapper for a Superclass promised by a client call.
@@ -1532,7 +1532,7 @@ type Method_List = capnp.StructList[Method]
 // NewMethod creates a new list of Method.
 func NewMethod_List(s *capnp.Segment, sz int32) (Method_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 24, PointerCount: 5}, sz)
-	return capnp.StructList[Method]{l}, err
+	return capnp.StructList[Method]{List: l}, err
 }
 
 // Method_Future is a wrapper for a Method promised by a client call.
@@ -2001,7 +2001,7 @@ type Type_List = capnp.StructList[Type]
 // NewType creates a new list of Type.
 func NewType_List(s *capnp.Segment, sz int32) (Type_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 24, PointerCount: 1}, sz)
-	return capnp.StructList[Type]{l}, err
+	return capnp.StructList[Type]{List: l}, err
 }
 
 // Type_Future is a wrapper for a Type promised by a client call.
@@ -2169,7 +2169,7 @@ type Brand_List = capnp.StructList[Brand]
 // NewBrand creates a new list of Brand.
 func NewBrand_List(s *capnp.Segment, sz int32) (Brand_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 0, PointerCount: 1}, sz)
-	return capnp.StructList[Brand]{l}, err
+	return capnp.StructList[Brand]{List: l}, err
 }
 
 // Brand_Future is a wrapper for a Brand promised by a client call.
@@ -2277,7 +2277,7 @@ type Brand_Scope_List = capnp.StructList[Brand_Scope]
 // NewBrand_Scope creates a new list of Brand_Scope.
 func NewBrand_Scope_List(s *capnp.Segment, sz int32) (Brand_Scope_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 16, PointerCount: 1}, sz)
-	return capnp.StructList[Brand_Scope]{l}, err
+	return capnp.StructList[Brand_Scope]{List: l}, err
 }
 
 // Brand_Scope_Future is a wrapper for a Brand_Scope promised by a client call.
@@ -2377,7 +2377,7 @@ type Brand_Binding_List = capnp.StructList[Brand_Binding]
 // NewBrand_Binding creates a new list of Brand_Binding.
 func NewBrand_Binding_List(s *capnp.Segment, sz int32) (Brand_Binding_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 8, PointerCount: 1}, sz)
-	return capnp.StructList[Brand_Binding]{l}, err
+	return capnp.StructList[Brand_Binding]{List: l}, err
 }
 
 // Brand_Binding_Future is a wrapper for a Brand_Binding promised by a client call.
@@ -2751,7 +2751,7 @@ type Value_List = capnp.StructList[Value]
 // NewValue creates a new list of Value.
 func NewValue_List(s *capnp.Segment, sz int32) (Value_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 16, PointerCount: 1}, sz)
-	return capnp.StructList[Value]{l}, err
+	return capnp.StructList[Value]{List: l}, err
 }
 
 // Value_Future is a wrapper for a Value promised by a client call.
@@ -2861,7 +2861,7 @@ type Annotation_List = capnp.StructList[Annotation]
 // NewAnnotation creates a new list of Annotation.
 func NewAnnotation_List(s *capnp.Segment, sz int32) (Annotation_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 8, PointerCount: 2}, sz)
-	return capnp.StructList[Annotation]{l}, err
+	return capnp.StructList[Annotation]{List: l}, err
 }
 
 // Annotation_Future is a wrapper for a Annotation promised by a client call.
@@ -3009,7 +3009,7 @@ type CapnpVersion_List = capnp.StructList[CapnpVersion]
 // NewCapnpVersion creates a new list of CapnpVersion.
 func NewCapnpVersion_List(s *capnp.Segment, sz int32) (CapnpVersion_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 8, PointerCount: 0}, sz)
-	return capnp.StructList[CapnpVersion]{l}, err
+	return capnp.StructList[CapnpVersion]{List: l}, err
 }
 
 // CapnpVersion_Future is a wrapper for a CapnpVersion promised by a client call.
@@ -3147,7 +3147,7 @@ type CodeGeneratorRequest_List = capnp.StructList[CodeGeneratorRequest]
 // NewCodeGeneratorRequest creates a new list of CodeGeneratorRequest.
 func NewCodeGeneratorRequest_List(s *capnp.Segment, sz int32) (CodeGeneratorRequest_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 0, PointerCount: 4}, sz)
-	return capnp.StructList[CodeGeneratorRequest]{l}, err
+	return capnp.StructList[CodeGeneratorRequest]{List: l}, err
 }
 
 // CodeGeneratorRequest_Future is a wrapper for a CodeGeneratorRequest promised by a client call.
@@ -3243,7 +3243,7 @@ type CodeGeneratorRequest_RequestedFile_List = capnp.StructList[CodeGeneratorReq
 // NewCodeGeneratorRequest_RequestedFile creates a new list of CodeGeneratorRequest_RequestedFile.
 func NewCodeGeneratorRequest_RequestedFile_List(s *capnp.Segment, sz int32) (CodeGeneratorRequest_RequestedFile_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 8, PointerCount: 2}, sz)
-	return capnp.StructList[CodeGeneratorRequest_RequestedFile]{l}, err
+	return capnp.StructList[CodeGeneratorRequest_RequestedFile]{List: l}, err
 }
 
 // CodeGeneratorRequest_RequestedFile_Future is a wrapper for a CodeGeneratorRequest_RequestedFile promised by a client call.
@@ -3311,7 +3311,7 @@ type CodeGeneratorRequest_RequestedFile_Import_List = capnp.StructList[CodeGener
 // NewCodeGeneratorRequest_RequestedFile_Import creates a new list of CodeGeneratorRequest_RequestedFile_Import.
 func NewCodeGeneratorRequest_RequestedFile_Import_List(s *capnp.Segment, sz int32) (CodeGeneratorRequest_RequestedFile_Import_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 8, PointerCount: 1}, sz)
-	return capnp.StructList[CodeGeneratorRequest_RequestedFile_Import]{l}, err
+	return capnp.StructList[CodeGeneratorRequest_RequestedFile_Import]{List: l}, err
 }
 
 // CodeGeneratorRequest_RequestedFile_Import_Future is a wrapper for a CodeGeneratorRequest_RequestedFile_Import promised by a client call.

--- a/std/capnp/stream/stream.capnp.go
+++ b/std/capnp/stream/stream.capnp.go
@@ -39,7 +39,7 @@ type StreamResult_List = capnp.StructList[StreamResult]
 // NewStreamResult creates a new list of StreamResult.
 func NewStreamResult_List(s *capnp.Segment, sz int32) (StreamResult_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 0, PointerCount: 0}, sz)
-	return capnp.StructList[StreamResult]{l}, err
+	return capnp.StructList[StreamResult]{List: l}, err
 }
 
 // StreamResult_Future is a wrapper for a StreamResult promised by a client call.


### PR DESCRIPTION
This is a minor change whose main benefit was to familiarize myself with the code generator, while also keeping linters happy.