### PR TITLE
Clean up formatting, inefassign and misspellings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Cap'n Proto bindings for Go
 
 ![License](https://img.shields.io/badge/license-MIT-brightgreen?style=flat-square)
-![CodeQuality](https://goreportcard.com/badge/capnproto.org/go/capnp)
+[![CodeQuality](https://goreportcard.com/badge/capnproto.org/go/capnp)](https://goreportcard.com/report/capnproto.org/go/capnp/v3)
 [![Go](https://github.com/capnproto/go-capnproto2/actions/workflows/go.yml/badge.svg)](https://github.com/capnproto/go-capnproto2/actions/workflows/go.yml)
 [![GoDoc](https://godoc.org/capnproto.org/go/capnp/v3?status.svg)][godoc]
 [![Matrix](https://img.shields.io/matrix/go-capnp:matrix.org?color=lightpink&label=Get%20Help&logo=matrix&style=flat-square)](https://matrix.to/#/#go-capnp:matrix.org)

--- a/internal/mpsc/mpsc_test.go
+++ b/internal/mpsc/mpsc_test.go
@@ -66,7 +66,7 @@ func TestSendManySequential(t *testing.T) {
 	assert.Equal(t, inputs, outputs, "Received sequence was different from sent.")
 
 	v, ok := q.TryRecv()
-	assert.False(t, ok, "Recieved more values than expected: ", v)
+	assert.False(t, ok, "Received more values than expected: ", v)
 }
 
 func TestSendManyConcurrent(t *testing.T) {
@@ -111,5 +111,5 @@ func TestSendManyConcurrent(t *testing.T) {
 	assert.Equal(t, expected, actual, "Different values came out of the queue than went in.")
 
 	v, ok := q.TryRecv()
-	assert.False(t, ok, "Recieved more values than expected: ", v)
+	assert.False(t, ok, "Received more values than expected: ", v)
 }

--- a/message.go
+++ b/message.go
@@ -110,7 +110,7 @@ func NewSingleSegmentMessage(b []byte) (msg *Message, first *Segment) {
 	return msg, first
 }
 
-// Analagous to NewSingleSegmentMessage, but using MutliSegment.
+// Analogous to NewSingleSegmentMessage, but using MutliSegment.
 func NewMultiSegmentMessage(b [][]byte) (msg *Message, first *Segment) {
 	msg, first, err := NewMessage(MultiSegment(b))
 	if err != nil {

--- a/pointer_test.go
+++ b/pointer_test.go
@@ -75,8 +75,8 @@ func TestEqual(t *testing.T) {
 		0: ec,
 		1: ec,
 		2: ErrorClient(errors.New("another boo")),
-		3: Client{},
-		4: Client{},
+		3: {},
+		4: {},
 	}
 	iface1 := NewInterface(seg, 0)
 	iface2 := NewInterface(seg, 1)

--- a/rpc/export.go
+++ b/rpc/export.go
@@ -188,7 +188,7 @@ func (c *Conn) fillPayloadCapTable(payload rpccp.Payload, clients []capnp.Client
 	for i, client := range clients {
 		id, isExport, err := c.sendCap(list.At(i), client)
 		if err != nil {
-			return nil, rpcerr.Failedf("Serializing capabiltiy: %w", err)
+			return nil, rpcerr.Failedf("Serializing capability: %w", err)
 		}
 		if !isExport {
 			continue

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -1205,7 +1205,7 @@ func (c *Conn) recvCapReceiverAnswer(ans *answer, transform []capnp.PipelineOp) 
 		return capnp.ErrorClient(rpcerr.Failedf("Result is not a capability"))
 	}
 
-	// We can't just call Client(), becasue the CapTable has been cleared; instead,
+	// We can't just call Client(), because the CapTable has been cleared; instead,
 	// look it up in resultCapTable ourselves:
 	capId := int(iface.Capability())
 	if capId < 0 || capId >= len(ans.resultCapTable) {

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -1154,11 +1154,11 @@ func (c *Conn) recvCap(d rpccp.CapDescriptor) (capnp.Client, error) {
 	case rpccp.CapDescriptor_Which_receiverAnswer:
 		promisedAnswer, err := d.ReceiverAnswer()
 		if err != nil {
-			return capnp.Client{}, rpcerr.Failedf("receive capabiltiy: reading promised answer: %v", err)
+			return capnp.Client{}, rpcerr.Failedf("receive capability: reading promised answer: %v", err)
 		}
 		rawTransform, err := promisedAnswer.Transform()
 		if err != nil {
-			return capnp.Client{}, rpcerr.Failedf("receive capabiltiy: reading promised answer transform: %v", err)
+			return capnp.Client{}, rpcerr.Failedf("receive capability: reading promised answer transform: %v", err)
 		}
 		transform, err := parseTransform(rawTransform)
 		if err != nil {

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -1364,8 +1364,8 @@ func (c *Conn) handleDisembargo(ctx context.Context, d rpccp.Disembargo, release
 				return
 			}
 
-			ptr, err := capnp.Transform(content, tgt.transform)
-			if err != nil {
+			var ptr capnp.Ptr
+			if ptr, err = capnp.Transform(content, tgt.transform); err != nil {
 				err = rpcerr.Failedf("incoming disembargo: read answer ID %d: %v", tgt.promisedAnswer, err)
 				return
 			}

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -1216,7 +1216,7 @@ func (c *Conn) recvCapReceiverAnswer(ans *answer, transform []capnp.PipelineOp) 
 }
 
 // Returns whether the client should be treated as local, for the purpose of
-// embargos.
+// embargoes.
 func (c *Conn) isLocalClient(client capnp.Client) bool {
 	if (client == capnp.Client{}) {
 		return false

--- a/std/capnp/rpc.capnp
+++ b/std/capnp/rpc.capnp
@@ -645,7 +645,7 @@ struct Disembargo {
   #
   # Message sent to indicate that an embargo on a recently-resolved promise may now be lifted.
   #
-  # Embargoes are used to enforce E-order in the presence of promise resolution.  That is, if an
+  # Embargos are used to enforce E-order in the presence of promise resolution.  That is, if an
   # application makes two calls foo() and bar() on the same capability reference, in that order,
   # the calls should be delivered in the order in which they were made.  But if foo() is called
   # on a promise, and that promise happens to resolve before bar() is called, then the two calls
@@ -654,7 +654,7 @@ struct Disembargo {
   # the same path as `foo()` to ensure that the `Disembargo` arrives after `foo()`.  Once the
   # `Disembargo` arrives, `bar()` can then be delivered.
   #
-  # There are two particular cases where embargoes are important.  Consider object Alice, in Vat A,
+  # There are two particular cases where embargos are important.  Consider object Alice, in Vat A,
   # who holds a promise P, pointing towards Vat B, that eventually resolves to Carol.  The two
   # cases are:
   # - Carol lives in Vat A, i.e. next to Alice.  In this case, Vat A needs to send a `Disembargo`
@@ -672,7 +672,7 @@ struct Disembargo {
   # same path as the later direct calls.
   #
   # Keep in mind that promise resolution happens both in the form of Resolve messages as well as
-  # Return messages (which resolve PromisedAnswers). Embargoes apply in both cases.
+  # Return messages (which resolve PromisedAnswers). Embargos apply in both cases.
   #
   # An alternative strategy for enforcing E-order over promise resolution could be for Vat A to
   # implement the embargo internally.  When Vat A is notified of promise resolution, it could
@@ -689,7 +689,7 @@ struct Disembargo {
   # "Tribble 4-way race condition", after Dean Tribble, who explained the problem in a lively
   # Friam meeting.
   #
-  # Embargoes are designed to work in the case where a two-hop path is being shortened to one hop.
+  # Embargos are designed to work in the case where a two-hop path is being shortened to one hop.
   # But sometimes there are more hops. Imagine that Alice has a reference to a remote promise P1
   # that eventually resolves to _another_ remote promise P2 (in a third vat), which _at the same
   # time_ happens to resolve to Bob (in a fourth vat). In this case, we're shortening from a 3-hop

--- a/std/capnp/rpc.capnp
+++ b/std/capnp/rpc.capnp
@@ -645,7 +645,7 @@ struct Disembargo {
   #
   # Message sent to indicate that an embargo on a recently-resolved promise may now be lifted.
   #
-  # Embargos are used to enforce E-order in the presence of promise resolution.  That is, if an
+  # Embargoes are used to enforce E-order in the presence of promise resolution.  That is, if an
   # application makes two calls foo() and bar() on the same capability reference, in that order,
   # the calls should be delivered in the order in which they were made.  But if foo() is called
   # on a promise, and that promise happens to resolve before bar() is called, then the two calls
@@ -654,7 +654,7 @@ struct Disembargo {
   # the same path as `foo()` to ensure that the `Disembargo` arrives after `foo()`.  Once the
   # `Disembargo` arrives, `bar()` can then be delivered.
   #
-  # There are two particular cases where embargos are important.  Consider object Alice, in Vat A,
+  # There are two particular cases where embargoes are important.  Consider object Alice, in Vat A,
   # who holds a promise P, pointing towards Vat B, that eventually resolves to Carol.  The two
   # cases are:
   # - Carol lives in Vat A, i.e. next to Alice.  In this case, Vat A needs to send a `Disembargo`
@@ -672,7 +672,7 @@ struct Disembargo {
   # same path as the later direct calls.
   #
   # Keep in mind that promise resolution happens both in the form of Resolve messages as well as
-  # Return messages (which resolve PromisedAnswers). Embargos apply in both cases.
+  # Return messages (which resolve PromisedAnswers). Embargoes apply in both cases.
   #
   # An alternative strategy for enforcing E-order over promise resolution could be for Vat A to
   # implement the embargo internally.  When Vat A is notified of promise resolution, it could
@@ -689,7 +689,7 @@ struct Disembargo {
   # "Tribble 4-way race condition", after Dean Tribble, who explained the problem in a lively
   # Friam meeting.
   #
-  # Embargos are designed to work in the case where a two-hop path is being shortened to one hop.
+  # Embargoes are designed to work in the case where a two-hop path is being shortened to one hop.
   # But sometimes there are more hops. Imagine that Alice has a reference to a remote promise P1
   # that eventually resolves to _another_ remote promise P2 (in a third vat), which _at the same
   # time_ happens to resolve to Bob (in a fourth vat). In this case, we're shortening from a 3-hop


### PR DESCRIPTION
Fixes https://github.com/capnproto/go-capnproto2/issues/280