### PR TITLE
Fix #306

### DIFF
--- a/answer.go
+++ b/answer.go
@@ -199,7 +199,7 @@ func (p *Promise) resolve(r Ptr, e error) {
 			res := resolution{p.method, r, e}
 			for path, cp := range p.clients {
 				t := path.transform()
-				cp.promise.Fulfill(res.client(t))
+				cp.promise.Fulfill(res.client(t).AddRef())
 				cp.promise = nil
 			}
 			if p.callsStopped != nil {

--- a/capability.go
+++ b/capability.go
@@ -667,11 +667,11 @@ func (cp *ClientPromise) Reject(err error) {
 	cp.Fulfill(ErrorClient(err))
 }
 
-// Fulfill resolves the client promise to c.  After Fulfill returns,
-// then all future calls to the client created by NewPromisedClient will
-// be sent to c.  It is guaranteed that the hook passed to
-// NewPromisedClient will be shut down after Fulfill returns, but the
-// hook may have been shut down earlier if the client ran out of
+// Fulfill resolves the client promise to c, stealing the reference c.
+// After Fulfill returns, then all future calls to the client created by
+// NewPromisedClient will be sent to c.  It is guaranteed that the hook
+// passed to NewPromisedClient will be shut down after Fulfill returns,
+// but the hook may have been shut down earlier if the client ran out of
 // references.
 func (cp *ClientPromise) Fulfill(c Client) {
 	// Obtain next client hook.


### PR DESCRIPTION
Also, document the fact that ClientPromise.Fulfill steals the reference.

Mixing this up was the root cause of the issue. Specifically both
Promise.ReleaseClients() and Message.Reset() were releasing the same
clients, causing them to be invalid if later used.

This patch just adds a call to .AddRef() in the appropriate spot, so
that the promise has its own references to the clients, as the API
suggests.

---

N.B. this patch is stacked on top of #310 to avoid conflicts; that PR should be reviewed & merged first.