### PR TITLE
Implement io.WriterTo for Message

### DIFF
--- a/message.go
+++ b/message.go
@@ -355,6 +355,23 @@ func alloc(s *Segment, sz Size) (*Segment, address, error) {
 	return s, addr, nil
 }
 
+func (m *Message) WriteTo(w io.Writer) (int64, error) {
+	wc := &writeCounter{Writer: w}
+	err := NewEncoder(wc).Encode(m)
+	return wc.N, err
+}
+
+type writeCounter struct {
+	N int64
+	io.Writer
+}
+
+func (wc *writeCounter) Write(b []byte) (n int, err error) {
+	n, err = wc.Writer.Write(b)
+	wc.N += int64(n)
+	return
+}
+
 // An Arena loads and allocates segments for a Message.
 type Arena interface {
 	// NumSegments returns the number of segments in the arena.

--- a/message_test.go
+++ b/message_test.go
@@ -10,6 +10,7 @@ import (
 	"testing/quick"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewMessage(t *testing.T) {
@@ -569,6 +570,30 @@ func TestUnmarshal(t *testing.T) {
 				t.Errorf("serializeTests[%d] - %s: Unmarshal Segment(%d) = % 02x; want % 02x", i, test.name, j, seg.Data(), test.segs[j])
 			}
 		}
+	}
+}
+
+func TestWriteTo(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	for _, test := range serializeTests {
+		if test.decodeFails {
+			continue
+		}
+
+		msg := &Message{Arena: test.arena()}
+		n, err := msg.WriteTo(&buf)
+		if test.encodeFails {
+			require.Error(t, err, test.name)
+			continue
+		}
+
+		require.NoError(t, err, test.name)
+		require.Equal(t, int64(len(test.out)), n, test.name)
+		require.Equal(t, test.out, buf.Bytes(), test.name)
+
+		buf.Reset()
 	}
 }
 


### PR DESCRIPTION
Partially addresses #259.  

@zenhack `ReadFrom` is a bit tricker to implement because `Decoder.Decode` returns a `*Message`, and there's no obvious place to hook into.  I'll leave that for a separate PR, but any insight would be most welcome.