### PR TITLE
Return error from generator.defineInterface

### DIFF
--- a/capnpc-go/capnpc-go.go
+++ b/capnpc-go/capnpc-go.go
@@ -1094,6 +1094,7 @@ func (g *generator) defineInterface(n *node) error {
 	if err != nil {
 		return fmt.Errorf("interface client %s: %v", n, err)
 	}
+
 	err = g.r.Render(interfaceServerParams{
 		G:           g,
 		Node:        n,
@@ -1108,6 +1109,10 @@ func (g *generator) defineInterface(n *node) error {
 		G:    g,
 		Node: n,
 	})
+	if err != nil {
+		return fmt.Errorf("interface list %s: %v", n, err)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Errors encountered while rendering `interfaceListParams` are not reported.  Seems like this was missed in code-review.