### PR TITLE
Server.handleCall: Run methods when the ctx is already canceled

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -203,10 +203,7 @@ func (srv *Server) handleCalls(ctx context.Context) {
 func (srv *Server) handleCall(ctx context.Context, c *Call) {
 	defer srv.wg.Done()
 
-	err := ctx.Err()
-	if err == nil {
-		err = c.method.Impl(ctx, c)
-	}
+	err := c.method.Impl(ctx, c)
 
 	c.recv.ReleaseArgs()
 	if err == nil {


### PR DESCRIPTION
...and let the method implementation check the context itself.

This solves an occasional hang (observed in #318) in TestRecvCancel, which involves a method implementation that waits for its context to be canceled and then closes a channel. Without this patch, if the context is cancelled early enough for handleCall to see it, it won't run the method at all, and so the channel will never be closed, causing the test to hang on a receive on that channel.