### PR TITLE
Defend against nil-pointer panics in question.release

### DIFF
--- a/rpc/question.go
+++ b/rpc/question.go
@@ -49,6 +49,7 @@ func (c *Conn) newQuestion(method capnp.Method) *question {
 	q := &question{
 		c:             c,
 		id:            questionID(c.questionID.next()),
+		release:       func() {},
 		finishMsgSend: make(chan struct{}),
 	}
 	q.p = capnp.NewPromise(method, q) // TODO(someday): customize error message for bootstrap

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -947,7 +947,6 @@ func (c *Conn) handleReturn(ctx context.Context, ret rpccp.Return, release capnp
 	go func() {
 		switch {
 		case q.bootstrapPromise != nil && pr.err == nil:
-			q.release = func() {}
 			syncutil.Without(&c.mu, func() {
 				q.p.Fulfill(pr.result)
 				q.bootstrapPromise.Fulfill(q.p.Answer().Client())
@@ -958,7 +957,6 @@ func (c *Conn) handleReturn(ctx context.Context, ret rpccp.Return, release capnp
 		case q.bootstrapPromise != nil && pr.err != nil:
 			// TODO(someday): send unimplemented message back to remote if
 			// pr.unimplemented == true.
-			q.release = func() {}
 			syncutil.Without(&c.mu, func() {
 				q.p.Reject(pr.err)
 				q.bootstrapPromise.Fulfill(q.p.Answer().Client())
@@ -968,7 +966,6 @@ func (c *Conn) handleReturn(ctx context.Context, ret rpccp.Return, release capnp
 		case q.bootstrapPromise == nil && pr.err != nil:
 			// TODO(someday): send unimplemented message back to remote if
 			// pr.unimplemented == true.
-			q.release = func() {}
 			syncutil.Without(&c.mu, func() {
 				q.p.Reject(pr.err)
 				release()


### PR DESCRIPTION
I was going to call this "Fix nil pointer panic due to nil question.release", but I'm not unsure whether this is what actually solved the problem I was experiencing in my application.  However, my application _was_ panicking due to a nil `question.release` function, so the proposed changes might still be reasonable defensive-programming measures.

I grepped for `.release == nil`, and there doesn't seem to be any code that depends on the nullability of this field, so I _think_ this should be correct.  A cross-check would be most welcome.