### PR TITLE
Fix a regression introduced by releaseQuestions()

### DIFF
--- a/rpc/question.go
+++ b/rpc/question.go
@@ -125,13 +125,6 @@ func (q *question) handleCancel(ctx context.Context) {
 		}
 		close(q.finishMsgSend)
 
-		// First remove the question from the table, so we don't
-		// double-resolve the promise. We can't free the id though,
-		// since the finish failed.
-		syncutil.With(&q.c.mu, func() {
-			q.c.questions[q.id] = nil
-		})
-
 		q.p.Reject(rejectErr)
 		if q.bootstrapPromise != nil {
 			q.bootstrapPromise.Fulfill(q.p.Answer().Client())

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -399,7 +399,13 @@ func (c *Conn) releaseAnswers(answers map[answerID]*answer) {
 
 func (c *Conn) releaseQuestions(questions []*question) {
 	for _, q := range questions {
-		q.Reject(ExcClosed)
+		canceled := q != nil && q.flags&finished != 0
+		if !canceled {
+			// Only reject the question if it isn't already flagged
+			// as finished; otherwise it was rejected when the finished
+			// flag was set.
+			q.Reject(ExcClosed)
+		}
 	}
 }
 


### PR DESCRIPTION
This was manifesting as occasional failures of
TestBootstrapReceiverAnswerRpc, as discussed in #318. When this was introduced, I attempted to avoid double-rejecting the promise by removing it from the table after the first rejection, but this is in fact incorrect in the case where we cancel the question, because the entry needs to stick around until the return message comes in.

With this patch, instead, we solve the problem by just having releaseQuestions() check the `finished` flag before calling Reject.