### PR TITLE
Add a .Release() method to FlowLimiter.

### DIFF
--- a/capability.go
+++ b/capability.go
@@ -286,6 +286,9 @@ func (c Client) GetFlowLimiter() flowcontrol.FlowLimiter {
 // this client. This affects all future calls, but not calls already
 // waiting to send. Passing nil sets the value to flowcontrol.NopLimiter,
 // which is also the default.
+//
+// When .Release() is called on the client, it will call .Release() on
+// the FlowLimiter in turn.
 func (c Client) SetFlowLimiter(lim flowcontrol.FlowLimiter) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -584,6 +587,7 @@ func (c Client) Release() {
 	c.mu.Unlock()
 	<-h.done
 	h.Shutdown()
+	c.GetFlowLimiter().Release()
 }
 
 func (c Client) EncodeAsPtr(seg *Segment) Ptr {

--- a/flowcontrol/fixed.go
+++ b/flowcontrol/fixed.go
@@ -3,8 +3,9 @@ package flowcontrol
 import (
 	"context"
 	"fmt"
-	"golang.org/x/sync/semaphore"
 	"math"
+
+	"golang.org/x/sync/semaphore"
 )
 
 // Returns a FlowLimiter that enforces a fixed limit on the total size of
@@ -32,3 +33,5 @@ func (fl *fixedLimiter) StartMessage(ctx context.Context, size uint64) (gotRespo
 		w.Release(int64(size))
 	}, nil
 }
+
+func (fixedLimiter) Release() {}

--- a/flowcontrol/flowlimiter.go
+++ b/flowcontrol/flowlimiter.go
@@ -28,4 +28,7 @@ type FlowLimiter interface {
 	//
 	// StartMessage must be safe to call from multiple goroutines.
 	StartMessage(ctx context.Context, size uint64) (gotResponse func(), err error)
+
+	// Release releases any resources used by the FlowLimiter.
+	Release()
 }

--- a/flowcontrol/nop.go
+++ b/flowcontrol/nop.go
@@ -15,3 +15,5 @@ type nopLimiter struct{}
 func (nopLimiter) StartMessage(context.Context, uint64) (func(), error) {
 	return func() {}, nil
 }
+
+func (nopLimiter) Release() {}


### PR DESCRIPTION
For the BBR implementation I'm working on, I'm finding spawning
a goroutine to manage things extremely attractive, but that means
needing to shut it down.

This gives us a way to do that: When a Client is Release()ed, it
will Release() its FlowLimiter.