### PR TITLE
Bugfix:  don't wrap nil error with fmt.Errorf.

### DIFF
--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -992,8 +992,10 @@ func (c *Conn) handleReturn(ctx context.Context, ret rpccp.Return, release capnp
 		// TODO(soon): make embargo resolve to error client.
 		for _, s := range pr.disembargoes {
 			c.sendMessage(ctx, s.buildDisembargo, func(err error) {
-				err = fmt.Errorf("incoming return: send disembargo: %w", err)
-				c.er.ReportError(err)
+				if err != nil {
+					err = fmt.Errorf("incoming return: send disembargo: %w", err)
+					c.er.ReportError(err)
+				}
 			})
 		}
 


### PR DESCRIPTION
This was suddenly causing a test to fail when working on #261.  When `err` is nil, `fmt.Errorf` produces a non-nil error, which is then reported to the `ErrorReporter`.