### PR TITLE
Fix moar deadlocks

### DIFF
--- a/capability.go
+++ b/capability.go
@@ -292,12 +292,12 @@ func (c *Client) SendCall(ctx context.Context, s Send) (*Answer, ReleaseFunc) {
 	}
 
 	limiter := c.GetFlowLimiter()
-	var gotResponse func()
 
 	// We need to call PlaceArgs before we will know the size of message for
 	// flow control purposes, so wrap it in a function that measures after the
 	// arguments have been placed:
 	placeArgs := s.PlaceArgs
+	var size uint64
 	s.PlaceArgs = func(args Struct) error {
 		var err error
 		if placeArgs != nil {
@@ -307,30 +307,48 @@ func (c *Client) SendCall(ctx context.Context, s Send) (*Answer, ReleaseFunc) {
 			}
 		}
 
-		var size uint64
 		size, err = args.Segment().Message().TotalSize()
-		if err != nil {
-			return err
-		}
-
-		gotResponse, err = limiter.StartMessage(ctx, size)
 		return err
 	}
 
-	ans, err := h.Send(ctx, s)
-	if err == nil {
-		p := ans.f.promise
-		p.mu.Lock()
-		if p.isResolved() {
-			// Wow, that was fast.
-			p.mu.Unlock()
-			gotResponse()
-		} else {
-			p.signals = append(p.signals, gotResponse)
-			p.mu.Unlock()
-		}
+	ans, rel := h.Send(ctx, s)
+	// FIXME: an earlier version of this code called StartMessage() from
+	// within PlaceArgs -- but that can result in a deadlock, since it means
+	// the client hook is holding a lock while we're waiting on the limiter.
+	//
+	// As a temporary workaround, we instead do StartMessage *after* the send.
+	// This still has a bug, but a much less serious one: we may slightly
+	// over-use our limit, but only by the size of a single message. This is
+	// mostly a problem in that it contradicts the documentation and is
+	// conceptually odd.
+	//
+	// Longer term, we should fix a more serious design problem: Send() is
+	// holding a lock while calling into user code (PlaceArgs), so this
+	// deadlock could also arise if the user code blocks. Once that is solved,
+	// we can back out this hack.
+	gotResponse, err := limiter.StartMessage(ctx, size)
+	if err != nil {
+		// HACK: An error should only happen if the context was cancelled,
+		// in which case the caller will notice it soon probably. The call
+		// still went off ok, so we can just return the result we already
+		// got, and trying to report the error is awkward because we can't
+		// return one... so we don't. Set gotResponse to something that won't
+		// break things, and call it a day. See comments above about a
+		// longer term solution to this mess.
+		gotResponse = func() {}
 	}
-	return ans, err
+	p := ans.f.promise
+	p.mu.Lock()
+	if p.isResolved() {
+		// Wow, that was fast.
+		p.mu.Unlock()
+		gotResponse()
+	} else {
+		p.signals = append(p.signals, gotResponse)
+		p.mu.Unlock()
+	}
+
+	return ans, rel
 }
 
 // RecvCall starts executing a method with the referenced arguments

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -936,78 +936,89 @@ func (c *Conn) handleReturn(ctx context.Context, ret rpccp.Return, release capnp
 	if pr.parseFailed {
 		c.er.ReportError(rpcerr.Annotate(pr.err, "incoming return"))
 	}
-	switch {
-	case q.bootstrapPromise != nil && pr.err == nil:
-		q.release = func() {}
-		syncutil.Without(&c.mu, func() {
-			q.p.Fulfill(pr.result)
-			q.bootstrapPromise.Fulfill(q.p.Answer().Client())
-			q.p.ReleaseClients()
-			clearCapTable(pr.result.Message())
-			release()
-		})
-	case q.bootstrapPromise != nil && pr.err != nil:
-		// TODO(someday): send unimplemented message back to remote if
-		// pr.unimplemented == true.
-		q.release = func() {}
-		syncutil.Without(&c.mu, func() {
-			q.p.Reject(pr.err)
-			q.bootstrapPromise.Fulfill(q.p.Answer().Client())
-			q.p.ReleaseClients()
-			release()
-		})
-	case q.bootstrapPromise == nil && pr.err != nil:
-		// TODO(someday): send unimplemented message back to remote if
-		// pr.unimplemented == true.
-		q.release = func() {}
-		syncutil.Without(&c.mu, func() {
-			q.p.Reject(pr.err)
-			release()
-		})
-	default:
-		m := ret.Message()
-		q.release = func() {
-			clearCapTable(m)
-			release()
-		}
-		syncutil.Without(&c.mu, func() {
-			q.p.Fulfill(pr.result)
-		})
-	}
-	c.mu.Unlock()
 
-	// Send disembargoes.  Failing to send one of these just never lifts
-	// the embargo on our side, but doesn't cause a leak.
+	// We're going to potentially block fulfilling some promises so fork
+	// off a goroutine to avoid blocking the receive loop.
 	//
-	// TODO(soon): make embargo resolve to error client.
-	for _, s := range pr.disembargoes {
-		c.sendMessage(ctx, s.buildDisembargo, func(err error) {
-			err = fmt.Errorf("incoming return: send disembargo: %w", err)
-			c.er.ReportError(err)
+	// TODO(cleanup): This is a bit weird in that we hold the lock across
+	// the go statement, and do the unlock in the new goroutine, but before
+	// we actually block. This was less weird when the go statement wasn't
+	// there, and we should rework this so it's easier to understand what's
+	// going on.
+	go func() {
+		switch {
+		case q.bootstrapPromise != nil && pr.err == nil:
+			q.release = func() {}
+			syncutil.Without(&c.mu, func() {
+				q.p.Fulfill(pr.result)
+				q.bootstrapPromise.Fulfill(q.p.Answer().Client())
+				q.p.ReleaseClients()
+				clearCapTable(pr.result.Message())
+				release()
+			})
+		case q.bootstrapPromise != nil && pr.err != nil:
+			// TODO(someday): send unimplemented message back to remote if
+			// pr.unimplemented == true.
+			q.release = func() {}
+			syncutil.Without(&c.mu, func() {
+				q.p.Reject(pr.err)
+				q.bootstrapPromise.Fulfill(q.p.Answer().Client())
+				q.p.ReleaseClients()
+				release()
+			})
+		case q.bootstrapPromise == nil && pr.err != nil:
+			// TODO(someday): send unimplemented message back to remote if
+			// pr.unimplemented == true.
+			q.release = func() {}
+			syncutil.Without(&c.mu, func() {
+				q.p.Reject(pr.err)
+				release()
+			})
+		default:
+			m := ret.Message()
+			q.release = func() {
+				clearCapTable(m)
+				release()
+			}
+			syncutil.Without(&c.mu, func() {
+				q.p.Fulfill(pr.result)
+			})
+		}
+		c.mu.Unlock()
+
+		// Send disembargoes.  Failing to send one of these just never lifts
+		// the embargo on our side, but doesn't cause a leak.
+		//
+		// TODO(soon): make embargo resolve to error client.
+		for _, s := range pr.disembargoes {
+			c.sendMessage(ctx, s.buildDisembargo, func(err error) {
+				err = fmt.Errorf("incoming return: send disembargo: %w", err)
+				c.er.ReportError(err)
+			})
+		}
+
+		// Send finish.
+		c.sendMessage(ctx, func(m rpccp.Message) error {
+			fin, err := m.NewFinish()
+			if err == nil {
+				fin.SetQuestionId(uint32(qid))
+				fin.SetReleaseResultCaps(false)
+			}
+			return err
+		}, func(err error) {
+			c.mu.Lock()
+			defer c.mu.Unlock()
+			defer close(q.finishMsgSend)
+
+			if err != nil {
+				err = fmt.Errorf("incoming return: send finish: build message: %w", err)
+				c.er.ReportError(err)
+			} else {
+				q.flags |= finishSent
+				c.questionID.remove(uint32(qid))
+			}
 		})
-	}
-
-	// Send finish.
-	c.sendMessage(ctx, func(m rpccp.Message) error {
-		fin, err := m.NewFinish()
-		if err == nil {
-			fin.SetQuestionId(uint32(qid))
-			fin.SetReleaseResultCaps(false)
-		}
-		return err
-	}, func(err error) {
-		c.mu.Lock()
-		defer c.mu.Unlock()
-		defer close(q.finishMsgSend)
-
-		if err != nil {
-			err = fmt.Errorf("incoming return: send finish: build message: %w", err)
-			c.er.ReportError(err)
-		} else {
-			q.flags |= finishSent
-			c.questionID.remove(uint32(qid))
-		}
-	})
+	}()
 
 	return nil
 }


### PR DESCRIPTION
The results of the debugging session @lthibault and I had the other day.

There are actually three separate deadlock bugs, only two of which we noticed the other day, the third of which we didn't notice but was probably what we were actually observing the symptoms of, and which was way way dumber than the other two and we fixed without even noticing -- see the commit messages.

Note that the diff for rpc.go is an abomination; all it's doing is wrapping a huge block of code in `go func() { ... } ()` and adding a comment, but this simple change is over git's head apparently.