### PR TITLE
Clarify a comment

### DIFF
--- a/rpc/export.go
+++ b/rpc/export.go
@@ -173,7 +173,7 @@ func (c *Conn) sendCap(d rpccp.CapDescriptor, client capnp.Client) (_ exportID, 
 
 // fillPayloadCapTable adds descriptors of payload's message's
 // capabilities into payload's capability table and returns the
-// reference counts added to the exports table.
+// reference counts that have been added to the exports table.
 //
 // The caller must be holding onto c.mu.
 func (c *Conn) fillPayloadCapTable(payload rpccp.Payload, clients []capnp.Client) (map[exportID]uint32, error) {


### PR DESCRIPTION
Per #306, the call sites where this is unused struck me as suspicious -- but they are actually fine; sendCap already takes care of incrementing where necessary.

The return value only needed by sendReturn, so that it can arrange to release these when it receives a finish message with releaseParamCaps = true.

This patch clarifies the comment to make it clear that the caller is not responsible for actually applying the refcounts.