### PR TITLE
Fix incorrect docs for Client.Release().

### DIFF
--- a/capability.go
+++ b/capability.go
@@ -554,7 +554,7 @@ func (c Client) String() string {
 // reference to the capability, then the underlying resources associated
 // with the capability will be released.
 //
-// Release will panic if c has already been released, but not if c is
+// Release has no effect if c has already been released, or if c is
 // nil or resolved to null.
 func (c Client) Release() {
 	if c.client == nil {


### PR DESCRIPTION
The implementation does *not* panic, and in fact some of the tests depend on this behavior to do a defer client.Release() even though they may end up releasing a client sooner than the end of the function call.