### PR TITLE
Remove pointless indirection in templates.

### DIFF
--- a/capnpc-go/capnpc-go.go
+++ b/capnpc-go/capnpc-go.go
@@ -108,10 +108,6 @@ func (g *generator) Imports() *imports {
 	return &g.imports
 }
 
-func (g *generator) Capnp() string {
-	return g.imports.Capnp()
-}
-
 // generate produces unformatted Go source code from the nodes defined in it.
 func (g *generator) generate() []byte {
 	var out bytes.Buffer

--- a/capnpc-go/templates/baseStructFuncs
+++ b/capnpc-go/templates/baseStructFuncs
@@ -1,16 +1,16 @@
 {{ template "_typeid" .Node }}
 
-func New{{.Node.Name}}(s *{{.G.Capnp}}.Segment) ({{.Node.Name}}, error) {
-	st, err := {{$.G.Capnp}}.NewStruct(s, {{.G.ObjectSize .Node}})
+func New{{.Node.Name}}(s *capnp.Segment) ({{.Node.Name}}, error) {
+	st, err := capnp.NewStruct(s, {{.G.ObjectSize .Node}})
 	return {{.Node.Name}}{st}, err
 }
 
-func NewRoot{{.Node.Name}}(s *{{.G.Capnp}}.Segment) ({{.Node.Name}}, error) {
-	st, err := {{.G.Capnp}}.NewRootStruct(s, {{.G.ObjectSize .Node}})
+func NewRoot{{.Node.Name}}(s *capnp.Segment) ({{.Node.Name}}, error) {
+	st, err := capnp.NewRootStruct(s, {{.G.ObjectSize .Node}})
 	return {{.Node.Name}}{st}, err
 }
 
-func ReadRoot{{.Node.Name}}(msg *{{.G.Capnp}}.Message) ({{.Node.Name}}, error) {
+func ReadRoot{{.Node.Name}}(msg *capnp.Message) ({{.Node.Name}}, error) {
 	root, err := msg.Root()
 	return {{.Node.Name}}{root.Struct()}, err
 }
@@ -21,6 +21,6 @@ func (s {{.Node.Name}}) String() string {
 }
 {{end}}
 
-func ({{.Node.Name}}) DecodeFromPtr(p {{.G.Capnp}}.Ptr) {{.Node.Name}} {
-	return {{.Node.Name}}{ Struct: {{.G.Capnp}}.Struct{}.DecodeFromPtr(p) }
+func ({{.Node.Name}}) DecodeFromPtr(p capnp.Ptr) {{.Node.Name}} {
+	return {{.Node.Name}}{ Struct: capnp.Struct{}.DecodeFromPtr(p) }
 }

--- a/capnpc-go/templates/enum
+++ b/capnpc-go/templates/enum
@@ -37,8 +37,8 @@ func {{$.Node.Name}}FromString(c string) {{$.Node.Name}} {
 }
 {{end}}
 
-type {{.Node.Name}}_List = {{$.G.Capnp}}.EnumList[{{.Node.Name}}]
+type {{.Node.Name}}_List = capnp.EnumList[{{.Node.Name}}]
 
-func New{{.Node.Name}}_List(s *{{$.G.Capnp}}.Segment, sz int32) ({{.Node.Name}}_List, error) {
-	return {{.G.Capnp}}.NewEnumList[{{.Node.Name}}](s, sz)
+func New{{.Node.Name}}_List(s *capnp.Segment, sz int32) ({{.Node.Name}}_List, error) {
+	return capnp.NewEnumList[{{.Node.Name}}](s, sz)
 }

--- a/capnpc-go/templates/interfaceClient
+++ b/capnpc-go/templates/interfaceClient
@@ -1,20 +1,20 @@
 {{with .Annotations.Doc -}}
 // {{.}}
 {{end -}}
-type {{.Node.Name}} struct { {{.G.Capnp}}.Client }
+type {{.Node.Name}} struct { capnp.Client }
 
 {{ template "_typeid" .Node }}
 
 {{range .Methods -}}
-func (c {{$.Node.Name}}) {{.Name|title}}(ctx {{$.G.Imports.Context}}.Context, params func({{$.G.RemoteNodeName .Params $.Node}}) error) ({{$.G.RemoteNodeName .Results $.Node}}_Future, {{$.G.Capnp}}.ReleaseFunc) {
-	s := {{$.G.Capnp}}.Send{
-		Method: {{$.G.Capnp}}.Method{
+func (c {{$.Node.Name}}) {{.Name|title}}(ctx {{$.G.Imports.Context}}.Context, params func({{$.G.RemoteNodeName .Params $.Node}}) error) ({{$.G.RemoteNodeName .Results $.Node}}_Future, capnp.ReleaseFunc) {
+	s := capnp.Send{
+		Method: capnp.Method{
 			{{template "_interfaceMethod" .}}
 		},
 	}
 	if params != nil {
 		s.ArgsSize = {{$.G.ObjectSize .Params}}
-		s.PlaceArgs = func(s {{$.G.Capnp}}.Struct) error { return params({{$.G.RemoteNodeName .Params $.Node}}{Struct: s}) }
+		s.PlaceArgs = func(s capnp.Struct) error { return params({{$.G.RemoteNodeName .Params $.Node}}{Struct: s}) }
 	}
 	ans, release := c.Client.SendCall(ctx, s)
 	return {{$.G.RemoteNodeName .Results $.Node}}_Future{Future: ans.Future()}, release
@@ -27,6 +27,6 @@ func (c {{$.Node.Name}}) AddRef() {{$.Node.Name}} {
 	}
 }
 
-func ({{$.Node.Name}}) DecodeFromPtr(p {{.G.Capnp}}.Ptr) {{$.Node.Name}} {
-	return {{$.Node.Name}}{ Client: {{.G.Capnp}}.Client{}.DecodeFromPtr(p) }
+func ({{$.Node.Name}}) DecodeFromPtr(p capnp.Ptr) {{$.Node.Name}} {
+	return {{$.Node.Name}}{ Client: capnp.Client{}.DecodeFromPtr(p) }
 }

--- a/capnpc-go/templates/interfaceList
+++ b/capnpc-go/templates/interfaceList
@@ -1,9 +1,9 @@
 
 // {{.Node.Name}}_List is a list of {{.Node.Name}}.
-type {{.Node.Name}}_List = {{.G.Capnp}}.CapList[{{.Node.Name}}]
+type {{.Node.Name}}_List = capnp.CapList[{{.Node.Name}}]
 
 // New{{.Node.Name}} creates a new list of {{.Node.Name}}.
-func New{{.Node.Name}}_List(s *{{.G.Capnp}}.Segment, sz int32) ({{.Node.Name}}_List, error) {
-	l, err := {{.G.Capnp}}.NewPointerList(s, sz)
-	return {{.G.Capnp}}.CapList[{{.Node.Name}}](l), err
+func New{{.Node.Name}}_List(s *capnp.Segment, sz int32) ({{.Node.Name}}_List, error) {
+	l, err := capnp.NewPointerList(s, sz)
+	return capnp.CapList[{{.Node.Name}}](l), err
 }

--- a/capnpc-go/templates/interfaceServer
+++ b/capnpc-go/templates/interfaceServer
@@ -14,7 +14,7 @@ func {{.Node.Name}}_NewServer(s {{.Node.Name}}_Server) *{{.G.Imports.Server}}.Se
 // {{.Node.Name}}_ServerToClient creates a new Client from an implementation of {{.Node.Name}}_Server.
 // The caller is responsible for calling Release on the returned Client.
 func {{.Node.Name}}_ServerToClient(s {{.Node.Name}}_Server) {{.Node.Name}} {
-	return {{.Node.Name}}{Client: {{.G.Capnp}}.NewClient({{.Node.Name}}_NewServer(s))}
+	return {{.Node.Name}}{Client: capnp.NewClient({{.Node.Name}}_NewServer(s))}
 }
 
 // {{.Node.Name}}_Methods appends Methods to a slice that invoke the methods on s.
@@ -25,7 +25,7 @@ func {{.Node.Name}}_Methods(methods []{{.G.Imports.Server}}.Method, s {{.Node.Na
 	}
 	{{range .Methods}}
 	methods = append(methods, {{$.G.Imports.Server}}.Method{
-		Method: {{$.G.Capnp}}.Method{
+		Method: capnp.Method{
 			{{template "_interfaceMethod" .}}
 		},
 		Impl: func(ctx {{$.G.Imports.Context}}.Context, call *{{$.G.Imports.Server}}.Call) error {

--- a/capnpc-go/templates/listValue
+++ b/capnpc-go/templates/listValue
@@ -1,2 +1,2 @@
-{{.Typ}}{List: {{.G.Capnp}}.MustUnmarshalRoot({{.Value}}).List()}
+{{.Typ}}{List: capnp.MustUnmarshalRoot({{.Value}}).List()}
 {{- /* no EOL */ -}}

--- a/capnpc-go/templates/pointerValue
+++ b/capnpc-go/templates/pointerValue
@@ -1,2 +1,2 @@
-{{.G.Capnp}}.MustUnmarshalRoot({{.Value}})
+capnp.MustUnmarshalRoot({{.Value}})
 {{- /* no EOL */ -}}

--- a/capnpc-go/templates/promise
+++ b/capnpc-go/templates/promise
@@ -1,5 +1,5 @@
 // {{.Node.Name}}_Future is a wrapper for a {{.Node.Name}} promised by a client call.
-type {{.Node.Name}}_Future struct { *{{.G.Capnp}}.Future }
+type {{.Node.Name}}_Future struct { *capnp.Future }
 
 func (p {{.Node.Name}}_Future) Struct() ({{.Node.Name}}, error) {
 	s, err := p.Future.Struct()

--- a/capnpc-go/templates/promiseFieldAnyPointer
+++ b/capnpc-go/templates/promiseFieldAnyPointer
@@ -1,4 +1,4 @@
-func (p {{.Node.Name}}_Future) {{.Field.Name|title}}() *{{.G.Capnp}}.Future {
+func (p {{.Node.Name}}_Future) {{.Field.Name|title}}() *capnp.Future {
 	return p.Future.Field({{.Field.Slot.Offset}}, nil)
 }
 

--- a/capnpc-go/templates/structCapabilityField
+++ b/capnpc-go/templates/structCapabilityField
@@ -12,6 +12,6 @@ func (s {{.Node.Name}}) Set{{.Field.Name|title}}(c {{.FieldType}}) error {
 		return s.Struct.SetPtr({{.Field.Slot.Offset}}, capnp.Ptr{})
 	}
 	seg := s.Segment()
-	in := {{.G.Capnp}}.NewInterface(seg, seg.Message().AddCap(c))
+	in := capnp.NewInterface(seg, seg.Message().AddCap(c))
 	return s.Struct.SetPtr({{.Field.Slot.Offset}}, in.ToPtr())
 }

--- a/capnpc-go/templates/structInterfaceField
+++ b/capnpc-go/templates/structInterfaceField
@@ -12,7 +12,7 @@ func (s {{.Node.Name}}) Set{{.Field.Name|title}}(v {{.FieldType}}) error {
 		return s.Struct.SetPtr({{.Field.Slot.Offset}}, capnp.Ptr{})
 	}
 	seg := s.Segment()
-	in := {{.G.Capnp}}.NewInterface(seg, seg.Message().AddCap(v.Client))
+	in := capnp.NewInterface(seg, seg.Message().AddCap(v.Client))
 	return s.Struct.SetPtr({{.Field.Slot.Offset}}, in.ToPtr())
 }
 

--- a/capnpc-go/templates/structList
+++ b/capnpc-go/templates/structList
@@ -1,8 +1,8 @@
 // {{.Node.Name}}_List is a list of {{.Node.Name}}.
-type {{.Node.Name}}_List = {{.G.Capnp}}.StructList[{{.Node.Name}}]
+type {{.Node.Name}}_List = capnp.StructList[{{.Node.Name}}]
 
 // New{{.Node.Name}} creates a new list of {{.Node.Name}}.
-func New{{.Node.Name}}_List(s *{{.G.Capnp}}.Segment, sz int32) ({{.Node.Name}}_List, error) {
-	l, err := {{.G.Capnp}}.NewCompositeList(s, {{.G.ObjectSize .Node}}, sz)
-	return {{.G.Capnp}}.StructList[{{.Node.Name}}]{List: l}, err
+func New{{.Node.Name}}_List(s *capnp.Segment, sz int32) ({{.Node.Name}}_List, error) {
+	l, err := capnp.NewCompositeList(s, {{.G.ObjectSize .Node}}, sz)
+	return capnp.StructList[{{.Node.Name}}]{List: l}, err
 }

--- a/capnpc-go/templates/structPointerField
+++ b/capnpc-go/templates/structPointerField
@@ -1,4 +1,4 @@
-func (s {{.Node.Name}}) {{.Field.Name|title}}() ({{.G.Capnp}}.Ptr, error) {
+func (s {{.Node.Name}}) {{.Field.Name|title}}() (capnp.Ptr, error) {
 	{{template "_checktag" . -}}
 	{{if .Default.IsValid -}}
 	p, err := s.Struct.Ptr({{.Field.Slot.Offset}})
@@ -13,7 +13,7 @@ func (s {{.Node.Name}}) {{.Field.Name|title}}() ({{.G.Capnp}}.Ptr, error) {
 
 {{template "_hasfield" .}}
 
-func (s {{.Node.Name}}) Set{{.Field.Name|title}}(v {{.G.Capnp}}.Ptr) error {
+func (s {{.Node.Name}}) Set{{.Field.Name|title}}(v capnp.Ptr) error {
 	{{template "_settag" . -}}
 	return s.Struct.SetPtr({{.Field.Slot.Offset}}, v)
 }

--- a/capnpc-go/templates/structTypes
+++ b/capnpc-go/templates/structTypes
@@ -2,7 +2,7 @@
 // {{.}}
 {{end -}}
 type {{.Node.Name}} {{if .IsBase -}}
-struct{ {{.G.Capnp}}.Struct }
+struct{ capnp.Struct }
 {{- else -}}
 {{.BaseNode.Name}}
 {{- end}}

--- a/capnpc-go/templates/structValue
+++ b/capnpc-go/templates/structValue
@@ -1,2 +1,2 @@
-{{.G.RemoteNodeName .Typ .Node}}{Struct: {{.G.Capnp}}.MustUnmarshalRoot({{.Value}}).Struct()}
+{{.G.RemoteNodeName .Typ .Node}}{Struct: capnp.MustUnmarshalRoot({{.Value}}).Struct()}
 {{- /* no EOL */ -}}


### PR DESCRIPTION
This is always `capnp`, and there's no real reason to believe that will
ever change. It makes the templates harder to read with no upside.