### PR TITLE
Client: hide pointer indirection.

### DIFF
--- a/answer.go
+++ b/answer.go
@@ -73,7 +73,7 @@ type Promise struct {
 }
 
 type clientAndPromise struct {
-	client  *Client
+	client  Client
 	promise *ClientPromise
 }
 
@@ -295,7 +295,7 @@ func (ans *Answer) Struct() (Struct, error) {
 // call has not completed, then calls will be queued until the original
 // call's completion.  The client reference is borrowed: the caller
 // should not call Close.
-func (ans *Answer) Client() *Client {
+func (ans *Answer) Client() Client {
 	return ans.f.Client()
 }
 
@@ -423,7 +423,7 @@ func (f *Future) Struct() (Struct, error) {
 // call has not completed, then calls will be queued until the original
 // call's completion.  The client reference is borrowed: the caller
 // should not call Close.
-func (f *Future) Client() *Client {
+func (f *Future) Client() Client {
 	p := f.promise
 	p.mu.Lock()
 	switch {
@@ -585,7 +585,7 @@ func (r resolution) strct(transform []PipelineOp) (Struct, error) {
 }
 
 // client obtains a Client by applying a transform.
-func (r resolution) client(transform []PipelineOp) *Client {
+func (r resolution) client(transform []PipelineOp) Client {
 	p, err := r.ptr(transform)
 	if err != nil {
 		return ErrorClient(err)

--- a/capability_test.go
+++ b/capability_test.go
@@ -117,19 +117,19 @@ func TestReleasedClient(t *testing.T) {
 func TestNullClient(t *testing.T) {
 	ctx := context.Background()
 	c, p := NewPromisedClient(new(dummyHook))
-	p.Fulfill(nil)
+	p.Fulfill(Client{})
 	tests := []struct {
 		name string
-		c    *Client
+		c    Client
 	}{
-		{"nil", nil},
+		{"nil", Client{}},
 		{"promised nil", c},
 	}
 
 	for _, test := range tests {
 		c := test.c
 		t.Run(test.name, func(t *testing.T) {
-			if NewClient(nil) != nil {
+			if (NewClient(nil) != Client{}) {
 				t.Error("NewClient(nil) != nil")
 			}
 			if !c.IsSame(c) {

--- a/capnpc-go/templates/interfaceClient
+++ b/capnpc-go/templates/interfaceClient
@@ -1,7 +1,7 @@
 {{with .Annotations.Doc -}}
 // {{.}}
 {{end -}}
-type {{.Node.Name}} struct { Client *{{.G.Capnp}}.Client }
+type {{.Node.Name}} struct { Client {{.G.Capnp}}.Client }
 
 {{ template "_typeid" .Node }}
 

--- a/capnpc-go/templates/structCapabilityField
+++ b/capnpc-go/templates/structCapabilityField
@@ -1,4 +1,4 @@
-func (s {{.Node.Name}}) {{.Field.Name|title}}() *{{.FieldType}} {
+func (s {{.Node.Name}}) {{.Field.Name|title}}() {{.FieldType}} {
 	{{template "_checktag" . -}}
 	p, _ := s.Struct.Ptr({{.Field.Slot.Offset}})
 	return p.Interface().Client()
@@ -6,7 +6,7 @@ func (s {{.Node.Name}}) {{.Field.Name|title}}() *{{.FieldType}} {
 
 {{template "_hasfield" .}}
 
-func (s {{.Node.Name}}) Set{{.Field.Name|title}}(c *{{.FieldType}}) error {
+func (s {{.Node.Name}}) Set{{.Field.Name|title}}(c {{.FieldType}}) error {
 	{{template "_settag" . -}}
 	if !c.IsValid() {
 		return s.Struct.SetPtr({{.Field.Slot.Offset}}, capnp.Ptr{})

--- a/internal/aircraftlib/aircraft.capnp.go
+++ b/internal/aircraftlib/aircraft.capnp.go
@@ -2245,7 +2245,7 @@ func (s Z) SetAnyList(v capnp.Ptr) error {
 	return s.Struct.SetPtr(0, v)
 }
 
-func (s Z) AnyCapability() *capnp.Client {
+func (s Z) AnyCapability() capnp.Client {
 	if s.Struct.Uint16(0) != 48 {
 		panic("Which() != anyCapability")
 	}
@@ -2260,7 +2260,7 @@ func (s Z) HasAnyCapability() bool {
 	return s.Struct.HasPtr(0)
 }
 
-func (s Z) SetAnyCapability(c *capnp.Client) error {
+func (s Z) SetAnyCapability(c capnp.Client) error {
 	s.Struct.SetUint16(0, 48)
 	if !c.IsValid() {
 		return s.Struct.SetPtr(0, capnp.Ptr{})
@@ -4318,7 +4318,7 @@ func (p ListStructCapn_Future) Struct() (ListStructCapn, error) {
 	return ListStructCapn{s}, err
 }
 
-type Echo struct{ Client *capnp.Client }
+type Echo struct{ Client capnp.Client }
 
 // Echo_TypeID is the unique identifier for the type Echo.
 const Echo_TypeID = 0x8e5322c1e9282534
@@ -4899,7 +4899,7 @@ func (p StackingB_Future) Struct() (StackingB, error) {
 	return StackingB{s}, err
 }
 
-type CallSequence struct{ Client *capnp.Client }
+type CallSequence struct{ Client capnp.Client }
 
 // CallSequence_TypeID is the unique identifier for the type CallSequence.
 const CallSequence_TypeID = 0xabaedf5f7817c820
@@ -5088,7 +5088,7 @@ func (p CallSequence_getNumber_Results_Future) Struct() (CallSequence_getNumber_
 	return CallSequence_getNumber_Results{s}, err
 }
 
-type Pipeliner struct{ Client *capnp.Client }
+type Pipeliner struct{ Client capnp.Client }
 
 // Pipeliner_TypeID is the unique identifier for the type Pipeliner.
 const Pipeliner_TypeID = 0xd6514008f0f84ebc

--- a/list.go
+++ b/list.go
@@ -1037,7 +1037,7 @@ func (s StructList[T]) String() string {
 	return buf.String()
 }
 
-type CapList[T ~struct{ Client *Client }] PointerList
+type CapList[T ~struct{ Client Client }] PointerList
 
 func (c CapList[T]) At(i int) (T, error) {
 	ptr, err := PointerList(c).At(i)
@@ -1050,7 +1050,7 @@ func (c CapList[T]) At(i int) (T, error) {
 func (c CapList[T]) Set(i int, v T) error {
 	pl := PointerList(c)
 	seg := pl.List.Segment()
-	capId := seg.Message().AddCap(struct{ Client *Client }(v).Client)
+	capId := seg.Message().AddCap(struct{ Client Client }(v).Client)
 	return pl.Set(i, NewInterface(seg, capId).ToPtr())
 }
 

--- a/message.go
+++ b/message.go
@@ -41,7 +41,7 @@ type Message struct {
 	//
 	// See https://capnproto.org/encoding.html#capabilities-interfaces for
 	// more details on the capability table.
-	CapTable []*Client
+	CapTable []Client
 
 	// TraverseLimit limits how many total bytes of data are allowed to be
 	// traversed while reading.  Traversal is counted when a Struct or
@@ -204,7 +204,7 @@ func (m *Message) SetRoot(p Ptr) error {
 // AddCap appends a capability to the message's capability table and
 // returns its ID.  It "steals" c's reference: the Message will release
 // the client when calling Reset.
-func (m *Message) AddCap(c *Client) CapabilityID {
+func (m *Message) AddCap(c Client) CapabilityID {
 	n := CapabilityID(len(m.CapTable))
 	m.CapTable = append(m.CapTable, c)
 	return n

--- a/message_test.go
+++ b/message_test.go
@@ -787,13 +787,13 @@ func TestAddCap(t *testing.T) {
 		t.Errorf("msg.CapTable[1] = %v; want %v", msg.CapTable[1], client1)
 	}
 	// nil client
-	id3 := msg.AddCap(nil)
+	id3 := msg.AddCap(Client{})
 	if id3 != 2 {
 		t.Errorf("third AddCap ID = %d; want 2", id3)
 	}
 	if len(msg.CapTable) != 3 {
 		t.Errorf("after third AddCap, len(msg.CapTable) = %d; want 3", len(msg.CapTable))
-	} else if !msg.CapTable[2].IsSame(nil) {
+	} else if !msg.CapTable[2].IsSame(Client{}) {
 		t.Errorf("msg.CapTable[2] = %v; want <nil>", msg.CapTable[2])
 	}
 	// AddCap should not attempt to deduplicate.

--- a/pogs/extract.go
+++ b/pogs/extract.go
@@ -26,8 +26,7 @@ type extracter struct {
 }
 
 var (
-	clientType = reflect.TypeOf((*capnp.Client)(nil))
-
+	clientType = reflect.TypeOf(capnp.Client{})
 	ptrType    = reflect.TypeOf(capnp.Ptr{})
 	structType = reflect.TypeOf(capnp.Struct{})
 	listType   = reflect.TypeOf(capnp.List{})
@@ -238,11 +237,7 @@ func (e *extracter) extractField(val reflect.Value, s capnp.Struct, f schema.Fie
 		}
 
 		client := p.Interface().Client()
-		if client == nil {
-			val.Set(reflect.Zero(val.Type()))
-		} else {
-			val.Set(reflect.ValueOf(client))
-		}
+		val.Set(reflect.ValueOf(client))
 	case schema.Type_Which_anyPointer:
 		p, err := s.Ptr(uint16(f.Slot().Offset()))
 		if err != nil {

--- a/pogs/insert.go
+++ b/pogs/insert.go
@@ -235,7 +235,7 @@ func (ins *inserter) insertField(s capnp.Struct, f schema.Field, val reflect.Val
 		case listType:
 			return s.SetPtr(off, val.Interface().(capnp.List).ToPtr())
 		case clientType:
-			c := val.Interface().(*capnp.Client)
+			c := val.Interface().(capnp.Client)
 			if !c.IsValid() {
 				return s.SetPtr(off, capnp.Ptr{})
 			}
@@ -251,9 +251,9 @@ func (ins *inserter) insertField(s capnp.Struct, f schema.Field, val reflect.Val
 }
 
 func capPtr(seg *capnp.Segment, val reflect.Value) capnp.Ptr {
-	client, ok := val.Interface().(*capnp.Client)
+	client, ok := val.Interface().(capnp.Client)
 	if !ok {
-		client = val.FieldByName("Client").Interface().(*capnp.Client)
+		client = val.FieldByName("Client").Interface().(capnp.Client)
 	}
 	if !client.IsValid() {
 		return capnp.Ptr{}

--- a/pogs/pogs_test.go
+++ b/pogs/pogs_test.go
@@ -59,7 +59,7 @@ type Z struct {
 	AnyPtr        capnp.Ptr
 	AnyStruct     capnp.Struct
 	AnyList       capnp.List
-	AnyCapability *capnp.Client
+	AnyCapability capnp.Client
 }
 
 type PlaneBase struct {
@@ -163,11 +163,11 @@ var goodTests = []Z{
 	{Which: air.Z_Which_echo, Echo: air.Echo{}},
 	{Which: air.Z_Which_echo, Echo: air.Echo{Client: capnp.ErrorClient(errors.New("boo"))}},
 	{Which: air.Z_Which_echoes, Echoes: []air.Echo{
-		{Client: nil},
+		{Client: capnp.Client{}},
 		{Client: capnp.ErrorClient(errors.New("boo"))},
-		{Client: nil},
+		{Client: capnp.Client{}},
 		{Client: capnp.ErrorClient(errors.New("boo"))},
-		{Client: nil},
+		{Client: capnp.Client{}},
 	}},
 	{Which: air.Z_Which_anyPtr, AnyPtr: capnp.Ptr{}},
 	{Which: air.Z_Which_anyPtr, AnyPtr: newTestStruct().ToPtr()},
@@ -177,7 +177,7 @@ var goodTests = []Z{
 	{Which: air.Z_Which_anyStruct, AnyStruct: newTestStruct()},
 	{Which: air.Z_Which_anyList, AnyList: capnp.List{}},
 	{Which: air.Z_Which_anyList, AnyList: newTestList()},
-	{Which: air.Z_Which_anyCapability, AnyCapability: nil},
+	{Which: air.Z_Which_anyCapability, AnyCapability: capnp.Client{}},
 	{Which: air.Z_Which_anyCapability, AnyCapability: capnp.ErrorClient(errors.New("boo"))},
 }
 

--- a/pointer_test.go
+++ b/pointer_test.go
@@ -71,12 +71,12 @@ func TestEqual(t *testing.T) {
 	plistB, _ := NewPointerList(seg, 1)
 	plistB.Set(0, structB.ToPtr())
 	ec := ErrorClient(errors.New("boo"))
-	msg.CapTable = []*Client{
+	msg.CapTable = []Client{
 		0: ec,
 		1: ec,
 		2: ErrorClient(errors.New("another boo")),
-		3: nil,
-		4: nil,
+		3: Client{},
+		4: Client{},
 	}
 	iface1 := NewInterface(seg, 0)
 	iface2 := NewInterface(seg, 1)

--- a/rpc/answer.go
+++ b/rpc/answer.go
@@ -52,7 +52,7 @@ type answer struct {
 	// results message because CapTable cannot be used once results are
 	// sent.  However, the capabilities need to be retained for promised
 	// answer targets.
-	resultCapTable []*capnp.Client
+	resultCapTable []capnp.Client
 
 	// exportRefs is the number of references to exports placed in the
 	// results.
@@ -161,12 +161,12 @@ func (ans *answer) AllocResults(sz capnp.ObjectSize) (capnp.Struct, error) {
 
 // setBootstrap sets the results to an interface pointer, stealing the
 // reference.
-func (ans *answer) setBootstrap(c *capnp.Client) error {
+func (ans *answer) setBootstrap(c capnp.Client) error {
 	if ans.ret.HasResults() || len(ans.ret.Message().CapTable) > 0 || len(ans.resultCapTable) > 0 {
 		panic("setBootstrap called after creating results")
 	}
 	// Add the capability to the table early to avoid leaks if setBootstrap fails.
-	ans.resultCapTable = []*capnp.Client{c}
+	ans.resultCapTable = []capnp.Client{c}
 
 	var err error
 	ans.results, err = ans.ret.NewResults()

--- a/rpc/import.go
+++ b/rpc/import.go
@@ -50,7 +50,7 @@ type impent struct {
 // This is separate from the reference counting that capnp.Client does.
 //
 // The caller must be holding onto c.mu.
-func (c *Conn) addImport(id importID) *capnp.Client {
+func (c *Conn) addImport(id importID) capnp.Client {
 	if ent := c.imports[id]; ent != nil {
 		ent.wireRefs++
 		client, ok := ent.wc.AddRef()

--- a/rpc/internal/testcapnp/test.capnp.go
+++ b/rpc/internal/testcapnp/test.capnp.go
@@ -11,7 +11,7 @@ import (
 	context "context"
 )
 
-type PingPong struct{ Client *capnp.Client }
+type PingPong struct{ Client capnp.Client }
 
 // PingPong_TypeID is the unique identifier for the type PingPong.
 const PingPong_TypeID = 0xf004c474c2f8ee7a
@@ -208,7 +208,7 @@ func (p PingPong_echoNum_Results_Future) Struct() (PingPong_echoNum_Results, err
 	return PingPong_echoNum_Results{s}, err
 }
 
-type StreamTest struct{ Client *capnp.Client }
+type StreamTest struct{ Client capnp.Client }
 
 // StreamTest_TypeID is the unique identifier for the type StreamTest.
 const StreamTest_TypeID = 0xbb3ca85b01eea465
@@ -360,7 +360,7 @@ func (p StreamTest_push_Params_Future) Struct() (StreamTest_push_Params, error) 
 	return StreamTest_push_Params{s}, err
 }
 
-type CapArgsTest struct{ Client *capnp.Client }
+type CapArgsTest struct{ Client capnp.Client }
 
 // CapArgsTest_TypeID is the unique identifier for the type CapArgsTest.
 const CapArgsTest_TypeID = 0xb86bce7f916a10cc
@@ -529,7 +529,7 @@ func (s CapArgsTest_call_Params) String() string {
 	return str
 }
 
-func (s CapArgsTest_call_Params) Cap() *capnp.Client {
+func (s CapArgsTest_call_Params) Cap() capnp.Client {
 	p, _ := s.Struct.Ptr(0)
 	return p.Interface().Client()
 }
@@ -538,7 +538,7 @@ func (s CapArgsTest_call_Params) HasCap() bool {
 	return s.Struct.HasPtr(0)
 }
 
-func (s CapArgsTest_call_Params) SetCap(c *capnp.Client) error {
+func (s CapArgsTest_call_Params) SetCap(c capnp.Client) error {
 	if !c.IsValid() {
 		return s.Struct.SetPtr(0, capnp.Ptr{})
 	}

--- a/rpc/level0_test.go
+++ b/rpc/level0_test.go
@@ -1775,7 +1775,7 @@ type errorfer interface {
 	Errorf(string, ...interface{})
 }
 
-func newServer(impl func(context.Context, *server.Call) error, shutdown shutdownFunc) *capnp.Client {
+func newServer(impl func(context.Context, *server.Call) error, shutdown shutdownFunc) capnp.Client {
 	var methods []server.Method
 	if impl != nil {
 		methods = []server.Method{{

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -66,7 +66,7 @@ is a common source of errors and/or inefficiencies.
 // A Conn is a connection to another Cap'n Proto vat.
 // It is safe to use from multiple goroutines.
 type Conn struct {
-	bootstrap    *capnp.Client
+	bootstrap    capnp.Client
 	er           errReporter
 	abortTimeout time.Duration
 
@@ -103,7 +103,7 @@ type Options struct {
 	// remote peer when receiving a Bootstrap message.  NewConn "steals"
 	// this reference: it will release the client when the connection is
 	// closed.
-	BootstrapClient *capnp.Client
+	BootstrapClient capnp.Client
 
 	// ErrorReporter will be called upon when errors occur while the Conn
 	// is receiving messages from the remote vat.
@@ -198,7 +198,7 @@ func (c *Conn) backgroundTask(f func() error) func() error {
 
 // Bootstrap returns the remote vat's bootstrap interface.  This creates
 // a new client that the caller is responsible for releasing.
-func (c *Conn) Bootstrap(ctx context.Context) (bc *capnp.Client) {
+func (c *Conn) Bootstrap(ctx context.Context) (bc capnp.Client) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -247,7 +247,7 @@ func (c *Conn) Bootstrap(ctx context.Context) (bc *capnp.Client) {
 }
 
 type bootstrapClient struct {
-	c      *capnp.Client
+	c      capnp.Client
 	cancel context.CancelFunc
 }
 
@@ -362,7 +362,7 @@ func (c *Conn) release() {
 
 func (c *Conn) releaseBootstrap() {
 	c.bootstrap.Release()
-	c.bootstrap = nil
+	c.bootstrap = capnp.Client{}
 }
 
 func (c *Conn) releaseExports(exports []*expent) {
@@ -765,12 +765,12 @@ func (c *Conn) handleCall(ctx context.Context, call rpccp.Call, releaseCall capn
 				return nil
 			}
 			iface := sub.Interface()
-			var tgt *capnp.Client
+			var tgt capnp.Client
 			switch {
 			case sub.IsValid() && !iface.IsValid():
 				tgt = capnp.ErrorClient(rpcerr.Failed(ErrNotACapability))
 			case !iface.IsValid() || int64(iface.Capability()) >= int64(len(tgtAns.resultCapTable)):
-				tgt = nil
+				tgt = capnp.Client{}
 			default:
 				tgt = tgtAns.resultCapTable[iface.Capability()]
 			}
@@ -1126,10 +1126,10 @@ func (c *Conn) handleFinish(ctx context.Context, id answerID, releaseResultCaps 
 // error indicates a protocol violation.
 //
 // The caller must be holding onto c.mu.
-func (c *Conn) recvCap(d rpccp.CapDescriptor) (*capnp.Client, error) {
+func (c *Conn) recvCap(d rpccp.CapDescriptor) (capnp.Client, error) {
 	switch w := d.Which(); w {
 	case rpccp.CapDescriptor_Which_none:
-		return nil, nil
+		return capnp.Client{}, nil
 	case rpccp.CapDescriptor_Which_senderHosted:
 		id := importID(d.SenderHosted())
 		return c.addImport(id), nil
@@ -1150,27 +1150,27 @@ func (c *Conn) recvCap(d rpccp.CapDescriptor) (*capnp.Client, error) {
 		id := exportID(d.ReceiverHosted())
 		ent := c.findExport(id)
 		if ent == nil {
-			return nil, rpcerr.Failedf("receive capability: invalid export %d", id)
+			return capnp.Client{}, rpcerr.Failedf("receive capability: invalid export %d", id)
 		}
 		return ent.client.AddRef(), nil
 	case rpccp.CapDescriptor_Which_receiverAnswer:
 		promisedAnswer, err := d.ReceiverAnswer()
 		if err != nil {
-			return nil, rpcerr.Failedf("receive capabiltiy: reading promised answer: %v", err)
+			return capnp.Client{}, rpcerr.Failedf("receive capabiltiy: reading promised answer: %v", err)
 		}
 		rawTransform, err := promisedAnswer.Transform()
 		if err != nil {
-			return nil, rpcerr.Failedf("receive capabiltiy: reading promised answer transform: %v", err)
+			return capnp.Client{}, rpcerr.Failedf("receive capabiltiy: reading promised answer transform: %v", err)
 		}
 		transform, err := parseTransform(rawTransform)
 		if err != nil {
-			return nil, rpcerr.Failedf("read target transform: %v", err)
+			return capnp.Client{}, rpcerr.Failedf("read target transform: %v", err)
 		}
 
 		id := answerID(promisedAnswer.QuestionId())
 		ans, ok := c.answers[id]
 		if !ok {
-			return nil, rpcerr.Failedf("receive capability: no such question id: %v", id)
+			return capnp.Client{}, rpcerr.Failedf("receive capability: no such question id: %v", id)
 		}
 
 		return c.recvCapReceiverAnswer(ans, transform), nil
@@ -1180,7 +1180,7 @@ func (c *Conn) recvCap(d rpccp.CapDescriptor) (*capnp.Client, error) {
 }
 
 // Helper for Conn.recvCap(); handles the receiverAnswer case.
-func (c *Conn) recvCapReceiverAnswer(ans *answer, transform []capnp.PipelineOp) *capnp.Client {
+func (c *Conn) recvCapReceiverAnswer(ans *answer, transform []capnp.PipelineOp) capnp.Client {
 	if ans.promise != nil {
 		// Still unresolved.
 		future := ans.promise.Answer().Future()
@@ -1211,7 +1211,7 @@ func (c *Conn) recvCapReceiverAnswer(ans *answer, transform []capnp.PipelineOp) 
 	// look it up in resultCapTable ourselves:
 	capId := int(iface.Capability())
 	if capId < 0 || capId >= len(ans.resultCapTable) {
-		return nil
+		return capnp.Client{}
 	}
 
 	return ans.resultCapTable[capId].AddRef()
@@ -1219,8 +1219,8 @@ func (c *Conn) recvCapReceiverAnswer(ans *answer, transform []capnp.PipelineOp) 
 
 // Returns whether the client should be treated as local, for the purpose of
 // embargos.
-func (c *Conn) isLocalClient(client *capnp.Client) bool {
-	if client == nil {
+func (c *Conn) isLocalClient(client capnp.Client) bool {
+	if (client == capnp.Client{}) {
 		return false
 	}
 
@@ -1276,7 +1276,7 @@ func (c *Conn) recvPayload(payload rpccp.Payload) (_ capnp.Ptr, locals uintSet, 
 		c.er.ReportError(fmt.Errorf("read payload: capability table: %w", err))
 		return p, nil, nil
 	}
-	mtab := make([]*capnp.Client, ptab.Len())
+	mtab := make([]capnp.Client, ptab.Len())
 	for i := 0; i < ptab.Len(); i++ {
 		var err error
 		mtab[i], err = c.recvCap(ptab.At(i))
@@ -1336,7 +1336,7 @@ func (c *Conn) handleDisembargo(ctx context.Context, d rpccp.Disembargo, release
 	case rpccp.Disembargo_context_Which_senderLoopback:
 		var (
 			imp    *importClient
-			client *capnp.Client
+			client capnp.Client
 		)
 
 		syncutil.With(&c.mu, func() {

--- a/segment_test.go
+++ b/segment_test.go
@@ -730,7 +730,7 @@ func TestSetInterfacePtr(t *testing.T) {
 		if err != nil {
 			t.Fatal("NewMessage:", err)
 		}
-		msg.AddCap(nil) // just to make the capability ID below non-zero
+		msg.AddCap(Client{}) // just to make the capability ID below non-zero
 		root, err := NewRootStruct(seg, ObjectSize{PointerCount: 2})
 		if err != nil {
 			t.Fatal("NewRootStruct:", err)

--- a/std/capnp/persistent/persistent.capnp.go
+++ b/std/capnp/persistent/persistent.capnp.go
@@ -12,7 +12,7 @@ import (
 
 const PersistentAnnotation = uint64(0xf622595091cafb67)
 
-type Persistent struct{ Client *capnp.Client }
+type Persistent struct{ Client capnp.Client }
 
 // Persistent_TypeID is the unique identifier for the type Persistent.
 const Persistent_TypeID = 0xc8cb212fcd9f5691


### PR DESCRIPTION
This changes the APIs so that everything operates on Client instead of
*Client. This will smooth over a couple things I've run into, mainly
around being able to implement interfaces where a method needs to
re-assign the receiver.

I'm open to debate as to whether this is a good change. Copying my message from matrix for posterity:

> @lthibault: How do you feel about changing the API to use Client instead of *Client everywhere (and probably hide the pointer indirection inside the struct)? I think this would make a lot of stuff esp. with generics cleaner.
>
> E.g. on my generics branch right now I have:
> 
> ```go
> package capnp
> 
> // The TypeParam interface must be satisified by a type to be used as a canpproto
> // type parameter. This is satisified by all capnproto pointer types. T should
> // be instantiated by the type itself; in type parameter lists you will typically
> // see parameter/constraints like T TypeParam[T].
> type TypeParam[T any] interface {
> 	// Convert the receiver to a Ptr, storing it in seg if it is not
> 	// already associated with some message (only true for Clients and
> 	// wrappers around them.
> 	EncodeAsPtr(seg *Segment) Ptr
>
>	// Decode the pointer as the type of the receiver. Generally,
>	// the reciever will be the zero value for the type.
>	DecodeFromPtr(p Ptr) T
> }
> ```
>
> ...but I'd like to drop the T parameter so it would just be:
>
> ```go
> type TypeParam interface {
>    EncodeAsPtr(*Segment) Ptr
>    DecodeFromPtr(Ptr)
> }
> ```
>
> ...but I can't do the latter because I would have to implement DecodeFromPtr on **Client, since it needs to modify the pointer. But you can't define methods on double-indirect pointers like that.
> Returning the T is kindof an awful hack so we can just define it on *Client instead.
> But if we hide the pointer indirection inside the struct, then we can define the method on *Client, and it can modify it in place.

Despite the size of the diff, I don't think this will be *horribly* disruptive to downstream code; for ocap-md I just needed to re-run the schema compiler and it just worked. Changes should be pretty mechanical in the cases where you are working with raw `Client`s.