### PR TITLE
Add typed wrapper for lists of capabilities.

### DIFF
--- a/capnpc-go/capnpc-go.go
+++ b/capnpc-go/capnpc-go.go
@@ -744,7 +744,15 @@ func makeTypeRef(t schema.Type, rel *node, nodes nodeMap) (typeRef, error) {
 			ref.name = ref.name + "_List"
 			ref.newfunc = "New" + ref.name
 			return ref, nil
-		case schema.Type_Which_anyPointer, schema.Type_Which_list, schema.Type_Which_interface:
+		case schema.Type_Which_interface:
+			ref, err := nodeRef(lt.Interface().TypeId())
+			if err != nil {
+				return ref, err
+			}
+			ref.name = ref.name + "_List"
+			ref.newfunc = "New" + ref.name
+			return ref, nil
+		case schema.Type_Which_anyPointer, schema.Type_Which_list:
 			return typeRef{name: "PointerList", newfunc: "NewPointerList", imp: capnpImportSpec}, nil
 		}
 	case schema.Type_Which_anyPointer:
@@ -1095,6 +1103,11 @@ func (g *generator) defineInterface(n *node) error {
 	if err != nil {
 		return fmt.Errorf("interface server %s: %v", n, err)
 	}
+
+	err = g.r.Render(interfaceListParams{
+		G:    g,
+		Node: n,
+	})
 	return nil
 }
 

--- a/capnpc-go/templateparams.go
+++ b/capnpc-go/templateparams.go
@@ -164,6 +164,11 @@ type promiseFieldInterfaceParams struct {
 	Interface *node
 }
 
