### PR TITLE
Remove a couple uses of the *_List type aliases.

### DIFF
--- a/capnpc-go/nodes.go
+++ b/capnpc-go/nodes.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"capnproto.org/go/capnp/v3"
 	"capnproto.org/go/capnp/v3/internal/schema"
 )
 
@@ -156,7 +157,7 @@ type annotations struct {
 	Name      string
 }
 
-func parseAnnotations(list schema.Annotation_List) *annotations {
+func parseAnnotations(list capnp.StructList[schema.Annotation]) *annotations {
 	ann := new(annotations)
 	for i, n := 0, list.Len(); i < n; i++ {
 		a := list.At(i)

--- a/integration_test.go
+++ b/integration_test.go
@@ -1040,7 +1040,7 @@ func TestReadNestedListOfStructWithList(t *testing.T) {
 			t.Errorf("RWTestCapn.nestMatrix[%d]: %v", i, err)
 			return
 		}
-		rowList := air.Nester1Capn_List{List: row.List()}
+		rowList := capnp.StructList[air.Nester1Capn]{List: row.List()}
 		if j >= rowList.Len() {
 			t.Errorf("len(RWTestCapn.nestMatrix[%d]) = %d; tried to index %d", i, rowList.Len(), j)
 			return


### PR DESCRIPTION
This is in preparation for removing the aliases entirely. Most
importantly, this patch removes the one use inside the code generator
itself.

We can't actually delete the aliases until the code generator no longer
uses them at call sites, but this is the first step.