### PR TITLE
call messages: let the transport release the cap table

### DIFF
--- a/rpc/import.go
+++ b/rpc/import.go
@@ -166,10 +166,6 @@ func (c *Conn) newImportCallMessage(msg rpccp.Message, imp importID, qid questio
 	}
 	m := args.Message()
 	if err := s.PlaceArgs(args); err != nil {
-		for _, c := range m.CapTable {
-			c.Release()
-		}
-		m.CapTable = nil
 		return rpcerr.Failedf("place arguments: %w", err)
 	}
 	clients := m.CapTable
@@ -177,7 +173,6 @@ func (c *Conn) newImportCallMessage(msg rpccp.Message, imp importID, qid questio
 		// TODO(soon): save param refs
 		_, err = c.fillPayloadCapTable(payload, clients)
 	})
-	releaseList(clients).release()
 	if err != nil {
 		return rpcerr.Annotatef(err, "build call message")
 	}

--- a/rpc/question.go
+++ b/rpc/question.go
@@ -232,10 +232,6 @@ func (c *Conn) newPipelineCallMessage(msg rpccp.Message, tgt questionID, transfo
 	}
 	m := args.Message()
 	if err := s.PlaceArgs(args); err != nil {
-		for _, c := range m.CapTable {
-			c.Release()
-		}
-		m.CapTable = nil
 		return rpcerr.Failedf("place arguments: %w", err)
 	}
 	clients := m.CapTable
@@ -243,7 +239,6 @@ func (c *Conn) newPipelineCallMessage(msg rpccp.Message, tgt questionID, transfo
 		// TODO(soon): save param refs
 		_, err = c.fillPayloadCapTable(payload, clients)
 	})
-	releaseList(clients).release()
 
 	if err != nil {
 		return rpcerr.Annotatef(err, "build call message")


### PR DESCRIPTION
For two reasons:

1. As clarified in #308, the transport will release these when the message is freed, so we don't need to do this here to avoid a leak, and letting the transport deal with it is simpler.
2. I smell a race condition: this releases the clients before the message is actually on the wire. I *think* it is actually fine, because I think by this time the message is already in the queue and so is morally on the wire, but it's a bit harder to reason about, and makes me nervous.

I *believe* there is no functional change here.