### PR TITLE
Add client methods to interfaceClient template

### DIFF
--- a/capnpc-go/capnpc-go.go
+++ b/capnpc-go/capnpc-go.go
@@ -30,10 +30,11 @@ import (
 
 // Non-stdlib import paths.
 const (
-	capnpImport   = "capnproto.org/go/capnp/v3"
-	textImport    = capnpImport + "/encoding/text"
-	schemasImport = capnpImport + "/schemas"
-	serverImport  = capnpImport + "/server"
+	capnpImport       = "capnproto.org/go/capnp/v3"
+	textImport        = capnpImport + "/encoding/text"
+	schemasImport     = capnpImport + "/schemas"
+	serverImport      = capnpImport + "/server"
+	flowcontrolImport = capnpImport + "/flowcontrol"
 )
 
 // genoptions are parameters that control code generation.

--- a/capnpc-go/fileparts.go
+++ b/capnpc-go/fileparts.go
@@ -69,6 +69,7 @@ func (i *imports) init() {
 	i.reserve(importSpec{path: textImport, name: "text"})
 	i.reserve(importSpec{path: flowcontrolImport, name: "fc"})
 
+	i.reserve(importSpec{path: "fmt", name: "fmt"})
 	i.reserve(importSpec{path: "context", name: "context"})
 	i.reserve(importSpec{path: "math", name: "math"})
 	i.reserve(importSpec{path: "strconv", name: "strconv"})
@@ -92,6 +93,10 @@ func (i *imports) Text() string {
 
 func (i *imports) FlowControl() string {
 	return i.add(importSpec{path: flowcontrolImport, name: "fc"})
+}
+
+func (i *imports) Fmt() string {
+	return i.add(importSpec{path: "fmt", name: "fmt"})
 }
 
 func (i *imports) Context() string {

--- a/capnpc-go/fileparts.go
+++ b/capnpc-go/fileparts.go
@@ -67,6 +67,7 @@ func (i *imports) init() {
 	i.reserve(importSpec{path: schemasImport, name: "schemas"})
 	i.reserve(importSpec{path: serverImport, name: "server"})
 	i.reserve(importSpec{path: textImport, name: "text"})
+	i.reserve(importSpec{path: flowcontrolImport, name: "fc"})
 
 	i.reserve(importSpec{path: "context", name: "context"})
 	i.reserve(importSpec{path: "math", name: "math"})
@@ -87,6 +88,10 @@ func (i *imports) Server() string {
 
 func (i *imports) Text() string {
 	return i.add(importSpec{path: textImport, name: "text"})
+}
+
+func (i *imports) FlowControl() string {
+	return i.add(importSpec{path: flowcontrolImport, name: "fc"})
 }
 
 func (i *imports) Context() string {

--- a/capnpc-go/templates/interfaceClient
+++ b/capnpc-go/templates/interfaceClient
@@ -26,7 +26,7 @@ func (c {{$.Node.Name}}) {{.Name|title}}(ctx {{$.G.Imports.Context}}.Context, pa
 // should not be used to compare clients.  Use IsSame to compare clients
 // for equality.
 func (c {{$.Node.Name}}) String() string {
-	return fmt.Sprintf("%T(%v)", c, capnp.Client(c))
+	return {{$.G.Imports.Fmt}}.Sprintf("%T(%v)", c, capnp.Client(c))
 }
 
 // AddRef creates a new Client that refers to the same capability as c.

--- a/capnpc-go/templates/interfaceClient
+++ b/capnpc-go/templates/interfaceClient
@@ -45,6 +45,12 @@ func (c {{$.Node.Name}}) Release() {
 	capnp.Client(c).Release()
 }
 
+// Resolve blocks until the capability is fully resolved or the Context
+// expires.
+func (c {{$.Node.Name}}) Resolve(ctx context.Context) error {
+	return capnp.Client(c).Resolve(ctx)
+}
+
 func (c {{$.Node.Name}}) EncodeAsPtr(seg *capnp.Segment) capnp.Ptr {
 	return capnp.Client(c).EncodeAsPtr(seg)
 }

--- a/capnpc-go/templates/interfaceClient
+++ b/capnpc-go/templates/interfaceClient
@@ -66,8 +66,8 @@ func (c {{$.Node.Name}}) IsValid() bool {
 	return capnp.Client(c).IsValid()
 }
 
-// IsSame reports whether c and c2 refer to a capability created by the
-// same call to NewClient.  This can return false negatives if c or c2
+// IsSame reports whether c and other refer to a capability created by the
+// same call to NewClient.  This can return false negatives if c or other
 // are not fully resolved: use Resolve if this is an issue.  If either
 // c or other are released, then IsSame panics.
 func (c {{$.Node.Name}}) IsSame(other {{$.Node.Name}}) bool {

--- a/capnpc-go/templates/interfaceClient
+++ b/capnpc-go/templates/interfaceClient
@@ -21,10 +21,18 @@ func (c {{$.Node.Name}}) {{.Name|title}}(ctx {{$.G.Imports.Context}}.Context, pa
 }
 {{end}}
 
+// AddRef creates a new Client that refers to the same capability as c.
+// If c is nil or has resolved to null, then AddRef returns nil.
 func (c {{$.Node.Name}}) AddRef() {{$.Node.Name}} {
 	return {{$.Node.Name}}(capnp.Client(c).AddRef())
 }
 
+// Release releases a capability reference.  If this is the last
+// reference to the capability, then the underlying resources associated
+// with the capability will be released.
+//
+// Release will panic if c has already been released, but not if c is
+// nil or resolved to null.
 func (c {{$.Node.Name}}) Release() {
 	capnp.Client(c).Release()
 }

--- a/capnpc-go/templates/interfaceClient
+++ b/capnpc-go/templates/interfaceClient
@@ -40,3 +40,11 @@ func ({{$.Node.Name}}) DecodeFromPtr(p capnp.Ptr) {{$.Node.Name}} {
 func (c {{$.Node.Name}}) IsValid() bool {
 	return capnp.Client(c).IsValid()
 }
+
+// Update the flowcontrol.FlowLimiter used to manage flow control for
+// this client. This affects all future calls, but not calls already
+// waiting to send. Passing nil sets the value to flowcontrol.NopLimiter,
+// which is also the default.
+func (c {{$.Node.Name}}) SetFlowLimiter(lim flowcontrol.FlowLimiter) {
+	capnp.Client(c).SetFlowLimiter(lim)
+}

--- a/capnpc-go/templates/interfaceClient
+++ b/capnpc-go/templates/interfaceClient
@@ -21,6 +21,14 @@ func (c {{$.Node.Name}}) {{.Name|title}}(ctx {{$.G.Imports.Context}}.Context, pa
 }
 {{end}}
 
+// String returns a string that identifies this capability for debugging
+// purposes.  Its format should not be depended on: in particular, it
+// should not be used to compare clients.  Use IsSame to compare clients
+// for equality.
+func (c {{$.Node.Name}}) String() string {
+	return capnp.Client(c).String()
+}
+
 // AddRef creates a new Client that refers to the same capability as c.
 // If c is nil or has resolved to null, then AddRef returns nil.
 func (c {{$.Node.Name}}) AddRef() {{$.Node.Name}} {

--- a/capnpc-go/templates/interfaceClient
+++ b/capnpc-go/templates/interfaceClient
@@ -37,6 +37,9 @@ func ({{$.Node.Name}}) DecodeFromPtr(p capnp.Ptr) {{$.Node.Name}} {
 	return {{$.Node.Name}}(capnp.Client{}.DecodeFromPtr(p))
 }
 
+// IsValid reports whether c is a valid reference to a capability.
+// A reference is invalid if it is nil, has resolved to null, or has
+// been released.
 func (c {{$.Node.Name}}) IsValid() bool {
 	return capnp.Client(c).IsValid()
 }

--- a/capnpc-go/templates/interfaceClient
+++ b/capnpc-go/templates/interfaceClient
@@ -66,6 +66,14 @@ func (c {{$.Node.Name}}) IsValid() bool {
 	return capnp.Client(c).IsValid()
 }
 
+// IsSame reports whether c and c2 refer to a capability created by the
+// same call to NewClient.  This can return false negatives if c or c2
+// are not fully resolved: use Resolve if this is an issue.  If either
+// c or other are released, then IsSame panics.
+func (c {{$.Node.Name}}) IsSame(other {{$.Node.Name}}) bool {
+	return capnp.Client(c).IsSame(capnp.Client(other))
+}
+
 // Update the flowcontrol.FlowLimiter used to manage flow control for
 // this client. This affects all future calls, but not calls already
 // waiting to send. Passing nil sets the value to flowcontrol.NopLimiter,

--- a/capnpc-go/templates/interfaceClient
+++ b/capnpc-go/templates/interfaceClient
@@ -81,3 +81,9 @@ func (c {{$.Node.Name}}) IsSame(other {{$.Node.Name}}) bool {
 func (c {{$.Node.Name}}) SetFlowLimiter(lim {{.G.Imports.FlowControl}}.FlowLimiter) {
 	capnp.Client(c).SetFlowLimiter(lim)
 }
+
+// Get the current flowcontrol.FlowLimiter used to manage flow control
+// for this client.
+func (c {{$.Node.Name}}) GetFlowLimiter() {{.G.Imports.FlowControl}}.FlowLimiter {
+	return capnp.Client(c).GetFlowLimiter()
+}

--- a/capnpc-go/templates/interfaceClient
+++ b/capnpc-go/templates/interfaceClient
@@ -26,7 +26,7 @@ func (c {{$.Node.Name}}) {{.Name|title}}(ctx {{$.G.Imports.Context}}.Context, pa
 // should not be used to compare clients.  Use IsSame to compare clients
 // for equality.
 func (c {{$.Node.Name}}) String() string {
-	return capnp.Client(c).String()
+	return fmt.Sprintf("%T(%v)", c, capnp.Client(c))
 }
 
 // AddRef creates a new Client that refers to the same capability as c.

--- a/capnpc-go/templates/interfaceClient
+++ b/capnpc-go/templates/interfaceClient
@@ -70,6 +70,6 @@ func (c {{$.Node.Name}}) IsValid() bool {
 // this client. This affects all future calls, but not calls already
 // waiting to send. Passing nil sets the value to flowcontrol.NopLimiter,
 // which is also the default.
-func (c {{$.Node.Name}}) SetFlowLimiter(lim flowcontrol.FlowLimiter) {
+func (c {{$.Node.Name}}) SetFlowLimiter(lim {{.G.Imports.FlowControl}}.FlowLimiter) {
 	capnp.Client(c).SetFlowLimiter(lim)
 }

--- a/internal/aircraftlib/aircraft.capnp.go
+++ b/internal/aircraftlib/aircraft.capnp.go
@@ -9,6 +9,7 @@ import (
 	schemas "capnproto.org/go/capnp/v3/schemas"
 	server "capnproto.org/go/capnp/v3/server"
 	context "context"
+	fmt "fmt"
 	math "math"
 	strconv "strconv"
 )
@@ -5131,7 +5132,7 @@ func (c Echo) Echo(ctx context.Context, params func(Echo_echo_Params) error) (Ec
 // should not be used to compare clients.  Use IsSame to compare clients
 // for equality.
 func (c Echo) String() string {
-	return capnp.Client(c).String()
+	return fmt.Sprintf("%T(%v)", c, capnp.Client(c))
 }
 
 // AddRef creates a new Client that refers to the same capability as c.
@@ -5169,6 +5170,14 @@ func (Echo) DecodeFromPtr(p capnp.Ptr) Echo {
 // been released.
 func (c Echo) IsValid() bool {
 	return capnp.Client(c).IsValid()
+}
+
+// IsSame reports whether c and c2 refer to a capability created by the
+// same call to NewClient.  This can return false negatives if c or c2
+// are not fully resolved: use Resolve if this is an issue.  If either
+// c or other are released, then IsSame panics.
+func (c Echo) IsSame(other Echo) bool {
+	return capnp.Client(c).IsSame(capnp.Client(other))
 }
 
 // Update the flowcontrol.FlowLimiter used to manage flow control for
@@ -5909,7 +5918,7 @@ func (c CallSequence) GetNumber(ctx context.Context, params func(CallSequence_ge
 // should not be used to compare clients.  Use IsSame to compare clients
 // for equality.
 func (c CallSequence) String() string {
-	return capnp.Client(c).String()
+	return fmt.Sprintf("%T(%v)", c, capnp.Client(c))
 }
 
 // AddRef creates a new Client that refers to the same capability as c.
@@ -5947,6 +5956,14 @@ func (CallSequence) DecodeFromPtr(p capnp.Ptr) CallSequence {
 // been released.
 func (c CallSequence) IsValid() bool {
 	return capnp.Client(c).IsValid()
+}
+
+// IsSame reports whether c and c2 refer to a capability created by the
+// same call to NewClient.  This can return false negatives if c or c2
+// are not fully resolved: use Resolve if this is an issue.  If either
+// c or other are released, then IsSame panics.
+func (c CallSequence) IsSame(other CallSequence) bool {
+	return capnp.Client(c).IsSame(capnp.Client(other))
 }
 
 // Update the flowcontrol.FlowLimiter used to manage flow control for
@@ -6202,7 +6219,7 @@ func (c Pipeliner) GetNumber(ctx context.Context, params func(CallSequence_getNu
 // should not be used to compare clients.  Use IsSame to compare clients
 // for equality.
 func (c Pipeliner) String() string {
-	return capnp.Client(c).String()
+	return fmt.Sprintf("%T(%v)", c, capnp.Client(c))
 }
 
 // AddRef creates a new Client that refers to the same capability as c.
@@ -6240,6 +6257,14 @@ func (Pipeliner) DecodeFromPtr(p capnp.Ptr) Pipeliner {
 // been released.
 func (c Pipeliner) IsValid() bool {
 	return capnp.Client(c).IsValid()
+}
+
+// IsSame reports whether c and c2 refer to a capability created by the
+// same call to NewClient.  This can return false negatives if c or c2
+// are not fully resolved: use Resolve if this is an issue.  If either
+// c or other are released, then IsSame panics.
+func (c Pipeliner) IsSame(other Pipeliner) bool {
+	return capnp.Client(c).IsSame(capnp.Client(other))
 }
 
 // Update the flowcontrol.FlowLimiter used to manage flow control for

--- a/internal/aircraftlib/aircraft.capnp.go
+++ b/internal/aircraftlib/aircraft.capnp.go
@@ -5,6 +5,7 @@ package aircraftlib
 import (
 	capnp "capnproto.org/go/capnp/v3"
 	text "capnproto.org/go/capnp/v3/encoding/text"
+	fc "capnproto.org/go/capnp/v3/flowcontrol"
 	schemas "capnproto.org/go/capnp/v3/schemas"
 	server "capnproto.org/go/capnp/v3/server"
 	context "context"
@@ -5125,12 +5126,34 @@ func (c Echo) Echo(ctx context.Context, params func(Echo_echo_Params) error) (Ec
 	return Echo_echo_Results_Future{Future: ans.Future()}, release
 }
 
+// String returns a string that identifies this capability for debugging
+// purposes.  Its format should not be depended on: in particular, it
+// should not be used to compare clients.  Use IsSame to compare clients
+// for equality.
+func (c Echo) String() string {
+	return capnp.Client(c).String()
+}
+
+// AddRef creates a new Client that refers to the same capability as c.
+// If c is nil or has resolved to null, then AddRef returns nil.
 func (c Echo) AddRef() Echo {
 	return Echo(capnp.Client(c).AddRef())
 }
 
+// Release releases a capability reference.  If this is the last
+// reference to the capability, then the underlying resources associated
+// with the capability will be released.
+//
+// Release will panic if c has already been released, but not if c is
+// nil or resolved to null.
 func (c Echo) Release() {
 	capnp.Client(c).Release()
+}
+
+// Resolve blocks until the capability is fully resolved or the Context
+// expires.
+func (c Echo) Resolve(ctx context.Context) error {
+	return capnp.Client(c).Resolve(ctx)
 }
 
 func (c Echo) EncodeAsPtr(seg *capnp.Segment) capnp.Ptr {
@@ -5141,8 +5164,19 @@ func (Echo) DecodeFromPtr(p capnp.Ptr) Echo {
 	return Echo(capnp.Client{}.DecodeFromPtr(p))
 }
 
+// IsValid reports whether c is a valid reference to a capability.
+// A reference is invalid if it is nil, has resolved to null, or has
+// been released.
 func (c Echo) IsValid() bool {
 	return capnp.Client(c).IsValid()
+}
+
+// Update the flowcontrol.FlowLimiter used to manage flow control for
+// this client. This affects all future calls, but not calls already
+// waiting to send. Passing nil sets the value to flowcontrol.NopLimiter,
+// which is also the default.
+func (c Echo) SetFlowLimiter(lim fc.FlowLimiter) {
+	capnp.Client(c).SetFlowLimiter(lim)
 }
 
 // A Echo_Server is a Echo with a local implementation.
@@ -5870,12 +5904,34 @@ func (c CallSequence) GetNumber(ctx context.Context, params func(CallSequence_ge
 	return CallSequence_getNumber_Results_Future{Future: ans.Future()}, release
 }
 
+// String returns a string that identifies this capability for debugging
+// purposes.  Its format should not be depended on: in particular, it
+// should not be used to compare clients.  Use IsSame to compare clients
+// for equality.
+func (c CallSequence) String() string {
+	return capnp.Client(c).String()
+}
+
+// AddRef creates a new Client that refers to the same capability as c.
+// If c is nil or has resolved to null, then AddRef returns nil.
 func (c CallSequence) AddRef() CallSequence {
 	return CallSequence(capnp.Client(c).AddRef())
 }
 
+// Release releases a capability reference.  If this is the last
+// reference to the capability, then the underlying resources associated
+// with the capability will be released.
+//
+// Release will panic if c has already been released, but not if c is
+// nil or resolved to null.
 func (c CallSequence) Release() {
 	capnp.Client(c).Release()
+}
+
+// Resolve blocks until the capability is fully resolved or the Context
+// expires.
+func (c CallSequence) Resolve(ctx context.Context) error {
+	return capnp.Client(c).Resolve(ctx)
 }
 
 func (c CallSequence) EncodeAsPtr(seg *capnp.Segment) capnp.Ptr {
@@ -5886,8 +5942,19 @@ func (CallSequence) DecodeFromPtr(p capnp.Ptr) CallSequence {
 	return CallSequence(capnp.Client{}.DecodeFromPtr(p))
 }
 
+// IsValid reports whether c is a valid reference to a capability.
+// A reference is invalid if it is nil, has resolved to null, or has
+// been released.
 func (c CallSequence) IsValid() bool {
 	return capnp.Client(c).IsValid()
+}
+
+// Update the flowcontrol.FlowLimiter used to manage flow control for
+// this client. This affects all future calls, but not calls already
+// waiting to send. Passing nil sets the value to flowcontrol.NopLimiter,
+// which is also the default.
+func (c CallSequence) SetFlowLimiter(lim fc.FlowLimiter) {
+	capnp.Client(c).SetFlowLimiter(lim)
 }
 
 // A CallSequence_Server is a CallSequence with a local implementation.
@@ -6130,12 +6197,34 @@ func (c Pipeliner) GetNumber(ctx context.Context, params func(CallSequence_getNu
 	return CallSequence_getNumber_Results_Future{Future: ans.Future()}, release
 }
 
+// String returns a string that identifies this capability for debugging
+// purposes.  Its format should not be depended on: in particular, it
+// should not be used to compare clients.  Use IsSame to compare clients
+// for equality.
+func (c Pipeliner) String() string {
+	return capnp.Client(c).String()
+}
+
+// AddRef creates a new Client that refers to the same capability as c.
+// If c is nil or has resolved to null, then AddRef returns nil.
 func (c Pipeliner) AddRef() Pipeliner {
 	return Pipeliner(capnp.Client(c).AddRef())
 }
 
+// Release releases a capability reference.  If this is the last
+// reference to the capability, then the underlying resources associated
+// with the capability will be released.
+//
+// Release will panic if c has already been released, but not if c is
+// nil or resolved to null.
 func (c Pipeliner) Release() {
 	capnp.Client(c).Release()
+}
+
+// Resolve blocks until the capability is fully resolved or the Context
+// expires.
+func (c Pipeliner) Resolve(ctx context.Context) error {
+	return capnp.Client(c).Resolve(ctx)
 }
 
 func (c Pipeliner) EncodeAsPtr(seg *capnp.Segment) capnp.Ptr {
@@ -6146,8 +6235,19 @@ func (Pipeliner) DecodeFromPtr(p capnp.Ptr) Pipeliner {
 	return Pipeliner(capnp.Client{}.DecodeFromPtr(p))
 }
 
+// IsValid reports whether c is a valid reference to a capability.
+// A reference is invalid if it is nil, has resolved to null, or has
+// been released.
 func (c Pipeliner) IsValid() bool {
 	return capnp.Client(c).IsValid()
+}
+
+// Update the flowcontrol.FlowLimiter used to manage flow control for
+// this client. This affects all future calls, but not calls already
+// waiting to send. Passing nil sets the value to flowcontrol.NopLimiter,
+// which is also the default.
+func (c Pipeliner) SetFlowLimiter(lim fc.FlowLimiter) {
+	capnp.Client(c).SetFlowLimiter(lim)
 }
 
 // A Pipeliner_Server is a Pipeliner with a local implementation.

--- a/internal/aircraftlib/aircraft.capnp.go
+++ b/internal/aircraftlib/aircraft.capnp.go
@@ -5172,8 +5172,8 @@ func (c Echo) IsValid() bool {
 	return capnp.Client(c).IsValid()
 }
 
-// IsSame reports whether c and c2 refer to a capability created by the
-// same call to NewClient.  This can return false negatives if c or c2
+// IsSame reports whether c and other refer to a capability created by the
+// same call to NewClient.  This can return false negatives if c or other
 // are not fully resolved: use Resolve if this is an issue.  If either
 // c or other are released, then IsSame panics.
 func (c Echo) IsSame(other Echo) bool {
@@ -5188,7 +5188,11 @@ func (c Echo) SetFlowLimiter(lim fc.FlowLimiter) {
 	capnp.Client(c).SetFlowLimiter(lim)
 }
 
-// A Echo_Server is a Echo with a local implementation.
+// Get the current flowcontrol.FlowLimiter used to manage flow control
+// for this client.
+func (c Echo) GetFlowLimiter() fc.FlowLimiter {
+	return capnp.Client(c).GetFlowLimiter()
+} // A Echo_Server is a Echo with a local implementation.
 type Echo_Server interface {
 	Echo(context.Context, Echo_echo) error
 }
@@ -5958,8 +5962,8 @@ func (c CallSequence) IsValid() bool {
 	return capnp.Client(c).IsValid()
 }
 
-// IsSame reports whether c and c2 refer to a capability created by the
-// same call to NewClient.  This can return false negatives if c or c2
+// IsSame reports whether c and other refer to a capability created by the
+// same call to NewClient.  This can return false negatives if c or other
 // are not fully resolved: use Resolve if this is an issue.  If either
 // c or other are released, then IsSame panics.
 func (c CallSequence) IsSame(other CallSequence) bool {
@@ -5974,7 +5978,11 @@ func (c CallSequence) SetFlowLimiter(lim fc.FlowLimiter) {
 	capnp.Client(c).SetFlowLimiter(lim)
 }
 
-// A CallSequence_Server is a CallSequence with a local implementation.
+// Get the current flowcontrol.FlowLimiter used to manage flow control
+// for this client.
+func (c CallSequence) GetFlowLimiter() fc.FlowLimiter {
+	return capnp.Client(c).GetFlowLimiter()
+} // A CallSequence_Server is a CallSequence with a local implementation.
 type CallSequence_Server interface {
 	GetNumber(context.Context, CallSequence_getNumber) error
 }
@@ -6259,8 +6267,8 @@ func (c Pipeliner) IsValid() bool {
 	return capnp.Client(c).IsValid()
 }
 
-// IsSame reports whether c and c2 refer to a capability created by the
-// same call to NewClient.  This can return false negatives if c or c2
+// IsSame reports whether c and other refer to a capability created by the
+// same call to NewClient.  This can return false negatives if c or other
 // are not fully resolved: use Resolve if this is an issue.  If either
 // c or other are released, then IsSame panics.
 func (c Pipeliner) IsSame(other Pipeliner) bool {
@@ -6275,7 +6283,11 @@ func (c Pipeliner) SetFlowLimiter(lim fc.FlowLimiter) {
 	capnp.Client(c).SetFlowLimiter(lim)
 }
 
-// A Pipeliner_Server is a Pipeliner with a local implementation.
+// Get the current flowcontrol.FlowLimiter used to manage flow control
+// for this client.
+func (c Pipeliner) GetFlowLimiter() fc.FlowLimiter {
+	return capnp.Client(c).GetFlowLimiter()
+} // A Pipeliner_Server is a Pipeliner with a local implementation.
 type Pipeliner_Server interface {
 	NewPipeliner(context.Context, Pipeliner_newPipeliner) error
 

--- a/rpc/internal/testcapnp/test.capnp.go
+++ b/rpc/internal/testcapnp/test.capnp.go
@@ -5,6 +5,7 @@ package testcapnp
 import (
 	capnp "capnproto.org/go/capnp/v3"
 	text "capnproto.org/go/capnp/v3/encoding/text"
+	fc "capnproto.org/go/capnp/v3/flowcontrol"
 	schemas "capnproto.org/go/capnp/v3/schemas"
 	server "capnproto.org/go/capnp/v3/server"
 	stream "capnproto.org/go/capnp/v3/std/capnp/stream"
@@ -33,12 +34,34 @@ func (c PingPong) EchoNum(ctx context.Context, params func(PingPong_echoNum_Para
 	return PingPong_echoNum_Results_Future{Future: ans.Future()}, release
 }
 
+// String returns a string that identifies this capability for debugging
+// purposes.  Its format should not be depended on: in particular, it
+// should not be used to compare clients.  Use IsSame to compare clients
+// for equality.
+func (c PingPong) String() string {
+	return capnp.Client(c).String()
+}
+
+// AddRef creates a new Client that refers to the same capability as c.
+// If c is nil or has resolved to null, then AddRef returns nil.
 func (c PingPong) AddRef() PingPong {
 	return PingPong(capnp.Client(c).AddRef())
 }
 
+// Release releases a capability reference.  If this is the last
+// reference to the capability, then the underlying resources associated
+// with the capability will be released.
+//
+// Release will panic if c has already been released, but not if c is
+// nil or resolved to null.
 func (c PingPong) Release() {
 	capnp.Client(c).Release()
+}
+
+// Resolve blocks until the capability is fully resolved or the Context
+// expires.
+func (c PingPong) Resolve(ctx context.Context) error {
+	return capnp.Client(c).Resolve(ctx)
 }
 
 func (c PingPong) EncodeAsPtr(seg *capnp.Segment) capnp.Ptr {
@@ -49,8 +72,19 @@ func (PingPong) DecodeFromPtr(p capnp.Ptr) PingPong {
 	return PingPong(capnp.Client{}.DecodeFromPtr(p))
 }
 
+// IsValid reports whether c is a valid reference to a capability.
+// A reference is invalid if it is nil, has resolved to null, or has
+// been released.
 func (c PingPong) IsValid() bool {
 	return capnp.Client(c).IsValid()
+}
+
+// Update the flowcontrol.FlowLimiter used to manage flow control for
+// this client. This affects all future calls, but not calls already
+// waiting to send. Passing nil sets the value to flowcontrol.NopLimiter,
+// which is also the default.
+func (c PingPong) SetFlowLimiter(lim fc.FlowLimiter) {
+	capnp.Client(c).SetFlowLimiter(lim)
 }
 
 // A PingPong_Server is a PingPong with a local implementation.
@@ -284,12 +318,34 @@ func (c StreamTest) Push(ctx context.Context, params func(StreamTest_push_Params
 	return stream.StreamResult_Future{Future: ans.Future()}, release
 }
 
+// String returns a string that identifies this capability for debugging
+// purposes.  Its format should not be depended on: in particular, it
+// should not be used to compare clients.  Use IsSame to compare clients
+// for equality.
+func (c StreamTest) String() string {
+	return capnp.Client(c).String()
+}
+
+// AddRef creates a new Client that refers to the same capability as c.
+// If c is nil or has resolved to null, then AddRef returns nil.
 func (c StreamTest) AddRef() StreamTest {
 	return StreamTest(capnp.Client(c).AddRef())
 }
 
+// Release releases a capability reference.  If this is the last
+// reference to the capability, then the underlying resources associated
+// with the capability will be released.
+//
+// Release will panic if c has already been released, but not if c is
+// nil or resolved to null.
 func (c StreamTest) Release() {
 	capnp.Client(c).Release()
+}
+
+// Resolve blocks until the capability is fully resolved or the Context
+// expires.
+func (c StreamTest) Resolve(ctx context.Context) error {
+	return capnp.Client(c).Resolve(ctx)
 }
 
 func (c StreamTest) EncodeAsPtr(seg *capnp.Segment) capnp.Ptr {
@@ -300,8 +356,19 @@ func (StreamTest) DecodeFromPtr(p capnp.Ptr) StreamTest {
 	return StreamTest(capnp.Client{}.DecodeFromPtr(p))
 }
 
+// IsValid reports whether c is a valid reference to a capability.
+// A reference is invalid if it is nil, has resolved to null, or has
+// been released.
 func (c StreamTest) IsValid() bool {
 	return capnp.Client(c).IsValid()
+}
+
+// Update the flowcontrol.FlowLimiter used to manage flow control for
+// this client. This affects all future calls, but not calls already
+// waiting to send. Passing nil sets the value to flowcontrol.NopLimiter,
+// which is also the default.
+func (c StreamTest) SetFlowLimiter(lim fc.FlowLimiter) {
+	capnp.Client(c).SetFlowLimiter(lim)
 }
 
 // A StreamTest_Server is a StreamTest with a local implementation.
@@ -484,12 +551,34 @@ func (c CapArgsTest) Self(ctx context.Context, params func(CapArgsTest_self_Para
 	return CapArgsTest_self_Results_Future{Future: ans.Future()}, release
 }
 
+// String returns a string that identifies this capability for debugging
+// purposes.  Its format should not be depended on: in particular, it
+// should not be used to compare clients.  Use IsSame to compare clients
+// for equality.
+func (c CapArgsTest) String() string {
+	return capnp.Client(c).String()
+}
+
+// AddRef creates a new Client that refers to the same capability as c.
+// If c is nil or has resolved to null, then AddRef returns nil.
 func (c CapArgsTest) AddRef() CapArgsTest {
 	return CapArgsTest(capnp.Client(c).AddRef())
 }
 
+// Release releases a capability reference.  If this is the last
+// reference to the capability, then the underlying resources associated
+// with the capability will be released.
+//
+// Release will panic if c has already been released, but not if c is
+// nil or resolved to null.
 func (c CapArgsTest) Release() {
 	capnp.Client(c).Release()
+}
+
+// Resolve blocks until the capability is fully resolved or the Context
+// expires.
+func (c CapArgsTest) Resolve(ctx context.Context) error {
+	return capnp.Client(c).Resolve(ctx)
 }
 
 func (c CapArgsTest) EncodeAsPtr(seg *capnp.Segment) capnp.Ptr {
@@ -500,8 +589,19 @@ func (CapArgsTest) DecodeFromPtr(p capnp.Ptr) CapArgsTest {
 	return CapArgsTest(capnp.Client{}.DecodeFromPtr(p))
 }
 
+// IsValid reports whether c is a valid reference to a capability.
+// A reference is invalid if it is nil, has resolved to null, or has
+// been released.
 func (c CapArgsTest) IsValid() bool {
 	return capnp.Client(c).IsValid()
+}
+
+// Update the flowcontrol.FlowLimiter used to manage flow control for
+// this client. This affects all future calls, but not calls already
+// waiting to send. Passing nil sets the value to flowcontrol.NopLimiter,
+// which is also the default.
+func (c CapArgsTest) SetFlowLimiter(lim fc.FlowLimiter) {
+	capnp.Client(c).SetFlowLimiter(lim)
 }
 
 // A CapArgsTest_Server is a CapArgsTest with a local implementation.

--- a/rpc/internal/testcapnp/test.capnp.go
+++ b/rpc/internal/testcapnp/test.capnp.go
@@ -80,8 +80,8 @@ func (c PingPong) IsValid() bool {
 	return capnp.Client(c).IsValid()
 }
 
-// IsSame reports whether c and c2 refer to a capability created by the
-// same call to NewClient.  This can return false negatives if c or c2
+// IsSame reports whether c and other refer to a capability created by the
+// same call to NewClient.  This can return false negatives if c or other
 // are not fully resolved: use Resolve if this is an issue.  If either
 // c or other are released, then IsSame panics.
 func (c PingPong) IsSame(other PingPong) bool {
@@ -96,7 +96,11 @@ func (c PingPong) SetFlowLimiter(lim fc.FlowLimiter) {
 	capnp.Client(c).SetFlowLimiter(lim)
 }
 
-// A PingPong_Server is a PingPong with a local implementation.
+// Get the current flowcontrol.FlowLimiter used to manage flow control
+// for this client.
+func (c PingPong) GetFlowLimiter() fc.FlowLimiter {
+	return capnp.Client(c).GetFlowLimiter()
+} // A PingPong_Server is a PingPong with a local implementation.
 type PingPong_Server interface {
 	EchoNum(context.Context, PingPong_echoNum) error
 }
@@ -372,8 +376,8 @@ func (c StreamTest) IsValid() bool {
 	return capnp.Client(c).IsValid()
 }
 
-// IsSame reports whether c and c2 refer to a capability created by the
-// same call to NewClient.  This can return false negatives if c or c2
+// IsSame reports whether c and other refer to a capability created by the
+// same call to NewClient.  This can return false negatives if c or other
 // are not fully resolved: use Resolve if this is an issue.  If either
 // c or other are released, then IsSame panics.
 func (c StreamTest) IsSame(other StreamTest) bool {
@@ -388,7 +392,11 @@ func (c StreamTest) SetFlowLimiter(lim fc.FlowLimiter) {
 	capnp.Client(c).SetFlowLimiter(lim)
 }
 
-// A StreamTest_Server is a StreamTest with a local implementation.
+// Get the current flowcontrol.FlowLimiter used to manage flow control
+// for this client.
+func (c StreamTest) GetFlowLimiter() fc.FlowLimiter {
+	return capnp.Client(c).GetFlowLimiter()
+} // A StreamTest_Server is a StreamTest with a local implementation.
 type StreamTest_Server interface {
 	Push(context.Context, StreamTest_push) error
 }
@@ -613,8 +621,8 @@ func (c CapArgsTest) IsValid() bool {
 	return capnp.Client(c).IsValid()
 }
 
-// IsSame reports whether c and c2 refer to a capability created by the
-// same call to NewClient.  This can return false negatives if c or c2
+// IsSame reports whether c and other refer to a capability created by the
+// same call to NewClient.  This can return false negatives if c or other
 // are not fully resolved: use Resolve if this is an issue.  If either
 // c or other are released, then IsSame panics.
 func (c CapArgsTest) IsSame(other CapArgsTest) bool {
@@ -629,7 +637,11 @@ func (c CapArgsTest) SetFlowLimiter(lim fc.FlowLimiter) {
 	capnp.Client(c).SetFlowLimiter(lim)
 }
 
-// A CapArgsTest_Server is a CapArgsTest with a local implementation.
+// Get the current flowcontrol.FlowLimiter used to manage flow control
+// for this client.
+func (c CapArgsTest) GetFlowLimiter() fc.FlowLimiter {
+	return capnp.Client(c).GetFlowLimiter()
+} // A CapArgsTest_Server is a CapArgsTest with a local implementation.
 type CapArgsTest_Server interface {
 	Call(context.Context, CapArgsTest_call) error
 

--- a/rpc/internal/testcapnp/test.capnp.go
+++ b/rpc/internal/testcapnp/test.capnp.go
@@ -10,6 +10,7 @@ import (
 	server "capnproto.org/go/capnp/v3/server"
 	stream "capnproto.org/go/capnp/v3/std/capnp/stream"
 	context "context"
+	fmt "fmt"
 )
 
 type PingPong capnp.Client
@@ -39,7 +40,7 @@ func (c PingPong) EchoNum(ctx context.Context, params func(PingPong_echoNum_Para
 // should not be used to compare clients.  Use IsSame to compare clients
 // for equality.
 func (c PingPong) String() string {
-	return capnp.Client(c).String()
+	return fmt.Sprintf("%T(%v)", c, capnp.Client(c))
 }
 
 // AddRef creates a new Client that refers to the same capability as c.
@@ -77,6 +78,14 @@ func (PingPong) DecodeFromPtr(p capnp.Ptr) PingPong {
 // been released.
 func (c PingPong) IsValid() bool {
 	return capnp.Client(c).IsValid()
+}
+
+// IsSame reports whether c and c2 refer to a capability created by the
+// same call to NewClient.  This can return false negatives if c or c2
+// are not fully resolved: use Resolve if this is an issue.  If either
+// c or other are released, then IsSame panics.
+func (c PingPong) IsSame(other PingPong) bool {
+	return capnp.Client(c).IsSame(capnp.Client(other))
 }
 
 // Update the flowcontrol.FlowLimiter used to manage flow control for
@@ -323,7 +332,7 @@ func (c StreamTest) Push(ctx context.Context, params func(StreamTest_push_Params
 // should not be used to compare clients.  Use IsSame to compare clients
 // for equality.
 func (c StreamTest) String() string {
-	return capnp.Client(c).String()
+	return fmt.Sprintf("%T(%v)", c, capnp.Client(c))
 }
 
 // AddRef creates a new Client that refers to the same capability as c.
@@ -361,6 +370,14 @@ func (StreamTest) DecodeFromPtr(p capnp.Ptr) StreamTest {
 // been released.
 func (c StreamTest) IsValid() bool {
 	return capnp.Client(c).IsValid()
+}
+
+// IsSame reports whether c and c2 refer to a capability created by the
+// same call to NewClient.  This can return false negatives if c or c2
+// are not fully resolved: use Resolve if this is an issue.  If either
+// c or other are released, then IsSame panics.
+func (c StreamTest) IsSame(other StreamTest) bool {
+	return capnp.Client(c).IsSame(capnp.Client(other))
 }
 
 // Update the flowcontrol.FlowLimiter used to manage flow control for
@@ -556,7 +573,7 @@ func (c CapArgsTest) Self(ctx context.Context, params func(CapArgsTest_self_Para
 // should not be used to compare clients.  Use IsSame to compare clients
 // for equality.
 func (c CapArgsTest) String() string {
-	return capnp.Client(c).String()
+	return fmt.Sprintf("%T(%v)", c, capnp.Client(c))
 }
 
 // AddRef creates a new Client that refers to the same capability as c.
@@ -594,6 +611,14 @@ func (CapArgsTest) DecodeFromPtr(p capnp.Ptr) CapArgsTest {
 // been released.
 func (c CapArgsTest) IsValid() bool {
 	return capnp.Client(c).IsValid()
+}
+
+// IsSame reports whether c and c2 refer to a capability created by the
+// same call to NewClient.  This can return false negatives if c or c2
+// are not fully resolved: use Resolve if this is an issue.  If either
+// c or other are released, then IsSame panics.
+func (c CapArgsTest) IsSame(other CapArgsTest) bool {
+	return capnp.Client(c).IsSame(capnp.Client(other))
 }
 
 // Update the flowcontrol.FlowLimiter used to manage flow control for

--- a/std/capnp/persistent/persistent.capnp.go
+++ b/std/capnp/persistent/persistent.capnp.go
@@ -81,8 +81,8 @@ func (c Persistent) IsValid() bool {
 	return capnp.Client(c).IsValid()
 }
 
-// IsSame reports whether c and c2 refer to a capability created by the
-// same call to NewClient.  This can return false negatives if c or c2
+// IsSame reports whether c and other refer to a capability created by the
+// same call to NewClient.  This can return false negatives if c or other
 // are not fully resolved: use Resolve if this is an issue.  If either
 // c or other are released, then IsSame panics.
 func (c Persistent) IsSame(other Persistent) bool {
@@ -97,7 +97,11 @@ func (c Persistent) SetFlowLimiter(lim fc.FlowLimiter) {
 	capnp.Client(c).SetFlowLimiter(lim)
 }
 
-// A Persistent_Server is a Persistent with a local implementation.
+// Get the current flowcontrol.FlowLimiter used to manage flow control
+// for this client.
+func (c Persistent) GetFlowLimiter() fc.FlowLimiter {
+	return capnp.Client(c).GetFlowLimiter()
+} // A Persistent_Server is a Persistent with a local implementation.
 type Persistent_Server interface {
 	Save(context.Context, Persistent_save) error
 }

--- a/std/capnp/persistent/persistent.capnp.go
+++ b/std/capnp/persistent/persistent.capnp.go
@@ -5,6 +5,7 @@ package persistent
 import (
 	capnp "capnproto.org/go/capnp/v3"
 	text "capnproto.org/go/capnp/v3/encoding/text"
+	fc "capnproto.org/go/capnp/v3/flowcontrol"
 	schemas "capnproto.org/go/capnp/v3/schemas"
 	server "capnproto.org/go/capnp/v3/server"
 	context "context"
@@ -34,12 +35,34 @@ func (c Persistent) Save(ctx context.Context, params func(Persistent_SaveParams)
 	return Persistent_SaveResults_Future{Future: ans.Future()}, release
 }
 
+// String returns a string that identifies this capability for debugging
+// purposes.  Its format should not be depended on: in particular, it
+// should not be used to compare clients.  Use IsSame to compare clients
+// for equality.
+func (c Persistent) String() string {
+	return capnp.Client(c).String()
+}
+
+// AddRef creates a new Client that refers to the same capability as c.
+// If c is nil or has resolved to null, then AddRef returns nil.
 func (c Persistent) AddRef() Persistent {
 	return Persistent(capnp.Client(c).AddRef())
 }
 
+// Release releases a capability reference.  If this is the last
+// reference to the capability, then the underlying resources associated
+// with the capability will be released.
+//
+// Release will panic if c has already been released, but not if c is
+// nil or resolved to null.
 func (c Persistent) Release() {
 	capnp.Client(c).Release()
+}
+
+// Resolve blocks until the capability is fully resolved or the Context
+// expires.
+func (c Persistent) Resolve(ctx context.Context) error {
+	return capnp.Client(c).Resolve(ctx)
 }
 
 func (c Persistent) EncodeAsPtr(seg *capnp.Segment) capnp.Ptr {
@@ -50,8 +73,19 @@ func (Persistent) DecodeFromPtr(p capnp.Ptr) Persistent {
 	return Persistent(capnp.Client{}.DecodeFromPtr(p))
 }
 
+// IsValid reports whether c is a valid reference to a capability.
+// A reference is invalid if it is nil, has resolved to null, or has
+// been released.
 func (c Persistent) IsValid() bool {
 	return capnp.Client(c).IsValid()
+}
+
+// Update the flowcontrol.FlowLimiter used to manage flow control for
+// this client. This affects all future calls, but not calls already
+// waiting to send. Passing nil sets the value to flowcontrol.NopLimiter,
+// which is also the default.
+func (c Persistent) SetFlowLimiter(lim fc.FlowLimiter) {
+	capnp.Client(c).SetFlowLimiter(lim)
 }
 
 // A Persistent_Server is a Persistent with a local implementation.

--- a/std/capnp/persistent/persistent.capnp.go
+++ b/std/capnp/persistent/persistent.capnp.go
@@ -9,6 +9,7 @@ import (
 	schemas "capnproto.org/go/capnp/v3/schemas"
 	server "capnproto.org/go/capnp/v3/server"
 	context "context"
+	fmt "fmt"
 )
 
 const PersistentAnnotation = uint64(0xf622595091cafb67)
@@ -40,7 +41,7 @@ func (c Persistent) Save(ctx context.Context, params func(Persistent_SaveParams)
 // should not be used to compare clients.  Use IsSame to compare clients
 // for equality.
 func (c Persistent) String() string {
-	return capnp.Client(c).String()
+	return fmt.Sprintf("%T(%v)", c, capnp.Client(c))
 }
 
 // AddRef creates a new Client that refers to the same capability as c.
@@ -78,6 +79,14 @@ func (Persistent) DecodeFromPtr(p capnp.Ptr) Persistent {
 // been released.
 func (c Persistent) IsValid() bool {
 	return capnp.Client(c).IsValid()
+}
+
+// IsSame reports whether c and c2 refer to a capability created by the
+// same call to NewClient.  This can return false negatives if c or c2
+// are not fully resolved: use Resolve if this is an issue.  If either
+// c or other are released, then IsSame panics.
+func (c Persistent) IsSame(other Persistent) bool {
+	return capnp.Client(c).IsSame(capnp.Client(other))
 }
 
 // Update the flowcontrol.FlowLimiter used to manage flow control for


### PR DESCRIPTION
As discussed on Matrix, commonly-used `Client` methods are not accessible from subtypes of `Client`.

This PR adds the following methods to the `interfaceClient` template:

- [x] `client.String`
- [x] `client.Resolve`
- [x] `client.SetFlowLimiter`

It also adds docstrings to existing methods.

@zenhack What are your thoughts the other methods (`WeakRef`, `State`, `IsSame`, ...)?  I can't quite decide whether it makes sense to export these.  Are they deliberately part of the public API, or are they intended for internal use, but originally exported out of necessity?  