### PR TITLE
Embed capnp.Client in generated interface types.

### DIFF
--- a/capnpc-go/templates/interfaceClient
+++ b/capnpc-go/templates/interfaceClient
@@ -1,7 +1,7 @@
 {{with .Annotations.Doc -}}
 // {{.}}
 {{end -}}
-type {{.Node.Name}} struct { Client {{.G.Capnp}}.Client }
+type {{.Node.Name}} struct { {{.G.Capnp}}.Client }
 
 {{ template "_typeid" .Node }}
 
@@ -25,8 +25,4 @@ func (c {{$.Node.Name}}) AddRef() {{$.Node.Name}} {
 	return {{$.Node.Name}} {
 		Client: c.Client.AddRef(),
 	}
-}
-
-func (c {{$.Node.Name}}) Release() {
-	c.Client.Release()
 }

--- a/internal/aircraftlib/aircraft.capnp.go
+++ b/internal/aircraftlib/aircraft.capnp.go
@@ -4318,7 +4318,7 @@ func (p ListStructCapn_Future) Struct() (ListStructCapn, error) {
 	return ListStructCapn{s}, err
 }
 
-type Echo struct{ Client capnp.Client }
+type Echo struct{ capnp.Client }
 
 // Echo_TypeID is the unique identifier for the type Echo.
 const Echo_TypeID = 0x8e5322c1e9282534
@@ -4344,10 +4344,6 @@ func (c Echo) AddRef() Echo {
 	return Echo{
 		Client: c.Client.AddRef(),
 	}
-}
-
-func (c Echo) Release() {
-	c.Client.Release()
 }
 
 // A Echo_Server is a Echo with a local implementation.
@@ -4899,7 +4895,7 @@ func (p StackingB_Future) Struct() (StackingB, error) {
 	return StackingB{s}, err
 }
 
-type CallSequence struct{ Client capnp.Client }
+type CallSequence struct{ capnp.Client }
 
 // CallSequence_TypeID is the unique identifier for the type CallSequence.
 const CallSequence_TypeID = 0xabaedf5f7817c820
@@ -4925,10 +4921,6 @@ func (c CallSequence) AddRef() CallSequence {
 	return CallSequence{
 		Client: c.Client.AddRef(),
 	}
-}
-
-func (c CallSequence) Release() {
-	c.Client.Release()
 }
 
 // A CallSequence_Server is a CallSequence with a local implementation.
@@ -5088,7 +5080,7 @@ func (p CallSequence_getNumber_Results_Future) Struct() (CallSequence_getNumber_
 	return CallSequence_getNumber_Results{s}, err
 }
 
-type Pipeliner struct{ Client capnp.Client }
+type Pipeliner struct{ capnp.Client }
 
 // Pipeliner_TypeID is the unique identifier for the type Pipeliner.
 const Pipeliner_TypeID = 0xd6514008f0f84ebc
@@ -5130,10 +5122,6 @@ func (c Pipeliner) AddRef() Pipeliner {
 	return Pipeliner{
 		Client: c.Client.AddRef(),
 	}
-}
-
-func (c Pipeliner) Release() {
-	c.Client.Release()
 }
 
 // A Pipeliner_Server is a Pipeliner with a local implementation.

--- a/list.go
+++ b/list.go
@@ -1037,7 +1037,7 @@ func (s StructList[T]) String() string {
 	return buf.String()
 }
 
-type CapList[T ~struct{ Client Client }] PointerList
+type CapList[T ~struct{ Client }] PointerList
 
 func (c CapList[T]) At(i int) (T, error) {
 	ptr, err := PointerList(c).At(i)
@@ -1050,7 +1050,7 @@ func (c CapList[T]) At(i int) (T, error) {
 func (c CapList[T]) Set(i int, v T) error {
 	pl := PointerList(c)
 	seg := pl.List.Segment()
-	capId := seg.Message().AddCap(struct{ Client Client }(v).Client)
+	capId := seg.Message().AddCap(struct{ Client }(v).Client)
 	return pl.Set(i, NewInterface(seg, capId).ToPtr())
 }
 

--- a/rpc/internal/testcapnp/test.capnp.go
+++ b/rpc/internal/testcapnp/test.capnp.go
@@ -11,7 +11,7 @@ import (
 	context "context"
 )
 
-type PingPong struct{ Client capnp.Client }
+type PingPong struct{ capnp.Client }
 
 // PingPong_TypeID is the unique identifier for the type PingPong.
 const PingPong_TypeID = 0xf004c474c2f8ee7a
@@ -37,10 +37,6 @@ func (c PingPong) AddRef() PingPong {
 	return PingPong{
 		Client: c.Client.AddRef(),
 	}
-}
-
-func (c PingPong) Release() {
-	c.Client.Release()
 }
 
 // A PingPong_Server is a PingPong with a local implementation.
@@ -208,7 +204,7 @@ func (p PingPong_echoNum_Results_Future) Struct() (PingPong_echoNum_Results, err
 	return PingPong_echoNum_Results{s}, err
 }
 
-type StreamTest struct{ Client capnp.Client }
+type StreamTest struct{ capnp.Client }
 
 // StreamTest_TypeID is the unique identifier for the type StreamTest.
 const StreamTest_TypeID = 0xbb3ca85b01eea465
@@ -234,10 +230,6 @@ func (c StreamTest) AddRef() StreamTest {
 	return StreamTest{
 		Client: c.Client.AddRef(),
 	}
-}
-
-func (c StreamTest) Release() {
-	c.Client.Release()
 }
 
 // A StreamTest_Server is a StreamTest with a local implementation.
@@ -360,7 +352,7 @@ func (p StreamTest_push_Params_Future) Struct() (StreamTest_push_Params, error) 
 	return StreamTest_push_Params{s}, err
 }
 
-type CapArgsTest struct{ Client capnp.Client }
+type CapArgsTest struct{ capnp.Client }
 
 // CapArgsTest_TypeID is the unique identifier for the type CapArgsTest.
 const CapArgsTest_TypeID = 0xb86bce7f916a10cc
@@ -402,10 +394,6 @@ func (c CapArgsTest) AddRef() CapArgsTest {
 	return CapArgsTest{
 		Client: c.Client.AddRef(),
 	}
-}
-
-func (c CapArgsTest) Release() {
-	c.Client.Release()
 }
 
 // A CapArgsTest_Server is a CapArgsTest with a local implementation.

--- a/std/capnp/persistent/persistent.capnp.go
+++ b/std/capnp/persistent/persistent.capnp.go
@@ -12,7 +12,7 @@ import (
 
 const PersistentAnnotation = uint64(0xf622595091cafb67)
 
-type Persistent struct{ Client capnp.Client }
+type Persistent struct{ capnp.Client }
 
 // Persistent_TypeID is the unique identifier for the type Persistent.
 const Persistent_TypeID = 0xc8cb212fcd9f5691
@@ -38,10 +38,6 @@ func (c Persistent) AddRef() Persistent {
 	return Persistent{
 		Client: c.Client.AddRef(),
 	}
-}
-
-func (c Persistent) Release() {
-	c.Client.Release()
 }
 
 // A Persistent_Server is a Persistent with a local implementation.


### PR DESCRIPTION
Like we do with struct types. Fixes #275