### PR TITLE
Fix intermittent hang in TestRecvAbort

### DIFF
--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -207,6 +207,7 @@ func (c *Conn) Bootstrap(ctx context.Context) (bc capnp.Client) {
 	if !c.startTask() {
 		return capnp.ErrorClient(rpcerr.Disconnectedf("connection closed"))
 	}
+	defer c.tasks.Done()
 
 	bootCtx, cancel := context.WithCancel(ctx)
 	q := c.newQuestion(capnp.Method{})
@@ -223,8 +224,6 @@ func (c *Conn) Bootstrap(ctx context.Context) (bc capnp.Client) {
 		return err
 
 	}, func(err error) {
-		defer c.tasks.Done()
-
 		if err != nil {
 			syncutil.With(&c.mu, func() {
 				c.questions[q.id] = nil


### PR DESCRIPTION
This fixes a problem where, if a bootstrap message is in the send queue but not sent when the connection begins shutdown, both connection shutdown and resolution of the bootstrap's promise will deadlock, which manifests as a timeout in TestRecvAbort.

The issue is that Bootstrap() starts a task to keep the connection from shutting down while it is sending the message, and stops it in the latter callback to sendMessage() -- but that callback may not be run until drainQueue is executed, which happens *after* stopTasks() returns, hence the deadlock.

This whole part of the design is a bit sketchy; we also invoke question.handleCancel in said callback, which itself invokes sendMessage(). We should audit for correctness of the design; I expect we'll find some bugs.

For the present bug though, there's no actual reason why the task needs to be held open until the message is actually sent; we can close it once the message is in the queue, which is what question.PipelineSend() does, so now Conn.Bootstrap() does the same. At some point we should factor out some of the common code between them.