### PR TITLE
CI: run RPC tests repeatedly

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -23,6 +23,12 @@ jobs:
       - name: Set GOARCH
         run: |
           echo "GOARCH=${{ matrix.arch }}" >> $GITHUB_ENV
-      - run: go test -v -race -short ./...
+      - name: Run tests with race detector
         if: env.GOARCH != '386'
-      - run: go test -v ./...
+        run: go test -v -race -short ./...
+      - name: Run all tests
+        run: go test -v ./...
+      - name: Run RPC tests repeatedly
+        run: |
+          cd rpc
+          for i in `seq 500`; do go test -v; done

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -31,4 +31,4 @@ jobs:
       - name: Run RPC tests repeatedly
         run: |
           cd rpc
-          for i in `seq 500`; do go test -v; done
+          for i in `seq 500`; do go test; done

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -207,6 +207,7 @@ func (c *Conn) Bootstrap(ctx context.Context) (bc capnp.Client) {
 	if !c.startTask() {
 		return capnp.ErrorClient(rpcerr.Disconnectedf("connection closed"))
 	}
+	defer c.tasks.Done()
 
 	bootCtx, cancel := context.WithCancel(ctx)
 	q := c.newQuestion(capnp.Method{})
@@ -223,8 +224,6 @@ func (c *Conn) Bootstrap(ctx context.Context) (bc capnp.Client) {
 		return err
 
 	}, func(err error) {
-		defer c.tasks.Done()
-
 		if err != nil {
 			syncutil.With(&c.mu, func() {
 				c.questions[q.id] = nil


### PR DESCRIPTION
...to try to better shake out flaky tests & race conditions. Many of the
tests listed in https://github.com/capnproto/go-capnproto2/issues/318 "usually" passed, which is how they snuck in in the
first place. This adjusts our CI to run the tests in the rpc package 500
times.

---

This is stacked on #327, since otherwise that test is going to fail in CI. 