+type interfaceListParams struct {
+	G    *generator
+	Node *node
+}
+
 type interfaceClientParams struct {
 	G           *generator
 	Node        *node

--- a/capnpc-go/templates/interfaceList
+++ b/capnpc-go/templates/interfaceList
@@ -1,0 +1,9 @@
+
+// {{.Node.Name}}_List is a list of {{.Node.Name}}.
+type {{.Node.Name}}_List = {{.G.Capnp}}.CapList[{{.Node.Name}}]
+
+// New{{.Node.Name}} creates a new list of {{.Node.Name}}.
+func New{{.Node.Name}}_List(s *{{.G.Capnp}}.Segment, sz int32) ({{.Node.Name}}_List, error) {
+	l, err := {{.G.Capnp}}.NewPointerList(s, sz)
+	return {{.G.Capnp}}.CapList[{{.Node.Name}}](l), err
+}

--- a/internal/aircraftlib/aircraft.capnp.go
+++ b/internal/aircraftlib/aircraft.capnp.go
@@ -2156,12 +2156,12 @@ func (s Z) SetEcho(v Echo) error {
 	return s.Struct.SetPtr(0, in.ToPtr())
 }
 
-func (s Z) Echoes() (capnp.PointerList, error) {
+func (s Z) Echoes() (Echo_List, error) {
 	if s.Struct.Uint16(0) != 44 {
 		panic("Which() != echoes")
 	}
 	p, err := s.Struct.Ptr(0)
-	return capnp.PointerList{List: p.List()}, err
+	return Echo_List{List: p.List()}, err
 }
 
 func (s Z) HasEchoes() bool {
@@ -2171,18 +2171,18 @@ func (s Z) HasEchoes() bool {
 	return s.Struct.HasPtr(0)
 }
 
-func (s Z) SetEchoes(v capnp.PointerList) error {
+func (s Z) SetEchoes(v Echo_List) error {
 	s.Struct.SetUint16(0, 44)
 	return s.Struct.SetPtr(0, v.List.ToPtr())
 }
 
 // NewEchoes sets the echoes field to a newly
-// allocated capnp.PointerList, preferring placement in s's segment.
-func (s Z) NewEchoes(n int32) (capnp.PointerList, error) {
+// allocated Echo_List, preferring placement in s's segment.
+func (s Z) NewEchoes(n int32) (Echo_List, error) {
 	s.Struct.SetUint16(0, 44)
-	l, err := capnp.NewPointerList(s.Struct.Segment(), n)
+	l, err := NewEcho_List(s.Struct.Segment(), n)
 	if err != nil {
-		return capnp.PointerList{}, err
+		return Echo_List{}, err
 	}
 	err = s.Struct.SetPtr(0, l.List.ToPtr())
 	return l, err
@@ -4406,6 +4406,15 @@ func (c Echo_echo) AllocResults() (Echo_echo_Results, error) {
 	return Echo_echo_Results{Struct: r}, err
 }
 
+// Echo_List is a list of Echo.
+type Echo_List = capnp.CapList[Echo]
+
+// NewEcho creates a new list of Echo.
+func NewEcho_List(s *capnp.Segment, sz int32) (Echo_List, error) {
+	l, err := capnp.NewPointerList(s, sz)
+	return capnp.CapList[Echo](l), err
+}
+
 type Echo_echo_Params struct{ capnp.Struct }
 
 // Echo_echo_Params_TypeID is the unique identifier for the type Echo_echo_Params.
@@ -4978,6 +4987,15 @@ func (c CallSequence_getNumber) AllocResults() (CallSequence_getNumber_Results, 
 	return CallSequence_getNumber_Results{Struct: r}, err
 }
 
+// CallSequence_List is a list of CallSequence.
+type CallSequence_List = capnp.CapList[CallSequence]
+
+// NewCallSequence creates a new list of CallSequence.
+func NewCallSequence_List(s *capnp.Segment, sz int32) (CallSequence_List, error) {
+	l, err := capnp.NewPointerList(s, sz)
+	return capnp.CapList[CallSequence](l), err
+}
+
 type CallSequence_getNumber_Params struct{ capnp.Struct }
 
 // CallSequence_getNumber_Params_TypeID is the unique identifier for the type CallSequence_getNumber_Params.
@@ -5186,6 +5204,15 @@ func (c Pipeliner_newPipeliner) Args() Pipeliner_newPipeliner_Params {
 func (c Pipeliner_newPipeliner) AllocResults() (Pipeliner_newPipeliner_Results, error) {
 	r, err := c.Call.AllocResults(capnp.ObjectSize{DataSize: 0, PointerCount: 2})
 	return Pipeliner_newPipeliner_Results{Struct: r}, err
+}
+
+// Pipeliner_List is a list of Pipeliner.
+type Pipeliner_List = capnp.CapList[Pipeliner]
+
+// NewPipeliner creates a new list of Pipeliner.
+func NewPipeliner_List(s *capnp.Segment, sz int32) (Pipeliner_List, error) {
+	l, err := capnp.NewPointerList(s, sz)
+	return capnp.CapList[Pipeliner](l), err
 }
 
 type Pipeliner_newPipeliner_Params struct{ capnp.Struct }

--- a/list.go
+++ b/list.go
@@ -1037,6 +1037,23 @@ func (s StructList[T]) String() string {
 	return buf.String()
 }
 
+type CapList[T ~struct{ Client *Client }] PointerList
+
+func (c CapList[T]) At(i int) (T, error) {
+	ptr, err := PointerList(c).At(i)
+	if err != nil {
+		return T{}, err
+	}
+	return T{Client: ptr.Interface().Client()}, nil
+}
+
+func (c CapList[T]) Set(i int, v T) error {
+	pl := PointerList(c)
+	seg := pl.List.Segment()
+	capId := seg.Message().AddCap(struct{ Client *Client }(v).Client)
+	return pl.Set(i, NewInterface(seg, capId).ToPtr())
+}
+
 type listFlags uint8
 
 const (

--- a/pogs/pogs_test.go
+++ b/pogs/pogs_test.go
@@ -1215,7 +1215,7 @@ func zfill(c air.Z, g *Z) error {
 			if !ee.Client.IsValid() {
 				continue
 			}
-			err := e.Set(i, capnp.NewInterface(e.Segment(), e.Message().AddCap(ee.Client)).ToPtr())
+			err := e.Set(i, ee)
 			if err != nil {
 				return err
 			}

--- a/rpc/internal/testcapnp/test.capnp.go
+++ b/rpc/internal/testcapnp/test.capnp.go
@@ -99,6 +99,15 @@ func (c PingPong_echoNum) AllocResults() (PingPong_echoNum_Results, error) {
 	return PingPong_echoNum_Results{Struct: r}, err
 }
 
+// PingPong_List is a list of PingPong.
+type PingPong_List = capnp.CapList[PingPong]
+
+// NewPingPong creates a new list of PingPong.
+func NewPingPong_List(s *capnp.Segment, sz int32) (PingPong_List, error) {
+	l, err := capnp.NewPointerList(s, sz)
+	return capnp.CapList[PingPong](l), err
+}
+
 type PingPong_echoNum_Params struct{ capnp.Struct }
 
 // PingPong_echoNum_Params_TypeID is the unique identifier for the type PingPong_echoNum_Params.
@@ -285,6 +294,15 @@ func (c StreamTest_push) Args() StreamTest_push_Params {
 func (c StreamTest_push) AllocResults() (stream.StreamResult, error) {
 	r, err := c.Call.AllocResults(capnp.ObjectSize{DataSize: 0, PointerCount: 0})
 	return stream.StreamResult{Struct: r}, err
+}
+
+// StreamTest_List is a list of StreamTest.
+type StreamTest_List = capnp.CapList[StreamTest]
+
+// NewStreamTest creates a new list of StreamTest.
+func NewStreamTest_List(s *capnp.Segment, sz int32) (StreamTest_List, error) {
+	l, err := capnp.NewPointerList(s, sz)
+	return capnp.CapList[StreamTest](l), err
 }
 
 type StreamTest_push_Params struct{ capnp.Struct }
@@ -475,6 +493,15 @@ func (c CapArgsTest_self) Args() CapArgsTest_self_Params {
 func (c CapArgsTest_self) AllocResults() (CapArgsTest_self_Results, error) {
 	r, err := c.Call.AllocResults(capnp.ObjectSize{DataSize: 0, PointerCount: 1})
 	return CapArgsTest_self_Results{Struct: r}, err
+}
+
+// CapArgsTest_List is a list of CapArgsTest.
+type CapArgsTest_List = capnp.CapList[CapArgsTest]
+
+// NewCapArgsTest creates a new list of CapArgsTest.
+func NewCapArgsTest_List(s *capnp.Segment, sz int32) (CapArgsTest_List, error) {
+	l, err := capnp.NewPointerList(s, sz)
+	return capnp.CapList[CapArgsTest](l), err
 }
 
 type CapArgsTest_call_Params struct{ capnp.Struct }

--- a/std/capnp/persistent/persistent.capnp.go
+++ b/std/capnp/persistent/persistent.capnp.go
@@ -100,6 +100,15 @@ func (c Persistent_save) AllocResults() (Persistent_SaveResults, error) {
 	return Persistent_SaveResults{Struct: r}, err
 }
 
+// Persistent_List is a list of Persistent.
+type Persistent_List = capnp.CapList[Persistent]
+
+// NewPersistent creates a new list of Persistent.
+func NewPersistent_List(s *capnp.Segment, sz int32) (Persistent_List, error) {
+	l, err := capnp.NewPointerList(s, sz)
+	return capnp.CapList[Persistent](l), err
+}
+
 type Persistent_SaveParams struct{ capnp.Struct }
 
 // Persistent_SaveParams_TypeID is the unique identifier for the type Persistent_SaveParams.


### PR DESCRIPTION
...To match the ones for structs and enums.

---

We should add a similar wrapper for nested lists (`List (List(T)`) before we release v3, and any other such missing list types I haven't thought of.