### PR TITLE
Conn.sendMessage: don't return an error.

### DIFF
--- a/rpc/import.go
+++ b/rpc/import.go
@@ -98,9 +98,8 @@ func (ic *importClient) Send(ctx context.Context, s capnp.Send) (*capnp.Answer, 
 	q := ic.c.newQuestion(s.Method)
 
 	// Send call message.
-	var err error
 	syncutil.Without(&ic.c.mu, func() {
-		err = ic.c.sendMessage(ctx, func(m rpccp.Message) error {
+		ic.c.sendMessage(ctx, func(m rpccp.Message) error {
 			return ic.c.newImportCallMessage(m, ic.id, q.id, s)
 		}, func(err error) {
 			ic.c.mu.Lock()
@@ -122,10 +121,6 @@ func (ic *importClient) Send(ctx context.Context, s capnp.Send) (*capnp.Answer, 
 			}()
 		})
 	})
-
-	if err != nil {
-		return capnp.ErrorAnswer(s.Method, err), func() {}
-	}
 
 	ans := q.p.Answer()
 	return ans, func() {

--- a/rpc/question.go
+++ b/rpc/question.go
@@ -151,10 +151,9 @@ func (q *question) PipelineSend(ctx context.Context, transform []capnp.PipelineO
 	q.mark(transform)
 	q2 := q.c.newQuestion(s.Method)
 
-	var err error
 	syncutil.Without(&q.c.mu, func() {
 		// Send call message.
-		err = q.c.sendMessage(ctx, func(m rpccp.Message) error {
+		q.c.sendMessage(ctx, func(m rpccp.Message) error {
 			return q.c.newPipelineCallMessage(m, q.id, transform, q2.id, s)
 		}, func(err error) {
 			if err != nil {
@@ -175,10 +174,6 @@ func (q *question) PipelineSend(ctx context.Context, transform []capnp.PipelineO
 			}()
 		})
 	})
-
-	if err != nil {
-		return capnp.ErrorAnswer(s.Method, err), func() {}
-	}
 
 	ans := q2.p.Answer()
 	return ans, func() {


### PR DESCRIPTION
Instead, arrange for the error handling logic in callback() to always be run.

Fixes #304, by obviating the need for extra checks.

---

I came to this when I realized a missing check could be the source of the intermittent `TestRecvAbort` failures. Sadly, it was not the cause, but this is still worth doing.