### PR TITLE
Export Client.h.done channel through Done() method.

### DIFF
--- a/capability.go
+++ b/capability.go
@@ -379,7 +379,8 @@ func (c *Client) IsSame(c2 *Client) bool {
 	return h1 == h2
 }
 
-// Done returns when the client has been shut down.
+// Done returns when the client begins shutting down.  The channel
+// returned by Done() is closed before ClientHook.Shutdown() is called.
 func (c *Client) Done() <-chan struct{} { return c.h.done }
 
 // Resolve blocks until the capability is fully resolved or the Context is Done.

--- a/capability.go
+++ b/capability.go
@@ -379,6 +379,9 @@ func (c *Client) IsSame(c2 *Client) bool {
 	return h1 == h2
 }
 
+// Done returns when the client has been shut down.
+func (c *Client) Done() <-chan struct{} { return c.h.done }
+
 // Resolve blocks until the capability is fully resolved or the Context is Done.
 func (c *Client) Resolve(ctx context.Context) error {
 	for {


### PR DESCRIPTION
This commit adds a `Client.Done() <-chan struct{}`  method that returns `c.h.done`.  This allows application code to perform cleanup when clients are released.