### PR TITLE
Wrap error returned by PlaceArgs using %w directive.

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -267,7 +267,7 @@ func sendArgsToStruct(s capnp.Send) (capnp.Struct, error) {
 	if err := s.PlaceArgs(st); err != nil {
 		st.Message().Reset(nil)
 		// Using fmt.Errorf to ensure sendArgsToStruct returns a generic error.
-		return capnp.Struct{}, fmt.Errorf("place args: %v", err)
+		return capnp.Struct{}, fmt.Errorf("place args: %w", err)
 	}
 	return st, nil
 }


### PR DESCRIPTION
This allows use of `errors.Is` for RPC calls on local capabilities, which is helpful when writing unit tests.  There is no functional change.