### PR TITLE
Add code generation for AnyList

### DIFF
--- a/answer.go
+++ b/answer.go
@@ -299,7 +299,15 @@ func (ans *Answer) Done() <-chan struct{} {
 // Struct waits until the answer is resolved and returns the struct
 // this answer represents.
 func (ans *Answer) Struct() (Struct, error) {
-	return ans.f.Struct()
+	p, err := ans.f.Ptr()
+	return p.Struct(), err
+}
+
+// List waits until the answer is resolved and returns the list
+// this answer represents.
+func (ans *Answer) List() (List, error) {
+	p, err := ans.f.Ptr()
+	return p.List(), err
 }
 
 // Client returns the answer as a client.  If the answer's originating
@@ -419,15 +427,15 @@ func (f *Future) Done() <-chan struct{} {
 	return f.promise.resolved
 }
 
-// Struct waits until the answer is resolved and returns the struct
+// Struct waits until the answer is resolved and returns the pointer
 // this future represents.
-func (f *Future) Struct() (Struct, error) {
+func (f *Future) Ptr() (Ptr, error) {
 	p := f.promise
 	<-p.resolved
 	p.mu.Lock()
 	r := p.resolution()
 	p.mu.Unlock()
-	return r.strct(f.transform())
+	return r.ptr(f.transform())
 }
 
 // Client returns the future as a client.  If the answer's originating
@@ -587,12 +595,6 @@ func (r resolution) ptr(transform []PipelineOp) (Ptr, error) {
 		return Ptr{}, exc.Annotate("", r.method.String(), err)
 	}
 	return p, nil
-}
-
-// strct obtains a Struct by applying a transform.
-func (r resolution) strct(transform []PipelineOp) (Struct, error) {
-	p, err := r.ptr(transform)
-	return p.Struct(), err
 }
 
 // client obtains a Client by applying a transform.

--- a/answer.go
+++ b/answer.go
@@ -299,15 +299,13 @@ func (ans *Answer) Done() <-chan struct{} {
 // Struct waits until the answer is resolved and returns the struct
 // this answer represents.
 func (ans *Answer) Struct() (Struct, error) {
-	p, err := ans.f.Ptr()
-	return p.Struct(), err
+	return ans.f.Struct()
 }
 
 // List waits until the answer is resolved and returns the list
 // this answer represents.
 func (ans *Answer) List() (List, error) {
-	p, err := ans.f.Ptr()
-	return p.List(), err
+	return ans.f.List()
 }
 
 // Client returns the answer as a client.  If the answer's originating
@@ -427,7 +425,7 @@ func (f *Future) Done() <-chan struct{} {
 	return f.promise.resolved
 }
 
-// Struct waits until the answer is resolved and returns the pointer
+// Ptr waits until the answer is resolved and returns the pointer
 // this future represents.
 func (f *Future) Ptr() (Ptr, error) {
 	p := f.promise
@@ -436,6 +434,20 @@ func (f *Future) Ptr() (Ptr, error) {
 	r := p.resolution()
 	p.mu.Unlock()
 	return r.ptr(f.transform())
+}
+
+// Struct waits until the answer is resolved and returns the struct
+// this answer represents.
+func (f *Future) Struct() (Struct, error) {
+	p, err := f.Ptr()
+	return p.Struct(), err
+}
+
+// List waits until the answer is resolved and returns the list
+// this answer represents.
+func (f *Future) List() (List, error) {
+	p, err := f.Ptr()
+	return p.List(), err
 }
 
 // Client returns the future as a client.  If the answer's originating

--- a/capnpc-go/any_pointer.go
+++ b/capnpc-go/any_pointer.go
@@ -56,7 +56,10 @@ func (s structAnyPointerRenderStrategy) StructParams() any {
 }
 
 func (s structAnyPointerRenderStrategy) ListParams() any {
-	return s.PtrParams() // TODO(soon): implement AnyList
+	return structAnyListFieldParams{
+		structFieldParams: s.Params,
+		Default:           s.Default,
+	}
 }
 
 func (s structAnyPointerRenderStrategy) CapabilityParams() any {

--- a/capnpc-go/any_pointer.go
+++ b/capnpc-go/any_pointer.go
@@ -84,7 +84,7 @@ func (s promiseAnyPointerRenderStrategy) StructParams() any {
 }
 
 func (s promiseAnyPointerRenderStrategy) ListParams() any {
-	return s.PtrParams() // TODO(soon): implement AnyList
+	return promiseFieldAnyListParams(s)
 }
 
 func (s promiseAnyPointerRenderStrategy) CapabilityParams() any {

--- a/capnpc-go/templateparams.go
+++ b/capnpc-go/templateparams.go
@@ -69,6 +69,7 @@ type (
 	structPointerFieldParams    structObjectFieldParams
 	structStructFieldParams     structObjectFieldParams
 	structAnyStructFieldParams  structObjectFieldParams
+	structAnyListFieldParams    structObjectFieldParams
 )
 
 type structBoolFieldParams struct {

--- a/capnpc-go/templateparams.go
+++ b/capnpc-go/templateparams.go
@@ -162,6 +162,7 @@ type promiseFieldParams struct {
 type (
 	promiseFieldAnyPointerParams promiseFieldParams
 	promiseCapabilityFieldParams promiseFieldParams
+	promiseFieldAnyListParams    promiseFieldParams
 )
 
 type promiseFieldInterfaceParams struct {

--- a/capnpc-go/templates/promise
+++ b/capnpc-go/templates/promise
@@ -1,8 +1,7 @@
 // {{.Node.Name}}_Future is a wrapper for a {{.Node.Name}} promised by a client call.
 type {{.Node.Name}}_Future struct { *capnp.Future }
 
-func (p {{.Node.Name}}_Future) Struct() ({{.Node.Name}}, error) {
-	s, err := p.Future.Struct()
-	return {{.Node.Name}}(s), err
+func (f {{.Node.Name}}_Future) Struct() ({{.Node.Name}}, error) {
+	p, err := f.Future.Ptr()
+	return {{.Node.Name}}(p.Struct()), err
 }
-

--- a/capnpc-go/templates/promiseFieldAnyList
+++ b/capnpc-go/templates/promiseFieldAnyList
@@ -1,0 +1,3 @@
+func (p {{ .Node.Name }}_Future) {{ .Field.Name|title }}() *capnp.Future {
+	return  p.Future.Field({{ .Field.Slot.Offset }}, nil)
+}

--- a/capnpc-go/templates/promiseFieldStruct
+++ b/capnpc-go/templates/promiseFieldStruct
@@ -2,4 +2,3 @@ func (p {{.Node.Name}}_Future) {{.Field.Name|title}}() {{.G.RemoteNodeName .Stru
 	return {{.G.RemoteNodeName .Struct .Node}}_Future{Future: p.Future.Field(
 		{{- .Field.Slot.Offset}}, {{if .Default.IsValid}}{{.Default}}{{else}}nil{{end}})}
 }
-

--- a/capnpc-go/templates/structAnyListField
+++ b/capnpc-go/templates/structAnyListField
@@ -1,0 +1,19 @@
+func (s {{.Node.Name}}) {{.Field.Name|title}}() (capnp.List, error) {
+	{{template "_checktag" . -}}
+	p, err := capnp.Struct(s).Ptr({{.Field.Slot.Offset}})
+	{{if .Default.IsValid -}}
+	if err != nil {
+		return capnp.List{}, err
+	}
+	return  p.ListDefault({{.Default}})
+	{{- else -}}
+	return p.List(), err
+	{{- end}}
+}
+
+{{template "_hasfield" .}}
+
+func (s {{.Node.Name}}) Set{{.Field.Name|title}}(v capnp.List) error {
+	{{template "_settag" . -}}
+	return capnp.Struct(s).SetPtr({{.Field.Slot.Offset}}, v.ToPtr())
+}

--- a/capnpc-go/templates/structListField
+++ b/capnpc-go/templates/structListField
@@ -30,4 +30,3 @@ func (s {{.Node.Name}}) New{{.Field.Name|title}}(n int32) ({{.FieldType}}, error
 	err = capnp.Struct(s).SetPtr({{.Field.Slot.Offset}}, l.ToPtr())
 	return l, err
 }
-

--- a/internal/aircraftlib/aircraft.capnp.go
+++ b/internal/aircraftlib/aircraft.capnp.go
@@ -347,7 +347,6 @@ func (s PlaneBase) NewHomes(n int32) (Airport_List, error) {
 	err = capnp.Struct(s).SetPtr(1, l.ToPtr())
 	return l, err
 }
-
 func (s PlaneBase) Rating() int64 {
 	return int64(capnp.Struct(s).Uint64(0))
 }
@@ -775,7 +774,6 @@ func (s Regression) NewBeta(n int32) (capnp.Float64List, error) {
 	err = capnp.Struct(s).SetPtr(1, l.ToPtr())
 	return l, err
 }
-
 func (s Regression) Planes() (Aircraft_List, error) {
 	p, err := capnp.Struct(s).Ptr(2)
 	return Aircraft_List(p.List()), err
@@ -799,7 +797,6 @@ func (s Regression) NewPlanes(n int32) (Aircraft_List, error) {
 	err = capnp.Struct(s).SetPtr(2, l.ToPtr())
 	return l, err
 }
-
 func (s Regression) Ymu() float64 {
 	return math.Float64frombits(capnp.Struct(s).Uint64(8))
 }
@@ -1498,7 +1495,6 @@ func (s Z) NewF64vec(n int32) (capnp.Float64List, error) {
 	err = capnp.Struct(s).SetPtr(0, l.ToPtr())
 	return l, err
 }
-
 func (s Z) F32vec() (capnp.Float32List, error) {
 	if capnp.Struct(s).Uint16(0) != 16 {
 		panic("Which() != f32vec")
@@ -1530,7 +1526,6 @@ func (s Z) NewF32vec(n int32) (capnp.Float32List, error) {
 	err = capnp.Struct(s).SetPtr(0, l.ToPtr())
 	return l, err
 }
-
 func (s Z) I64vec() (capnp.Int64List, error) {
 	if capnp.Struct(s).Uint16(0) != 17 {
 		panic("Which() != i64vec")
@@ -1562,7 +1557,6 @@ func (s Z) NewI64vec(n int32) (capnp.Int64List, error) {
 	err = capnp.Struct(s).SetPtr(0, l.ToPtr())
 	return l, err
 }
-
 func (s Z) I32vec() (capnp.Int32List, error) {
 	if capnp.Struct(s).Uint16(0) != 18 {
 		panic("Which() != i32vec")
@@ -1594,7 +1588,6 @@ func (s Z) NewI32vec(n int32) (capnp.Int32List, error) {
 	err = capnp.Struct(s).SetPtr(0, l.ToPtr())
 	return l, err
 }
-
 func (s Z) I16vec() (capnp.Int16List, error) {
 	if capnp.Struct(s).Uint16(0) != 19 {
 		panic("Which() != i16vec")
@@ -1626,7 +1619,6 @@ func (s Z) NewI16vec(n int32) (capnp.Int16List, error) {
 	err = capnp.Struct(s).SetPtr(0, l.ToPtr())
 	return l, err
 }
-
 func (s Z) I8vec() (capnp.Int8List, error) {
 	if capnp.Struct(s).Uint16(0) != 20 {
 		panic("Which() != i8vec")
@@ -1658,7 +1650,6 @@ func (s Z) NewI8vec(n int32) (capnp.Int8List, error) {
 	err = capnp.Struct(s).SetPtr(0, l.ToPtr())
 	return l, err
 }
-
 func (s Z) U64vec() (capnp.UInt64List, error) {
 	if capnp.Struct(s).Uint16(0) != 21 {
 		panic("Which() != u64vec")
@@ -1690,7 +1681,6 @@ func (s Z) NewU64vec(n int32) (capnp.UInt64List, error) {
 	err = capnp.Struct(s).SetPtr(0, l.ToPtr())
 	return l, err
 }
-
 func (s Z) U32vec() (capnp.UInt32List, error) {
 	if capnp.Struct(s).Uint16(0) != 22 {
 		panic("Which() != u32vec")
@@ -1722,7 +1712,6 @@ func (s Z) NewU32vec(n int32) (capnp.UInt32List, error) {
 	err = capnp.Struct(s).SetPtr(0, l.ToPtr())
 	return l, err
 }
-
 func (s Z) U16vec() (capnp.UInt16List, error) {
 	if capnp.Struct(s).Uint16(0) != 23 {
 		panic("Which() != u16vec")
@@ -1754,7 +1743,6 @@ func (s Z) NewU16vec(n int32) (capnp.UInt16List, error) {
 	err = capnp.Struct(s).SetPtr(0, l.ToPtr())
 	return l, err
 }
-
 func (s Z) U8vec() (capnp.UInt8List, error) {
 	if capnp.Struct(s).Uint16(0) != 24 {
 		panic("Which() != u8vec")
@@ -1786,7 +1774,6 @@ func (s Z) NewU8vec(n int32) (capnp.UInt8List, error) {
 	err = capnp.Struct(s).SetPtr(0, l.ToPtr())
 	return l, err
 }
-
 func (s Z) Boolvec() (capnp.BitList, error) {
 	if capnp.Struct(s).Uint16(0) != 39 {
 		panic("Which() != boolvec")
@@ -1818,7 +1805,6 @@ func (s Z) NewBoolvec(n int32) (capnp.BitList, error) {
 	err = capnp.Struct(s).SetPtr(0, l.ToPtr())
 	return l, err
 }
-
 func (s Z) Datavec() (capnp.DataList, error) {
 	if capnp.Struct(s).Uint16(0) != 40 {
 		panic("Which() != datavec")
@@ -1850,7 +1836,6 @@ func (s Z) NewDatavec(n int32) (capnp.DataList, error) {
 	err = capnp.Struct(s).SetPtr(0, l.ToPtr())
 	return l, err
 }
-
 func (s Z) Textvec() (capnp.TextList, error) {
 	if capnp.Struct(s).Uint16(0) != 41 {
 		panic("Which() != textvec")
@@ -1882,7 +1867,6 @@ func (s Z) NewTextvec(n int32) (capnp.TextList, error) {
 	err = capnp.Struct(s).SetPtr(0, l.ToPtr())
 	return l, err
 }
-
 func (s Z) Zvec() (Z_List, error) {
 	if capnp.Struct(s).Uint16(0) != 25 {
 		panic("Which() != zvec")
@@ -1914,7 +1898,6 @@ func (s Z) NewZvec(n int32) (Z_List, error) {
 	err = capnp.Struct(s).SetPtr(0, l.ToPtr())
 	return l, err
 }
-
 func (s Z) Zvecvec() (capnp.PointerList, error) {
 	if capnp.Struct(s).Uint16(0) != 26 {
 		panic("Which() != zvecvec")
@@ -1946,7 +1929,6 @@ func (s Z) NewZvecvec(n int32) (capnp.PointerList, error) {
 	err = capnp.Struct(s).SetPtr(0, l.ToPtr())
 	return l, err
 }
-
 func (s Z) Zdate() (Zdate, error) {
 	if capnp.Struct(s).Uint16(0) != 27 {
 		panic("Which() != zdate")
@@ -2042,7 +2024,6 @@ func (s Z) NewAircraftvec(n int32) (Aircraft_List, error) {
 	err = capnp.Struct(s).SetPtr(0, l.ToPtr())
 	return l, err
 }
-
 func (s Z) Aircraft() (Aircraft, error) {
 	if capnp.Struct(s).Uint16(0) != 30 {
 		panic("Which() != aircraft")
@@ -2278,7 +2259,6 @@ func (s Z) NewZdatevec(n int32) (Zdate_List, error) {
 	err = capnp.Struct(s).SetPtr(0, l.ToPtr())
 	return l, err
 }
-
 func (s Z) Zdatavec() (Zdata_List, error) {
 	if capnp.Struct(s).Uint16(0) != 38 {
 		panic("Which() != zdatavec")
@@ -2310,7 +2290,6 @@ func (s Z) NewZdatavec(n int32) (Zdata_List, error) {
 	err = capnp.Struct(s).SetPtr(0, l.ToPtr())
 	return l, err
 }
-
 func (s Z) Grp() Z_grp { return Z_grp(s) }
 
 func (s Z) SetGrp() {
@@ -2400,7 +2379,6 @@ func (s Z) NewEchoes(n int32) (Echo_List, error) {
 	err = capnp.Struct(s).SetPtr(0, l.ToPtr())
 	return l, err
 }
-
 func (s Z) AnyPtr() (capnp.Ptr, error) {
 	if capnp.Struct(s).Uint16(0) != 45 {
 		panic("Which() != anyPtr")
@@ -2438,11 +2416,12 @@ func (s Z) SetAnyStruct(v capnp.Struct) error {
 	capnp.Struct(s).SetUint16(0, 46)
 	return capnp.Struct(s).SetPtr(0, v.ToPtr())
 }
-func (s Z) AnyList() (capnp.Ptr, error) {
+func (s Z) AnyList() (capnp.List, error) {
 	if capnp.Struct(s).Uint16(0) != 47 {
 		panic("Which() != anyList")
 	}
-	return capnp.Struct(s).Ptr(0)
+	p, err := capnp.Struct(s).Ptr(0)
+	return p.List(), err
 }
 
 func (s Z) HasAnyList() bool {
@@ -2452,9 +2431,9 @@ func (s Z) HasAnyList() bool {
 	return capnp.Struct(s).HasPtr(0)
 }
 
-func (s Z) SetAnyList(v capnp.Ptr) error {
+func (s Z) SetAnyList(v capnp.List) error {
 	capnp.Struct(s).SetUint16(0, 47)
-	return capnp.Struct(s).SetPtr(0, v)
+	return capnp.Struct(s).SetPtr(0, v.ToPtr())
 }
 func (s Z) AnyCapability() capnp.Client {
 	if capnp.Struct(s).Uint16(0) != 48 {
@@ -2657,7 +2636,6 @@ func (s Counter) NewWordlist(n int32) (capnp.TextList, error) {
 	err = capnp.Struct(s).SetPtr(1, l.ToPtr())
 	return l, err
 }
-
 func (s Counter) Bitlist() (capnp.BitList, error) {
 	p, err := capnp.Struct(s).Ptr(2)
 	return capnp.BitList(p.List()), err
@@ -4422,7 +4400,6 @@ func (s HoldsText) NewLst(n int32) (capnp.TextList, error) {
 	err = capnp.Struct(s).SetPtr(1, l.ToPtr())
 	return l, err
 }
-
 func (s HoldsText) Lstlst() (capnp.PointerList, error) {
 	p, err := capnp.Struct(s).Ptr(2)
 	return capnp.PointerList(p.List()), err

--- a/internal/aircraftlib/aircraft.capnp.go
+++ b/internal/aircraftlib/aircraft.capnp.go
@@ -108,9 +108,9 @@ func NewZdate_List(s *capnp.Segment, sz int32) (Zdate_List, error) {
 // Zdate_Future is a wrapper for a Zdate promised by a client call.
 type Zdate_Future struct{ *capnp.Future }
 
-func (p Zdate_Future) Struct() (Zdate, error) {
-	s, err := p.Future.Struct()
-	return Zdate(s), err
+func (f Zdate_Future) Struct() (Zdate, error) {
+	p, err := f.Future.Ptr()
+	return Zdate(p.Struct()), err
 }
 
 type Zdata capnp.Struct
@@ -185,9 +185,9 @@ func NewZdata_List(s *capnp.Segment, sz int32) (Zdata_List, error) {
 // Zdata_Future is a wrapper for a Zdata promised by a client call.
 type Zdata_Future struct{ *capnp.Future }
 
-func (p Zdata_Future) Struct() (Zdata, error) {
-	s, err := p.Future.Struct()
-	return Zdata(s), err
+func (f Zdata_Future) Struct() (Zdata, error) {
+	p, err := f.Future.Ptr()
+	return Zdata(p.Struct()), err
 }
 
 type Airport uint16
@@ -391,9 +391,9 @@ func NewPlaneBase_List(s *capnp.Segment, sz int32) (PlaneBase_List, error) {
 // PlaneBase_Future is a wrapper for a PlaneBase promised by a client call.
 type PlaneBase_Future struct{ *capnp.Future }
 
-func (p PlaneBase_Future) Struct() (PlaneBase, error) {
-	s, err := p.Future.Struct()
-	return PlaneBase(s), err
+func (f PlaneBase_Future) Struct() (PlaneBase, error) {
+	p, err := f.Future.Ptr()
+	return PlaneBase(p.Struct()), err
 }
 
 type B737 capnp.Struct
@@ -479,11 +479,10 @@ func NewB737_List(s *capnp.Segment, sz int32) (B737_List, error) {
 // B737_Future is a wrapper for a B737 promised by a client call.
 type B737_Future struct{ *capnp.Future }
 
-func (p B737_Future) Struct() (B737, error) {
-	s, err := p.Future.Struct()
-	return B737(s), err
+func (f B737_Future) Struct() (B737, error) {
+	p, err := f.Future.Ptr()
+	return B737(p.Struct()), err
 }
-
 func (p B737_Future) Base() PlaneBase_Future {
 	return PlaneBase_Future{Future: p.Future.Field(0, nil)}
 }
@@ -571,11 +570,10 @@ func NewA320_List(s *capnp.Segment, sz int32) (A320_List, error) {
 // A320_Future is a wrapper for a A320 promised by a client call.
 type A320_Future struct{ *capnp.Future }
 
-func (p A320_Future) Struct() (A320, error) {
-	s, err := p.Future.Struct()
-	return A320(s), err
+func (f A320_Future) Struct() (A320, error) {
+	p, err := f.Future.Ptr()
+	return A320(p.Struct()), err
 }
-
 func (p A320_Future) Base() PlaneBase_Future {
 	return PlaneBase_Future{Future: p.Future.Field(0, nil)}
 }
@@ -663,11 +661,10 @@ func NewF16_List(s *capnp.Segment, sz int32) (F16_List, error) {
 // F16_Future is a wrapper for a F16 promised by a client call.
 type F16_Future struct{ *capnp.Future }
 
-func (p F16_Future) Struct() (F16, error) {
-	s, err := p.Future.Struct()
-	return F16(s), err
+func (f F16_Future) Struct() (F16, error) {
+	p, err := f.Future.Ptr()
+	return F16(p.Struct()), err
 }
-
 func (p F16_Future) Base() PlaneBase_Future {
 	return PlaneBase_Future{Future: p.Future.Field(0, nil)}
 }
@@ -825,11 +822,10 @@ func NewRegression_List(s *capnp.Segment, sz int32) (Regression_List, error) {
 // Regression_Future is a wrapper for a Regression promised by a client call.
 type Regression_Future struct{ *capnp.Future }
 
-func (p Regression_Future) Struct() (Regression, error) {
-	s, err := p.Future.Struct()
-	return Regression(s), err
+func (f Regression_Future) Struct() (Regression, error) {
+	p, err := f.Future.Ptr()
+	return Regression(p.Struct()), err
 }
-
 func (p Regression_Future) Base() PlaneBase_Future {
 	return PlaneBase_Future{Future: p.Future.Field(0, nil)}
 }
@@ -1022,19 +1018,16 @@ func NewAircraft_List(s *capnp.Segment, sz int32) (Aircraft_List, error) {
 // Aircraft_Future is a wrapper for a Aircraft promised by a client call.
 type Aircraft_Future struct{ *capnp.Future }
 
-func (p Aircraft_Future) Struct() (Aircraft, error) {
-	s, err := p.Future.Struct()
-	return Aircraft(s), err
+func (f Aircraft_Future) Struct() (Aircraft, error) {
+	p, err := f.Future.Ptr()
+	return Aircraft(p.Struct()), err
 }
-
 func (p Aircraft_Future) B737() B737_Future {
 	return B737_Future{Future: p.Future.Field(0, nil)}
 }
-
 func (p Aircraft_Future) A320() A320_Future {
 	return A320_Future{Future: p.Future.Field(0, nil)}
 }
-
 func (p Aircraft_Future) F16() F16_Future {
 	return F16_Future{Future: p.Future.Field(0, nil)}
 }
@@ -2472,57 +2465,46 @@ func NewZ_List(s *capnp.Segment, sz int32) (Z_List, error) {
 // Z_Future is a wrapper for a Z promised by a client call.
 type Z_Future struct{ *capnp.Future }
 
-func (p Z_Future) Struct() (Z, error) {
-	s, err := p.Future.Struct()
-	return Z(s), err
+func (f Z_Future) Struct() (Z, error) {
+	p, err := f.Future.Ptr()
+	return Z(p.Struct()), err
 }
-
 func (p Z_Future) Zz() Z_Future {
 	return Z_Future{Future: p.Future.Field(0, nil)}
 }
-
 func (p Z_Future) Zdate() Zdate_Future {
 	return Zdate_Future{Future: p.Future.Field(0, nil)}
 }
-
 func (p Z_Future) Zdata() Zdata_Future {
 	return Zdata_Future{Future: p.Future.Field(0, nil)}
 }
-
 func (p Z_Future) Aircraft() Aircraft_Future {
 	return Aircraft_Future{Future: p.Future.Field(0, nil)}
 }
-
 func (p Z_Future) Regression() Regression_Future {
 	return Regression_Future{Future: p.Future.Field(0, nil)}
 }
-
 func (p Z_Future) Planebase() PlaneBase_Future {
 	return PlaneBase_Future{Future: p.Future.Field(0, nil)}
 }
-
 func (p Z_Future) B737() B737_Future {
 	return B737_Future{Future: p.Future.Field(0, nil)}
 }
-
 func (p Z_Future) A320() A320_Future {
 	return A320_Future{Future: p.Future.Field(0, nil)}
 }
-
 func (p Z_Future) F16() F16_Future {
 	return F16_Future{Future: p.Future.Field(0, nil)}
 }
-
 func (p Z_Future) Grp() Z_grp_Future { return Z_grp_Future{p.Future} }
 
 // Z_grp_Future is a wrapper for a Z_grp promised by a client call.
 type Z_grp_Future struct{ *capnp.Future }
 
-func (p Z_grp_Future) Struct() (Z_grp, error) {
-	s, err := p.Future.Struct()
-	return Z_grp(s), err
+func (f Z_grp_Future) Struct() (Z_grp, error) {
+	p, err := f.Future.Ptr()
+	return Z_grp(p.Struct()), err
 }
-
 func (p Z_Future) Echo() Echo {
 	return Echo(p.Future.Field(0, nil).Client())
 }
@@ -2672,9 +2654,9 @@ func NewCounter_List(s *capnp.Segment, sz int32) (Counter_List, error) {
 // Counter_Future is a wrapper for a Counter promised by a client call.
 type Counter_Future struct{ *capnp.Future }
 
-func (p Counter_Future) Struct() (Counter, error) {
-	s, err := p.Future.Struct()
-	return Counter(s), err
+func (f Counter_Future) Struct() (Counter, error) {
+	p, err := f.Future.Ptr()
+	return Counter(p.Struct()), err
 }
 
 type Bag capnp.Struct
@@ -2760,11 +2742,10 @@ func NewBag_List(s *capnp.Segment, sz int32) (Bag_List, error) {
 // Bag_Future is a wrapper for a Bag promised by a client call.
 type Bag_Future struct{ *capnp.Future }
 
-func (p Bag_Future) Struct() (Bag, error) {
-	s, err := p.Future.Struct()
-	return Bag(s), err
+func (f Bag_Future) Struct() (Bag, error) {
+	p, err := f.Future.Ptr()
+	return Bag(p.Struct()), err
 }
-
 func (p Bag_Future) Counter() Counter_Future {
 	return Counter_Future{Future: p.Future.Field(0, nil)}
 }
@@ -2852,9 +2833,9 @@ func NewZserver_List(s *capnp.Segment, sz int32) (Zserver_List, error) {
 // Zserver_Future is a wrapper for a Zserver promised by a client call.
 type Zserver_Future struct{ *capnp.Future }
 
-func (p Zserver_Future) Struct() (Zserver, error) {
-	s, err := p.Future.Struct()
-	return Zserver(s), err
+func (f Zserver_Future) Struct() (Zserver, error) {
+	p, err := f.Future.Ptr()
+	return Zserver(p.Struct()), err
 }
 
 type Zjob capnp.Struct
@@ -2958,9 +2939,9 @@ func NewZjob_List(s *capnp.Segment, sz int32) (Zjob_List, error) {
 // Zjob_Future is a wrapper for a Zjob promised by a client call.
 type Zjob_Future struct{ *capnp.Future }
 
-func (p Zjob_Future) Struct() (Zjob, error) {
-	s, err := p.Future.Struct()
-	return Zjob(s), err
+func (f Zjob_Future) Struct() (Zjob, error) {
+	p, err := f.Future.Ptr()
+	return Zjob(p.Struct()), err
 }
 
 type VerEmpty capnp.Struct
@@ -3023,9 +3004,9 @@ func NewVerEmpty_List(s *capnp.Segment, sz int32) (VerEmpty_List, error) {
 // VerEmpty_Future is a wrapper for a VerEmpty promised by a client call.
 type VerEmpty_Future struct{ *capnp.Future }
 
-func (p VerEmpty_Future) Struct() (VerEmpty, error) {
-	s, err := p.Future.Struct()
-	return VerEmpty(s), err
+func (f VerEmpty_Future) Struct() (VerEmpty, error) {
+	p, err := f.Future.Ptr()
+	return VerEmpty(p.Struct()), err
 }
 
 type VerOneData capnp.Struct
@@ -3095,9 +3076,9 @@ func NewVerOneData_List(s *capnp.Segment, sz int32) (VerOneData_List, error) {
 // VerOneData_Future is a wrapper for a VerOneData promised by a client call.
 type VerOneData_Future struct{ *capnp.Future }
 
-func (p VerOneData_Future) Struct() (VerOneData, error) {
-	s, err := p.Future.Struct()
-	return VerOneData(s), err
+func (f VerOneData_Future) Struct() (VerOneData, error) {
+	p, err := f.Future.Ptr()
+	return VerOneData(p.Struct()), err
 }
 
 type VerTwoData capnp.Struct
@@ -3175,9 +3156,9 @@ func NewVerTwoData_List(s *capnp.Segment, sz int32) (VerTwoData_List, error) {
 // VerTwoData_Future is a wrapper for a VerTwoData promised by a client call.
 type VerTwoData_Future struct{ *capnp.Future }
 
-func (p VerTwoData_Future) Struct() (VerTwoData, error) {
-	s, err := p.Future.Struct()
-	return VerTwoData(s), err
+func (f VerTwoData_Future) Struct() (VerTwoData, error) {
+	p, err := f.Future.Ptr()
+	return VerTwoData(p.Struct()), err
 }
 
 type VerOnePtr capnp.Struct
@@ -3263,11 +3244,10 @@ func NewVerOnePtr_List(s *capnp.Segment, sz int32) (VerOnePtr_List, error) {
 // VerOnePtr_Future is a wrapper for a VerOnePtr promised by a client call.
 type VerOnePtr_Future struct{ *capnp.Future }
 
-func (p VerOnePtr_Future) Struct() (VerOnePtr, error) {
-	s, err := p.Future.Struct()
-	return VerOnePtr(s), err
+func (f VerOnePtr_Future) Struct() (VerOnePtr, error) {
+	p, err := f.Future.Ptr()
+	return VerOnePtr(p.Struct()), err
 }
-
 func (p VerOnePtr_Future) Ptr() VerOneData_Future {
 	return VerOneData_Future{Future: p.Future.Field(0, nil)}
 }
@@ -3379,15 +3359,13 @@ func NewVerTwoPtr_List(s *capnp.Segment, sz int32) (VerTwoPtr_List, error) {
 // VerTwoPtr_Future is a wrapper for a VerTwoPtr promised by a client call.
 type VerTwoPtr_Future struct{ *capnp.Future }
 
-func (p VerTwoPtr_Future) Struct() (VerTwoPtr, error) {
-	s, err := p.Future.Struct()
-	return VerTwoPtr(s), err
+func (f VerTwoPtr_Future) Struct() (VerTwoPtr, error) {
+	p, err := f.Future.Ptr()
+	return VerTwoPtr(p.Struct()), err
 }
-
 func (p VerTwoPtr_Future) Ptr1() VerOneData_Future {
 	return VerOneData_Future{Future: p.Future.Field(0, nil)}
 }
-
 func (p VerTwoPtr_Future) Ptr2() VerOneData_Future {
 	return VerOneData_Future{Future: p.Future.Field(1, nil)}
 }
@@ -3515,15 +3493,13 @@ func NewVerTwoDataTwoPtr_List(s *capnp.Segment, sz int32) (VerTwoDataTwoPtr_List
 // VerTwoDataTwoPtr_Future is a wrapper for a VerTwoDataTwoPtr promised by a client call.
 type VerTwoDataTwoPtr_Future struct{ *capnp.Future }
 
-func (p VerTwoDataTwoPtr_Future) Struct() (VerTwoDataTwoPtr, error) {
-	s, err := p.Future.Struct()
-	return VerTwoDataTwoPtr(s), err
+func (f VerTwoDataTwoPtr_Future) Struct() (VerTwoDataTwoPtr, error) {
+	p, err := f.Future.Ptr()
+	return VerTwoDataTwoPtr(p.Struct()), err
 }
-
 func (p VerTwoDataTwoPtr_Future) Ptr1() VerOneData_Future {
 	return VerOneData_Future{Future: p.Future.Field(0, nil)}
 }
-
 func (p VerTwoDataTwoPtr_Future) Ptr2() VerOneData_Future {
 	return VerOneData_Future{Future: p.Future.Field(1, nil)}
 }
@@ -3611,9 +3587,9 @@ func NewHoldsVerEmptyList_List(s *capnp.Segment, sz int32) (HoldsVerEmptyList_Li
 // HoldsVerEmptyList_Future is a wrapper for a HoldsVerEmptyList promised by a client call.
 type HoldsVerEmptyList_Future struct{ *capnp.Future }
 
-func (p HoldsVerEmptyList_Future) Struct() (HoldsVerEmptyList, error) {
-	s, err := p.Future.Struct()
-	return HoldsVerEmptyList(s), err
+func (f HoldsVerEmptyList_Future) Struct() (HoldsVerEmptyList, error) {
+	p, err := f.Future.Ptr()
+	return HoldsVerEmptyList(p.Struct()), err
 }
 
 type HoldsVerOneDataList capnp.Struct
@@ -3699,9 +3675,9 @@ func NewHoldsVerOneDataList_List(s *capnp.Segment, sz int32) (HoldsVerOneDataLis
 // HoldsVerOneDataList_Future is a wrapper for a HoldsVerOneDataList promised by a client call.
 type HoldsVerOneDataList_Future struct{ *capnp.Future }
 
-func (p HoldsVerOneDataList_Future) Struct() (HoldsVerOneDataList, error) {
-	s, err := p.Future.Struct()
-	return HoldsVerOneDataList(s), err
+func (f HoldsVerOneDataList_Future) Struct() (HoldsVerOneDataList, error) {
+	p, err := f.Future.Ptr()
+	return HoldsVerOneDataList(p.Struct()), err
 }
 
 type HoldsVerTwoDataList capnp.Struct
@@ -3787,9 +3763,9 @@ func NewHoldsVerTwoDataList_List(s *capnp.Segment, sz int32) (HoldsVerTwoDataLis
 // HoldsVerTwoDataList_Future is a wrapper for a HoldsVerTwoDataList promised by a client call.
 type HoldsVerTwoDataList_Future struct{ *capnp.Future }
 
-func (p HoldsVerTwoDataList_Future) Struct() (HoldsVerTwoDataList, error) {
-	s, err := p.Future.Struct()
-	return HoldsVerTwoDataList(s), err
+func (f HoldsVerTwoDataList_Future) Struct() (HoldsVerTwoDataList, error) {
+	p, err := f.Future.Ptr()
+	return HoldsVerTwoDataList(p.Struct()), err
 }
 
 type HoldsVerOnePtrList capnp.Struct
@@ -3875,9 +3851,9 @@ func NewHoldsVerOnePtrList_List(s *capnp.Segment, sz int32) (HoldsVerOnePtrList_
 // HoldsVerOnePtrList_Future is a wrapper for a HoldsVerOnePtrList promised by a client call.
 type HoldsVerOnePtrList_Future struct{ *capnp.Future }
 
-func (p HoldsVerOnePtrList_Future) Struct() (HoldsVerOnePtrList, error) {
-	s, err := p.Future.Struct()
-	return HoldsVerOnePtrList(s), err
+func (f HoldsVerOnePtrList_Future) Struct() (HoldsVerOnePtrList, error) {
+	p, err := f.Future.Ptr()
+	return HoldsVerOnePtrList(p.Struct()), err
 }
 
 type HoldsVerTwoPtrList capnp.Struct
@@ -3963,9 +3939,9 @@ func NewHoldsVerTwoPtrList_List(s *capnp.Segment, sz int32) (HoldsVerTwoPtrList_
 // HoldsVerTwoPtrList_Future is a wrapper for a HoldsVerTwoPtrList promised by a client call.
 type HoldsVerTwoPtrList_Future struct{ *capnp.Future }
 
-func (p HoldsVerTwoPtrList_Future) Struct() (HoldsVerTwoPtrList, error) {
-	s, err := p.Future.Struct()
-	return HoldsVerTwoPtrList(s), err
+func (f HoldsVerTwoPtrList_Future) Struct() (HoldsVerTwoPtrList, error) {
+	p, err := f.Future.Ptr()
+	return HoldsVerTwoPtrList(p.Struct()), err
 }
 
 type HoldsVerTwoTwoList capnp.Struct
@@ -4051,9 +4027,9 @@ func NewHoldsVerTwoTwoList_List(s *capnp.Segment, sz int32) (HoldsVerTwoTwoList_
 // HoldsVerTwoTwoList_Future is a wrapper for a HoldsVerTwoTwoList promised by a client call.
 type HoldsVerTwoTwoList_Future struct{ *capnp.Future }
 
-func (p HoldsVerTwoTwoList_Future) Struct() (HoldsVerTwoTwoList, error) {
-	s, err := p.Future.Struct()
-	return HoldsVerTwoTwoList(s), err
+func (f HoldsVerTwoTwoList_Future) Struct() (HoldsVerTwoTwoList, error) {
+	p, err := f.Future.Ptr()
+	return HoldsVerTwoTwoList(p.Struct()), err
 }
 
 type HoldsVerTwoTwoPlus capnp.Struct
@@ -4139,9 +4115,9 @@ func NewHoldsVerTwoTwoPlus_List(s *capnp.Segment, sz int32) (HoldsVerTwoTwoPlus_
 // HoldsVerTwoTwoPlus_Future is a wrapper for a HoldsVerTwoTwoPlus promised by a client call.
 type HoldsVerTwoTwoPlus_Future struct{ *capnp.Future }
 
-func (p HoldsVerTwoTwoPlus_Future) Struct() (HoldsVerTwoTwoPlus, error) {
-	s, err := p.Future.Struct()
-	return HoldsVerTwoTwoPlus(s), err
+func (f HoldsVerTwoTwoPlus_Future) Struct() (HoldsVerTwoTwoPlus, error) {
+	p, err := f.Future.Ptr()
+	return HoldsVerTwoTwoPlus(p.Struct()), err
 }
 
 type VerTwoTwoPlus capnp.Struct
@@ -4299,15 +4275,13 @@ func NewVerTwoTwoPlus_List(s *capnp.Segment, sz int32) (VerTwoTwoPlus_List, erro
 // VerTwoTwoPlus_Future is a wrapper for a VerTwoTwoPlus promised by a client call.
 type VerTwoTwoPlus_Future struct{ *capnp.Future }
 
-func (p VerTwoTwoPlus_Future) Struct() (VerTwoTwoPlus, error) {
-	s, err := p.Future.Struct()
-	return VerTwoTwoPlus(s), err
+func (f VerTwoTwoPlus_Future) Struct() (VerTwoTwoPlus, error) {
+	p, err := f.Future.Ptr()
+	return VerTwoTwoPlus(p.Struct()), err
 }
-
 func (p VerTwoTwoPlus_Future) Ptr1() VerTwoDataTwoPtr_Future {
 	return VerTwoDataTwoPtr_Future{Future: p.Future.Field(0, nil)}
 }
-
 func (p VerTwoTwoPlus_Future) Ptr2() VerTwoDataTwoPtr_Future {
 	return VerTwoDataTwoPtr_Future{Future: p.Future.Field(1, nil)}
 }
@@ -4436,9 +4410,9 @@ func NewHoldsText_List(s *capnp.Segment, sz int32) (HoldsText_List, error) {
 // HoldsText_Future is a wrapper for a HoldsText promised by a client call.
 type HoldsText_Future struct{ *capnp.Future }
 
-func (p HoldsText_Future) Struct() (HoldsText, error) {
-	s, err := p.Future.Struct()
-	return HoldsText(s), err
+func (f HoldsText_Future) Struct() (HoldsText, error) {
+	p, err := f.Future.Ptr()
+	return HoldsText(p.Struct()), err
 }
 
 type WrapEmpty capnp.Struct
@@ -4524,11 +4498,10 @@ func NewWrapEmpty_List(s *capnp.Segment, sz int32) (WrapEmpty_List, error) {
 // WrapEmpty_Future is a wrapper for a WrapEmpty promised by a client call.
 type WrapEmpty_Future struct{ *capnp.Future }
 
-func (p WrapEmpty_Future) Struct() (WrapEmpty, error) {
-	s, err := p.Future.Struct()
-	return WrapEmpty(s), err
+func (f WrapEmpty_Future) Struct() (WrapEmpty, error) {
+	p, err := f.Future.Ptr()
+	return WrapEmpty(p.Struct()), err
 }
-
 func (p WrapEmpty_Future) MightNotBeReallyEmpty() VerEmpty_Future {
 	return VerEmpty_Future{Future: p.Future.Field(0, nil)}
 }
@@ -4616,11 +4589,10 @@ func NewWrap2x2_List(s *capnp.Segment, sz int32) (Wrap2x2_List, error) {
 // Wrap2x2_Future is a wrapper for a Wrap2x2 promised by a client call.
 type Wrap2x2_Future struct{ *capnp.Future }
 
-func (p Wrap2x2_Future) Struct() (Wrap2x2, error) {
-	s, err := p.Future.Struct()
-	return Wrap2x2(s), err
+func (f Wrap2x2_Future) Struct() (Wrap2x2, error) {
+	p, err := f.Future.Ptr()
+	return Wrap2x2(p.Struct()), err
 }
-
 func (p Wrap2x2_Future) MightNotBeReallyEmpty() VerTwoDataTwoPtr_Future {
 	return VerTwoDataTwoPtr_Future{Future: p.Future.Field(0, nil)}
 }
@@ -4708,11 +4680,10 @@ func NewWrap2x2plus_List(s *capnp.Segment, sz int32) (Wrap2x2plus_List, error) {
 // Wrap2x2plus_Future is a wrapper for a Wrap2x2plus promised by a client call.
 type Wrap2x2plus_Future struct{ *capnp.Future }
 
-func (p Wrap2x2plus_Future) Struct() (Wrap2x2plus, error) {
-	s, err := p.Future.Struct()
-	return Wrap2x2plus(s), err
+func (f Wrap2x2plus_Future) Struct() (Wrap2x2plus, error) {
+	p, err := f.Future.Ptr()
+	return Wrap2x2plus(p.Struct()), err
 }
-
 func (p Wrap2x2plus_Future) MightNotBeReallyEmpty() VerTwoTwoPlus_Future {
 	return VerTwoTwoPlus_Future{Future: p.Future.Field(0, nil)}
 }
@@ -4808,9 +4779,9 @@ func NewVoidUnion_List(s *capnp.Segment, sz int32) (VoidUnion_List, error) {
 // VoidUnion_Future is a wrapper for a VoidUnion promised by a client call.
 type VoidUnion_Future struct{ *capnp.Future }
 
-func (p VoidUnion_Future) Struct() (VoidUnion, error) {
-	s, err := p.Future.Struct()
-	return VoidUnion(s), err
+func (f VoidUnion_Future) Struct() (VoidUnion, error) {
+	p, err := f.Future.Ptr()
+	return VoidUnion(p.Struct()), err
 }
 
 type Nester1Capn capnp.Struct
@@ -4896,9 +4867,9 @@ func NewNester1Capn_List(s *capnp.Segment, sz int32) (Nester1Capn_List, error) {
 // Nester1Capn_Future is a wrapper for a Nester1Capn promised by a client call.
 type Nester1Capn_Future struct{ *capnp.Future }
 
-func (p Nester1Capn_Future) Struct() (Nester1Capn, error) {
-	s, err := p.Future.Struct()
-	return Nester1Capn(s), err
+func (f Nester1Capn_Future) Struct() (Nester1Capn, error) {
+	p, err := f.Future.Ptr()
+	return Nester1Capn(p.Struct()), err
 }
 
 type RWTestCapn capnp.Struct
@@ -4984,9 +4955,9 @@ func NewRWTestCapn_List(s *capnp.Segment, sz int32) (RWTestCapn_List, error) {
 // RWTestCapn_Future is a wrapper for a RWTestCapn promised by a client call.
 type RWTestCapn_Future struct{ *capnp.Future }
 
-func (p RWTestCapn_Future) Struct() (RWTestCapn, error) {
-	s, err := p.Future.Struct()
-	return RWTestCapn(s), err
+func (f RWTestCapn_Future) Struct() (RWTestCapn, error) {
+	p, err := f.Future.Ptr()
+	return RWTestCapn(p.Struct()), err
 }
 
 type ListStructCapn capnp.Struct
@@ -5072,9 +5043,9 @@ func NewListStructCapn_List(s *capnp.Segment, sz int32) (ListStructCapn_List, er
 // ListStructCapn_Future is a wrapper for a ListStructCapn promised by a client call.
 type ListStructCapn_Future struct{ *capnp.Future }
 
-func (p ListStructCapn_Future) Struct() (ListStructCapn, error) {
-	s, err := p.Future.Struct()
-	return ListStructCapn(s), err
+func (f ListStructCapn_Future) Struct() (ListStructCapn, error) {
+	p, err := f.Future.Ptr()
+	return ListStructCapn(p.Struct()), err
 }
 
 type Echo capnp.Client
@@ -5306,9 +5277,9 @@ func NewEcho_echo_Params_List(s *capnp.Segment, sz int32) (Echo_echo_Params_List
 // Echo_echo_Params_Future is a wrapper for a Echo_echo_Params promised by a client call.
 type Echo_echo_Params_Future struct{ *capnp.Future }
 
-func (p Echo_echo_Params_Future) Struct() (Echo_echo_Params, error) {
-	s, err := p.Future.Struct()
-	return Echo_echo_Params(s), err
+func (f Echo_echo_Params_Future) Struct() (Echo_echo_Params, error) {
+	p, err := f.Future.Ptr()
+	return Echo_echo_Params(p.Struct()), err
 }
 
 type Echo_echo_Results capnp.Struct
@@ -5388,9 +5359,9 @@ func NewEcho_echo_Results_List(s *capnp.Segment, sz int32) (Echo_echo_Results_Li
 // Echo_echo_Results_Future is a wrapper for a Echo_echo_Results promised by a client call.
 type Echo_echo_Results_Future struct{ *capnp.Future }
 
-func (p Echo_echo_Results_Future) Struct() (Echo_echo_Results, error) {
-	s, err := p.Future.Struct()
-	return Echo_echo_Results(s), err
+func (f Echo_echo_Results_Future) Struct() (Echo_echo_Results, error) {
+	p, err := f.Future.Ptr()
+	return Echo_echo_Results(p.Struct()), err
 }
 
 type Hoth capnp.Struct
@@ -5476,11 +5447,10 @@ func NewHoth_List(s *capnp.Segment, sz int32) (Hoth_List, error) {
 // Hoth_Future is a wrapper for a Hoth promised by a client call.
 type Hoth_Future struct{ *capnp.Future }
 
-func (p Hoth_Future) Struct() (Hoth, error) {
-	s, err := p.Future.Struct()
-	return Hoth(s), err
+func (f Hoth_Future) Struct() (Hoth, error) {
+	p, err := f.Future.Ptr()
+	return Hoth(p.Struct()), err
 }
-
 func (p Hoth_Future) Base() EchoBase_Future {
 	return EchoBase_Future{Future: p.Future.Field(0, nil)}
 }
@@ -5562,11 +5532,10 @@ func NewEchoBase_List(s *capnp.Segment, sz int32) (EchoBase_List, error) {
 // EchoBase_Future is a wrapper for a EchoBase promised by a client call.
 type EchoBase_Future struct{ *capnp.Future }
 
-func (p EchoBase_Future) Struct() (EchoBase, error) {
-	s, err := p.Future.Struct()
-	return EchoBase(s), err
+func (f EchoBase_Future) Struct() (EchoBase, error) {
+	p, err := f.Future.Ptr()
+	return EchoBase(p.Struct()), err
 }
-
 func (p EchoBase_Future) Echo() Echo {
 	return Echo(p.Future.Field(0, nil).Client())
 }
@@ -5682,15 +5651,13 @@ func NewStackingRoot_List(s *capnp.Segment, sz int32) (StackingRoot_List, error)
 // StackingRoot_Future is a wrapper for a StackingRoot promised by a client call.
 type StackingRoot_Future struct{ *capnp.Future }
 
-func (p StackingRoot_Future) Struct() (StackingRoot, error) {
-	s, err := p.Future.Struct()
-	return StackingRoot(s), err
+func (f StackingRoot_Future) Struct() (StackingRoot, error) {
+	p, err := f.Future.Ptr()
+	return StackingRoot(p.Struct()), err
 }
-
 func (p StackingRoot_Future) A() StackingA_Future {
 	return StackingA_Future{Future: p.Future.Field(1, nil)}
 }
-
 func (p StackingRoot_Future) AWithDefault() StackingA_Future {
 	return StackingA_Future{Future: p.Future.Field(0, x_832bcc6686a26d56[96:128])}
 }
@@ -5786,11 +5753,10 @@ func NewStackingA_List(s *capnp.Segment, sz int32) (StackingA_List, error) {
 // StackingA_Future is a wrapper for a StackingA promised by a client call.
 type StackingA_Future struct{ *capnp.Future }
 
-func (p StackingA_Future) Struct() (StackingA, error) {
-	s, err := p.Future.Struct()
-	return StackingA(s), err
+func (f StackingA_Future) Struct() (StackingA, error) {
+	p, err := f.Future.Ptr()
+	return StackingA(p.Struct()), err
 }
-
 func (p StackingA_Future) B() StackingB_Future {
 	return StackingB_Future{Future: p.Future.Field(0, nil)}
 }
@@ -5862,9 +5828,9 @@ func NewStackingB_List(s *capnp.Segment, sz int32) (StackingB_List, error) {
 // StackingB_Future is a wrapper for a StackingB promised by a client call.
 type StackingB_Future struct{ *capnp.Future }
 
-func (p StackingB_Future) Struct() (StackingB, error) {
-	s, err := p.Future.Struct()
-	return StackingB(s), err
+func (f StackingB_Future) Struct() (StackingB, error) {
+	p, err := f.Future.Ptr()
+	return StackingB(p.Struct()), err
 }
 
 type CallSequence capnp.Client
@@ -6079,9 +6045,9 @@ func NewCallSequence_getNumber_Params_List(s *capnp.Segment, sz int32) (CallSequ
 // CallSequence_getNumber_Params_Future is a wrapper for a CallSequence_getNumber_Params promised by a client call.
 type CallSequence_getNumber_Params_Future struct{ *capnp.Future }
 
-func (p CallSequence_getNumber_Params_Future) Struct() (CallSequence_getNumber_Params, error) {
-	s, err := p.Future.Struct()
-	return CallSequence_getNumber_Params(s), err
+func (f CallSequence_getNumber_Params_Future) Struct() (CallSequence_getNumber_Params, error) {
+	p, err := f.Future.Ptr()
+	return CallSequence_getNumber_Params(p.Struct()), err
 }
 
 type CallSequence_getNumber_Results capnp.Struct
@@ -6151,9 +6117,9 @@ func NewCallSequence_getNumber_Results_List(s *capnp.Segment, sz int32) (CallSeq
 // CallSequence_getNumber_Results_Future is a wrapper for a CallSequence_getNumber_Results promised by a client call.
 type CallSequence_getNumber_Results_Future struct{ *capnp.Future }
 
-func (p CallSequence_getNumber_Results_Future) Struct() (CallSequence_getNumber_Results, error) {
-	s, err := p.Future.Struct()
-	return CallSequence_getNumber_Results(s), err
+func (f CallSequence_getNumber_Results_Future) Struct() (CallSequence_getNumber_Results, error) {
+	p, err := f.Future.Ptr()
+	return CallSequence_getNumber_Results(p.Struct()), err
 }
 
 type Pipeliner capnp.Client
@@ -6398,9 +6364,9 @@ func NewPipeliner_newPipeliner_Params_List(s *capnp.Segment, sz int32) (Pipeline
 // Pipeliner_newPipeliner_Params_Future is a wrapper for a Pipeliner_newPipeliner_Params promised by a client call.
 type Pipeliner_newPipeliner_Params_Future struct{ *capnp.Future }
 
-func (p Pipeliner_newPipeliner_Params_Future) Struct() (Pipeliner_newPipeliner_Params, error) {
-	s, err := p.Future.Struct()
-	return Pipeliner_newPipeliner_Params(s), err
+func (f Pipeliner_newPipeliner_Params_Future) Struct() (Pipeliner_newPipeliner_Params, error) {
+	p, err := f.Future.Ptr()
+	return Pipeliner_newPipeliner_Params(p.Struct()), err
 }
 
 type Pipeliner_newPipeliner_Results capnp.Struct
@@ -6491,11 +6457,10 @@ func NewPipeliner_newPipeliner_Results_List(s *capnp.Segment, sz int32) (Pipelin
 // Pipeliner_newPipeliner_Results_Future is a wrapper for a Pipeliner_newPipeliner_Results promised by a client call.
 type Pipeliner_newPipeliner_Results_Future struct{ *capnp.Future }
 
-func (p Pipeliner_newPipeliner_Results_Future) Struct() (Pipeliner_newPipeliner_Results, error) {
-	s, err := p.Future.Struct()
-	return Pipeliner_newPipeliner_Results(s), err
+func (f Pipeliner_newPipeliner_Results_Future) Struct() (Pipeliner_newPipeliner_Results, error) {
+	p, err := f.Future.Ptr()
+	return Pipeliner_newPipeliner_Results(p.Struct()), err
 }
-
 func (p Pipeliner_newPipeliner_Results_Future) Extra() *capnp.Future {
 	return p.Future.Field(0, nil)
 }
@@ -6620,9 +6585,9 @@ func NewDefaults_List(s *capnp.Segment, sz int32) (Defaults_List, error) {
 // Defaults_Future is a wrapper for a Defaults promised by a client call.
 type Defaults_Future struct{ *capnp.Future }
 
-func (p Defaults_Future) Struct() (Defaults, error) {
-	s, err := p.Future.Struct()
-	return Defaults(s), err
+func (f Defaults_Future) Struct() (Defaults, error) {
+	p, err := f.Future.Ptr()
+	return Defaults(p.Struct()), err
 }
 
 type BenchmarkA capnp.Struct
@@ -6752,9 +6717,9 @@ func NewBenchmarkA_List(s *capnp.Segment, sz int32) (BenchmarkA_List, error) {
 // BenchmarkA_Future is a wrapper for a BenchmarkA promised by a client call.
 type BenchmarkA_Future struct{ *capnp.Future }
 
-func (p BenchmarkA_Future) Struct() (BenchmarkA, error) {
-	s, err := p.Future.Struct()
-	return BenchmarkA(s), err
+func (f BenchmarkA_Future) Struct() (BenchmarkA, error) {
+	p, err := f.Future.Ptr()
+	return BenchmarkA(p.Struct()), err
 }
 
 type AllocBenchmark capnp.Struct
@@ -6840,9 +6805,9 @@ func NewAllocBenchmark_List(s *capnp.Segment, sz int32) (AllocBenchmark_List, er
 // AllocBenchmark_Future is a wrapper for a AllocBenchmark promised by a client call.
 type AllocBenchmark_Future struct{ *capnp.Future }
 
-func (p AllocBenchmark_Future) Struct() (AllocBenchmark, error) {
-	s, err := p.Future.Struct()
-	return AllocBenchmark(s), err
+func (f AllocBenchmark_Future) Struct() (AllocBenchmark, error) {
+	p, err := f.Future.Ptr()
+	return AllocBenchmark(p.Struct()), err
 }
 
 type AllocBenchmark_Field capnp.Struct
@@ -6922,9 +6887,9 @@ func NewAllocBenchmark_Field_List(s *capnp.Segment, sz int32) (AllocBenchmark_Fi
 // AllocBenchmark_Field_Future is a wrapper for a AllocBenchmark_Field promised by a client call.
 type AllocBenchmark_Field_Future struct{ *capnp.Future }
 
-func (p AllocBenchmark_Field_Future) Struct() (AllocBenchmark_Field, error) {
-	s, err := p.Future.Struct()
-	return AllocBenchmark_Field(s), err
+func (f AllocBenchmark_Field_Future) Struct() (AllocBenchmark_Field, error) {
+	p, err := f.Future.Ptr()
+	return AllocBenchmark_Field(p.Struct()), err
 }
 
 const schema_832bcc6686a26d56 = "x\xda\xacZ}t\x14U\x96\xbf\xb7\xaa;\x15\x92t" +

--- a/internal/demo/books/books.capnp.go
+++ b/internal/demo/books/books.capnp.go
@@ -93,9 +93,9 @@ func NewBook_List(s *capnp.Segment, sz int32) (Book_List, error) {
 // Book_Future is a wrapper for a Book promised by a client call.
 type Book_Future struct{ *capnp.Future }
 
-func (p Book_Future) Struct() (Book, error) {
-	s, err := p.Future.Struct()
-	return Book(s), err
+func (f Book_Future) Struct() (Book, error) {
+	p, err := f.Future.Ptr()
+	return Book(p.Struct()), err
 }
 
 const schema_85d3acc39d94e0f8 = "x\xda\x12Ht`1\xe4\xdd\xcf\xc8\xc0\x14(\xc2\xca" +

--- a/internal/schema/schema.capnp.go
+++ b/internal/schema/schema.capnp.go
@@ -159,7 +159,6 @@ func (s Node) NewParameters(n int32) (Node_Parameter_List, error) {
 	err = capnp.Struct(s).SetPtr(5, l.ToPtr())
 	return l, err
 }
-
 func (s Node) IsGeneric() bool {
 	return capnp.Struct(s).Bit(288)
 }
@@ -191,7 +190,6 @@ func (s Node) NewNestedNodes(n int32) (Node_NestedNode_List, error) {
 	err = capnp.Struct(s).SetPtr(1, l.ToPtr())
 	return l, err
 }
-
 func (s Node) Annotations() (Annotation_List, error) {
 	p, err := capnp.Struct(s).Ptr(2)
 	return Annotation_List(p.List()), err
@@ -215,7 +213,6 @@ func (s Node) NewAnnotations(n int32) (Annotation_List, error) {
 	err = capnp.Struct(s).SetPtr(2, l.ToPtr())
 	return l, err
 }
-
 func (s Node) SetFile() {
 	capnp.Struct(s).SetUint16(12, 0)
 
@@ -309,7 +306,6 @@ func (s Node_structNode) NewFields(n int32) (Field_List, error) {
 	err = capnp.Struct(s).SetPtr(3, l.ToPtr())
 	return l, err
 }
-
 func (s Node) Enum() Node_enum { return Node_enum(s) }
 
 func (s Node) SetEnum() {
@@ -350,7 +346,6 @@ func (s Node_enum) NewEnumerants(n int32) (Enumerant_List, error) {
 	err = capnp.Struct(s).SetPtr(3, l.ToPtr())
 	return l, err
 }
-
 func (s Node) Interface() Node_interface { return Node_interface(s) }
 
 func (s Node) SetInterface() {
@@ -391,7 +386,6 @@ func (s Node_interface) NewMethods(n int32) (Method_List, error) {
 	err = capnp.Struct(s).SetPtr(3, l.ToPtr())
 	return l, err
 }
-
 func (s Node_interface) Superclasses() (Superclass_List, error) {
 	p, err := capnp.Struct(s).Ptr(4)
 	return Superclass_List(p.List()), err
@@ -415,7 +409,6 @@ func (s Node_interface) NewSuperclasses(n int32) (Superclass_List, error) {
 	err = capnp.Struct(s).SetPtr(4, l.ToPtr())
 	return l, err
 }
-
 func (s Node) Const() Node_const { return Node_const(s) }
 
 func (s Node) SetConst() {
@@ -1078,7 +1071,6 @@ func (s Field) NewAnnotations(n int32) (Annotation_List, error) {
 	err = capnp.Struct(s).SetPtr(1, l.ToPtr())
 	return l, err
 }
-
 func (s Field) DiscriminantValue() uint16 {
 	return capnp.Struct(s).Uint16(2) ^ 65535
 }
@@ -1510,7 +1502,6 @@ func (s Method) NewImplicitParameters(n int32) (Node_Parameter_List, error) {
 	err = capnp.Struct(s).SetPtr(4, l.ToPtr())
 	return l, err
 }
-
 func (s Method) ParamStructType() uint64 {
 	return capnp.Struct(s).Uint64(8)
 }
@@ -2345,7 +2336,6 @@ func (s Brand_Scope) NewBind(n int32) (Brand_Binding_List, error) {
 	err = capnp.Struct(s).SetPtr(0, l.ToPtr())
 	return l, err
 }
-
 func (s Brand_Scope) SetInherit() {
 	capnp.Struct(s).SetUint16(8, 1)
 
@@ -3193,7 +3183,6 @@ func (s CodeGeneratorRequest) NewNodes(n int32) (Node_List, error) {
 	err = capnp.Struct(s).SetPtr(0, l.ToPtr())
 	return l, err
 }
-
 func (s CodeGeneratorRequest) SourceInfo() (Node_SourceInfo_List, error) {
 	p, err := capnp.Struct(s).Ptr(3)
 	return Node_SourceInfo_List(p.List()), err
@@ -3217,7 +3206,6 @@ func (s CodeGeneratorRequest) NewSourceInfo(n int32) (Node_SourceInfo_List, erro
 	err = capnp.Struct(s).SetPtr(3, l.ToPtr())
 	return l, err
 }
-
 func (s CodeGeneratorRequest) RequestedFiles() (CodeGeneratorRequest_RequestedFile_List, error) {
 	p, err := capnp.Struct(s).Ptr(1)
 	return CodeGeneratorRequest_RequestedFile_List(p.List()), err

--- a/pogs/pogs_test.go
+++ b/pogs/pogs_test.go
@@ -1225,7 +1225,7 @@ func zfill(c air.Z, g *Z) error {
 	case air.Z_Which_anyStruct:
 		return c.SetAnyStruct(g.AnyStruct)
 	case air.Z_Which_anyList:
-		return c.SetAnyList(g.AnyList.ToPtr())
+		return c.SetAnyList(g.AnyList)
 	case air.Z_Which_anyCapability:
 		return c.SetAnyCapability(g.AnyCapability)
 	default:

--- a/rpc/internal/testcapnp/test.capnp.go
+++ b/rpc/internal/testcapnp/test.capnp.go
@@ -232,9 +232,9 @@ func NewPingPong_echoNum_Params_List(s *capnp.Segment, sz int32) (PingPong_echoN
 // PingPong_echoNum_Params_Future is a wrapper for a PingPong_echoNum_Params promised by a client call.
 type PingPong_echoNum_Params_Future struct{ *capnp.Future }
 
-func (p PingPong_echoNum_Params_Future) Struct() (PingPong_echoNum_Params, error) {
-	s, err := p.Future.Struct()
-	return PingPong_echoNum_Params(s), err
+func (f PingPong_echoNum_Params_Future) Struct() (PingPong_echoNum_Params, error) {
+	p, err := f.Future.Ptr()
+	return PingPong_echoNum_Params(p.Struct()), err
 }
 
 type PingPong_echoNum_Results capnp.Struct
@@ -304,9 +304,9 @@ func NewPingPong_echoNum_Results_List(s *capnp.Segment, sz int32) (PingPong_echo
 // PingPong_echoNum_Results_Future is a wrapper for a PingPong_echoNum_Results promised by a client call.
 type PingPong_echoNum_Results_Future struct{ *capnp.Future }
 
-func (p PingPong_echoNum_Results_Future) Struct() (PingPong_echoNum_Results, error) {
-	s, err := p.Future.Struct()
-	return PingPong_echoNum_Results(s), err
+func (f PingPong_echoNum_Results_Future) Struct() (PingPong_echoNum_Results, error) {
+	p, err := f.Future.Ptr()
+	return PingPong_echoNum_Results(p.Struct()), err
 }
 
 type StreamTest capnp.Client
@@ -533,9 +533,9 @@ func NewStreamTest_push_Params_List(s *capnp.Segment, sz int32) (StreamTest_push
 // StreamTest_push_Params_Future is a wrapper for a StreamTest_push_Params promised by a client call.
 type StreamTest_push_Params_Future struct{ *capnp.Future }
 
-func (p StreamTest_push_Params_Future) Struct() (StreamTest_push_Params, error) {
-	s, err := p.Future.Struct()
-	return StreamTest_push_Params(s), err
+func (f StreamTest_push_Params_Future) Struct() (StreamTest_push_Params, error) {
+	p, err := f.Future.Ptr()
+	return StreamTest_push_Params(p.Struct()), err
 }
 
 type CapArgsTest capnp.Client
@@ -814,11 +814,10 @@ func NewCapArgsTest_call_Params_List(s *capnp.Segment, sz int32) (CapArgsTest_ca
 // CapArgsTest_call_Params_Future is a wrapper for a CapArgsTest_call_Params promised by a client call.
 type CapArgsTest_call_Params_Future struct{ *capnp.Future }
 
-func (p CapArgsTest_call_Params_Future) Struct() (CapArgsTest_call_Params, error) {
-	s, err := p.Future.Struct()
-	return CapArgsTest_call_Params(s), err
+func (f CapArgsTest_call_Params_Future) Struct() (CapArgsTest_call_Params, error) {
+	p, err := f.Future.Ptr()
+	return CapArgsTest_call_Params(p.Struct()), err
 }
-
 func (p CapArgsTest_call_Params_Future) Cap() capnp.Client {
 	return p.Future.Field(0, nil).Client()
 }
@@ -883,9 +882,9 @@ func NewCapArgsTest_call_Results_List(s *capnp.Segment, sz int32) (CapArgsTest_c
 // CapArgsTest_call_Results_Future is a wrapper for a CapArgsTest_call_Results promised by a client call.
 type CapArgsTest_call_Results_Future struct{ *capnp.Future }
 
-func (p CapArgsTest_call_Results_Future) Struct() (CapArgsTest_call_Results, error) {
-	s, err := p.Future.Struct()
-	return CapArgsTest_call_Results(s), err
+func (f CapArgsTest_call_Results_Future) Struct() (CapArgsTest_call_Results, error) {
+	p, err := f.Future.Ptr()
+	return CapArgsTest_call_Results(p.Struct()), err
 }
 
 type CapArgsTest_self_Params capnp.Struct
@@ -948,9 +947,9 @@ func NewCapArgsTest_self_Params_List(s *capnp.Segment, sz int32) (CapArgsTest_se
 // CapArgsTest_self_Params_Future is a wrapper for a CapArgsTest_self_Params promised by a client call.
 type CapArgsTest_self_Params_Future struct{ *capnp.Future }
 
-func (p CapArgsTest_self_Params_Future) Struct() (CapArgsTest_self_Params, error) {
-	s, err := p.Future.Struct()
-	return CapArgsTest_self_Params(s), err
+func (f CapArgsTest_self_Params_Future) Struct() (CapArgsTest_self_Params, error) {
+	p, err := f.Future.Ptr()
+	return CapArgsTest_self_Params(p.Struct()), err
 }
 
 type CapArgsTest_self_Results capnp.Struct
@@ -1030,11 +1029,10 @@ func NewCapArgsTest_self_Results_List(s *capnp.Segment, sz int32) (CapArgsTest_s
 // CapArgsTest_self_Results_Future is a wrapper for a CapArgsTest_self_Results promised by a client call.
 type CapArgsTest_self_Results_Future struct{ *capnp.Future }
 
-func (p CapArgsTest_self_Results_Future) Struct() (CapArgsTest_self_Results, error) {
-	s, err := p.Future.Struct()
-	return CapArgsTest_self_Results(s), err
+func (f CapArgsTest_self_Results_Future) Struct() (CapArgsTest_self_Results, error) {
+	p, err := f.Future.Ptr()
+	return CapArgsTest_self_Results(p.Struct()), err
 }
-
 func (p CapArgsTest_self_Results_Future) Self() CapArgsTest {
 	return CapArgsTest(p.Future.Field(0, nil).Client())
 }

--- a/std/capnp/compat/json/json.capnp.go
+++ b/std/capnp/compat/json/json.capnp.go
@@ -186,7 +186,6 @@ func (s Value) NewArray(n int32) (Value_List, error) {
 	err = capnp.Struct(s).SetPtr(0, l.ToPtr())
 	return l, err
 }
-
 func (s Value) Object() (Value_Field_List, error) {
 	if capnp.Struct(s).Uint16(0) != 5 {
 		panic("Which() != object")
@@ -218,7 +217,6 @@ func (s Value) NewObject(n int32) (Value_Field_List, error) {
 	err = capnp.Struct(s).SetPtr(0, l.ToPtr())
 	return l, err
 }
-
 func (s Value) Call() (Value_Call, error) {
 	if capnp.Struct(s).Uint16(0) != 6 {
 		panic("Which() != call")

--- a/std/capnp/compat/json/json.capnp.go
+++ b/std/capnp/compat/json/json.capnp.go
@@ -261,11 +261,10 @@ func NewValue_List(s *capnp.Segment, sz int32) (Value_List, error) {
 // Value_Future is a wrapper for a Value promised by a client call.
 type Value_Future struct{ *capnp.Future }
 
-func (p Value_Future) Struct() (Value, error) {
-	s, err := p.Future.Struct()
-	return Value(s), err
+func (f Value_Future) Struct() (Value, error) {
+	p, err := f.Future.Ptr()
+	return Value(p.Struct()), err
 }
-
 func (p Value_Future) Call() Value_Call_Future {
 	return Value_Call_Future{Future: p.Future.Field(0, nil)}
 }
@@ -371,11 +370,10 @@ func NewValue_Field_List(s *capnp.Segment, sz int32) (Value_Field_List, error) {
 // Value_Field_Future is a wrapper for a Value_Field promised by a client call.
 type Value_Field_Future struct{ *capnp.Future }
 
-func (p Value_Field_Future) Struct() (Value_Field, error) {
-	s, err := p.Future.Struct()
-	return Value_Field(s), err
+func (f Value_Field_Future) Struct() (Value_Field, error) {
+	p, err := f.Future.Ptr()
+	return Value_Field(p.Struct()), err
 }
-
 func (p Value_Field_Future) Value() Value_Future {
 	return Value_Future{Future: p.Future.Field(1, nil)}
 }
@@ -481,9 +479,9 @@ func NewValue_Call_List(s *capnp.Segment, sz int32) (Value_Call_List, error) {
 // Value_Call_Future is a wrapper for a Value_Call promised by a client call.
 type Value_Call_Future struct{ *capnp.Future }
 
-func (p Value_Call_Future) Struct() (Value_Call, error) {
-	s, err := p.Future.Struct()
-	return Value_Call(s), err
+func (f Value_Call_Future) Struct() (Value_Call, error) {
+	p, err := f.Future.Ptr()
+	return Value_Call(p.Struct()), err
 }
 
 type FlattenOptions capnp.Struct
@@ -563,9 +561,9 @@ func NewFlattenOptions_List(s *capnp.Segment, sz int32) (FlattenOptions_List, er
 // FlattenOptions_Future is a wrapper for a FlattenOptions promised by a client call.
 type FlattenOptions_Future struct{ *capnp.Future }
 
-func (p FlattenOptions_Future) Struct() (FlattenOptions, error) {
-	s, err := p.Future.Struct()
-	return FlattenOptions(s), err
+func (f FlattenOptions_Future) Struct() (FlattenOptions, error) {
+	p, err := f.Future.Ptr()
+	return FlattenOptions(p.Struct()), err
 }
 
 type DiscriminatorOptions capnp.Struct
@@ -663,9 +661,9 @@ func NewDiscriminatorOptions_List(s *capnp.Segment, sz int32) (DiscriminatorOpti
 // DiscriminatorOptions_Future is a wrapper for a DiscriminatorOptions promised by a client call.
 type DiscriminatorOptions_Future struct{ *capnp.Future }
 
-func (p DiscriminatorOptions_Future) Struct() (DiscriminatorOptions, error) {
-	s, err := p.Future.Struct()
-	return DiscriminatorOptions(s), err
+func (f DiscriminatorOptions_Future) Struct() (DiscriminatorOptions, error) {
+	p, err := f.Future.Ptr()
+	return DiscriminatorOptions(p.Struct()), err
 }
 
 const schema_8ef99297a43a5e34 = "x\xda\x8c\x94_h[e\x18\xc6\x9f\xe7\xfb\xce9\xeb" +

--- a/std/capnp/persistent/persistent.capnp.go
+++ b/std/capnp/persistent/persistent.capnp.go
@@ -237,11 +237,10 @@ func NewPersistent_SaveParams_List(s *capnp.Segment, sz int32) (Persistent_SaveP
 // Persistent_SaveParams_Future is a wrapper for a Persistent_SaveParams promised by a client call.
 type Persistent_SaveParams_Future struct{ *capnp.Future }
 
-func (p Persistent_SaveParams_Future) Struct() (Persistent_SaveParams, error) {
-	s, err := p.Future.Struct()
-	return Persistent_SaveParams(s), err
+func (f Persistent_SaveParams_Future) Struct() (Persistent_SaveParams, error) {
+	p, err := f.Future.Ptr()
+	return Persistent_SaveParams(p.Struct()), err
 }
-
 func (p Persistent_SaveParams_Future) SealFor() *capnp.Future {
 	return p.Future.Field(0, nil)
 }
@@ -317,11 +316,10 @@ func NewPersistent_SaveResults_List(s *capnp.Segment, sz int32) (Persistent_Save
 // Persistent_SaveResults_Future is a wrapper for a Persistent_SaveResults promised by a client call.
 type Persistent_SaveResults_Future struct{ *capnp.Future }
 
-func (p Persistent_SaveResults_Future) Struct() (Persistent_SaveResults, error) {
-	s, err := p.Future.Struct()
-	return Persistent_SaveResults(s), err
+func (f Persistent_SaveResults_Future) Struct() (Persistent_SaveResults, error) {
+	p, err := f.Future.Ptr()
+	return Persistent_SaveResults(p.Struct()), err
 }
-
 func (p Persistent_SaveResults_Future) SturdyRef() *capnp.Future {
 	return p.Future.Field(0, nil)
 }

--- a/std/capnp/rpc/rpc.capnp.go
+++ b/std/capnp/rpc/rpc.capnp.go
@@ -546,47 +546,37 @@ func NewMessage_List(s *capnp.Segment, sz int32) (Message_List, error) {
 // Message_Future is a wrapper for a Message promised by a client call.
 type Message_Future struct{ *capnp.Future }
 
-func (p Message_Future) Struct() (Message, error) {
-	s, err := p.Future.Struct()
-	return Message(s), err
+func (f Message_Future) Struct() (Message, error) {
+	p, err := f.Future.Ptr()
+	return Message(p.Struct()), err
 }
-
 func (p Message_Future) Unimplemented() Message_Future {
 	return Message_Future{Future: p.Future.Field(0, nil)}
 }
-
 func (p Message_Future) Abort() Exception_Future {
 	return Exception_Future{Future: p.Future.Field(0, nil)}
 }
-
 func (p Message_Future) Bootstrap() Bootstrap_Future {
 	return Bootstrap_Future{Future: p.Future.Field(0, nil)}
 }
-
 func (p Message_Future) Call() Call_Future {
 	return Call_Future{Future: p.Future.Field(0, nil)}
 }
-
 func (p Message_Future) Return() Return_Future {
 	return Return_Future{Future: p.Future.Field(0, nil)}
 }
-
 func (p Message_Future) Finish() Finish_Future {
 	return Finish_Future{Future: p.Future.Field(0, nil)}
 }
-
 func (p Message_Future) Resolve() Resolve_Future {
 	return Resolve_Future{Future: p.Future.Field(0, nil)}
 }
-
 func (p Message_Future) Release() Release_Future {
 	return Release_Future{Future: p.Future.Field(0, nil)}
 }
-
 func (p Message_Future) Disembargo() Disembargo_Future {
 	return Disembargo_Future{Future: p.Future.Field(0, nil)}
 }
-
 func (p Message_Future) ObsoleteSave() *capnp.Future {
 	return p.Future.Field(0, nil)
 }
@@ -596,11 +586,9 @@ func (p Message_Future) ObsoleteDelete() *capnp.Future {
 func (p Message_Future) Provide() Provide_Future {
 	return Provide_Future{Future: p.Future.Field(0, nil)}
 }
-
 func (p Message_Future) Accept() Accept_Future {
 	return Accept_Future{Future: p.Future.Field(0, nil)}
 }
-
 func (p Message_Future) Join() Join_Future {
 	return Join_Future{Future: p.Future.Field(0, nil)}
 }
@@ -684,11 +672,10 @@ func NewBootstrap_List(s *capnp.Segment, sz int32) (Bootstrap_List, error) {
 // Bootstrap_Future is a wrapper for a Bootstrap promised by a client call.
 type Bootstrap_Future struct{ *capnp.Future }
 
-func (p Bootstrap_Future) Struct() (Bootstrap, error) {
-	s, err := p.Future.Struct()
-	return Bootstrap(s), err
+func (f Bootstrap_Future) Struct() (Bootstrap, error) {
+	p, err := f.Future.Ptr()
+	return Bootstrap(p.Struct()), err
 }
-
 func (p Bootstrap_Future) DeprecatedObjectId() *capnp.Future {
 	return p.Future.Field(0, nil)
 }
@@ -899,19 +886,16 @@ func NewCall_List(s *capnp.Segment, sz int32) (Call_List, error) {
 // Call_Future is a wrapper for a Call promised by a client call.
 type Call_Future struct{ *capnp.Future }
 
-func (p Call_Future) Struct() (Call, error) {
-	s, err := p.Future.Struct()
-	return Call(s), err
+func (f Call_Future) Struct() (Call, error) {
+	p, err := f.Future.Ptr()
+	return Call(p.Struct()), err
 }
-
 func (p Call_Future) Target() MessageTarget_Future {
 	return MessageTarget_Future{Future: p.Future.Field(0, nil)}
 }
-
 func (p Call_Future) Params() Payload_Future {
 	return Payload_Future{Future: p.Future.Field(1, nil)}
 }
-
 func (p Call_Future) SendResultsTo() Call_sendResultsTo_Future {
 	return Call_sendResultsTo_Future{p.Future}
 }
@@ -919,11 +903,10 @@ func (p Call_Future) SendResultsTo() Call_sendResultsTo_Future {
 // Call_sendResultsTo_Future is a wrapper for a Call_sendResultsTo promised by a client call.
 type Call_sendResultsTo_Future struct{ *capnp.Future }
 
-func (p Call_sendResultsTo_Future) Struct() (Call_sendResultsTo, error) {
-	s, err := p.Future.Struct()
-	return Call_sendResultsTo(s), err
+func (f Call_sendResultsTo_Future) Struct() (Call_sendResultsTo, error) {
+	p, err := f.Future.Ptr()
+	return Call_sendResultsTo(p.Struct()), err
 }
-
 func (p Call_sendResultsTo_Future) ThirdParty() *capnp.Future {
 	return p.Future.Field(2, nil)
 }
@@ -1142,19 +1125,16 @@ func NewReturn_List(s *capnp.Segment, sz int32) (Return_List, error) {
 // Return_Future is a wrapper for a Return promised by a client call.
 type Return_Future struct{ *capnp.Future }
 
-func (p Return_Future) Struct() (Return, error) {
-	s, err := p.Future.Struct()
-	return Return(s), err
+func (f Return_Future) Struct() (Return, error) {
+	p, err := f.Future.Ptr()
+	return Return(p.Struct()), err
 }
-
 func (p Return_Future) Results() Payload_Future {
 	return Payload_Future{Future: p.Future.Field(0, nil)}
 }
-
 func (p Return_Future) Exception() Exception_Future {
 	return Exception_Future{Future: p.Future.Field(0, nil)}
 }
-
 func (p Return_Future) AcceptFromThirdParty() *capnp.Future {
 	return p.Future.Field(0, nil)
 }
@@ -1234,9 +1214,9 @@ func NewFinish_List(s *capnp.Segment, sz int32) (Finish_List, error) {
 // Finish_Future is a wrapper for a Finish promised by a client call.
 type Finish_Future struct{ *capnp.Future }
 
-func (p Finish_Future) Struct() (Finish, error) {
-	s, err := p.Future.Struct()
-	return Finish(s), err
+func (f Finish_Future) Struct() (Finish, error) {
+	p, err := f.Future.Ptr()
+	return Finish(p.Struct()), err
 }
 
 type Resolve capnp.Struct
@@ -1392,15 +1372,13 @@ func NewResolve_List(s *capnp.Segment, sz int32) (Resolve_List, error) {
 // Resolve_Future is a wrapper for a Resolve promised by a client call.
 type Resolve_Future struct{ *capnp.Future }
 
-func (p Resolve_Future) Struct() (Resolve, error) {
-	s, err := p.Future.Struct()
-	return Resolve(s), err
+func (f Resolve_Future) Struct() (Resolve, error) {
+	p, err := f.Future.Ptr()
+	return Resolve(p.Struct()), err
 }
-
 func (p Resolve_Future) Cap() CapDescriptor_Future {
 	return CapDescriptor_Future{Future: p.Future.Field(0, nil)}
 }
-
 func (p Resolve_Future) Exception() Exception_Future {
 	return Exception_Future{Future: p.Future.Field(0, nil)}
 }
@@ -1480,9 +1458,9 @@ func NewRelease_List(s *capnp.Segment, sz int32) (Release_List, error) {
 // Release_Future is a wrapper for a Release promised by a client call.
 type Release_Future struct{ *capnp.Future }
 
-func (p Release_Future) Struct() (Release, error) {
-	s, err := p.Future.Struct()
-	return Release(s), err
+func (f Release_Future) Struct() (Release, error) {
+	p, err := f.Future.Ptr()
+	return Release(p.Struct()), err
 }
 
 type Disembargo capnp.Struct
@@ -1650,15 +1628,13 @@ func NewDisembargo_List(s *capnp.Segment, sz int32) (Disembargo_List, error) {
 // Disembargo_Future is a wrapper for a Disembargo promised by a client call.
 type Disembargo_Future struct{ *capnp.Future }
 
-func (p Disembargo_Future) Struct() (Disembargo, error) {
-	s, err := p.Future.Struct()
-	return Disembargo(s), err
+func (f Disembargo_Future) Struct() (Disembargo, error) {
+	p, err := f.Future.Ptr()
+	return Disembargo(p.Struct()), err
 }
-
 func (p Disembargo_Future) Target() MessageTarget_Future {
 	return MessageTarget_Future{Future: p.Future.Field(0, nil)}
 }
-
 func (p Disembargo_Future) Context() Disembargo_context_Future {
 	return Disembargo_context_Future{p.Future}
 }
@@ -1666,9 +1642,9 @@ func (p Disembargo_Future) Context() Disembargo_context_Future {
 // Disembargo_context_Future is a wrapper for a Disembargo_context promised by a client call.
 type Disembargo_context_Future struct{ *capnp.Future }
 
-func (p Disembargo_context_Future) Struct() (Disembargo_context, error) {
-	s, err := p.Future.Struct()
-	return Disembargo_context(s), err
+func (f Disembargo_context_Future) Struct() (Disembargo_context, error) {
+	p, err := f.Future.Ptr()
+	return Disembargo_context(p.Struct()), err
 }
 
 type Provide capnp.Struct
@@ -1774,15 +1750,13 @@ func NewProvide_List(s *capnp.Segment, sz int32) (Provide_List, error) {
 // Provide_Future is a wrapper for a Provide promised by a client call.
 type Provide_Future struct{ *capnp.Future }
 
-func (p Provide_Future) Struct() (Provide, error) {
-	s, err := p.Future.Struct()
-	return Provide(s), err
+func (f Provide_Future) Struct() (Provide, error) {
+	p, err := f.Future.Ptr()
+	return Provide(p.Struct()), err
 }
-
 func (p Provide_Future) Target() MessageTarget_Future {
 	return MessageTarget_Future{Future: p.Future.Field(0, nil)}
 }
-
 func (p Provide_Future) Recipient() *capnp.Future {
 	return p.Future.Field(1, nil)
 }
@@ -1873,11 +1847,10 @@ func NewAccept_List(s *capnp.Segment, sz int32) (Accept_List, error) {
 // Accept_Future is a wrapper for a Accept promised by a client call.
 type Accept_Future struct{ *capnp.Future }
 
-func (p Accept_Future) Struct() (Accept, error) {
-	s, err := p.Future.Struct()
-	return Accept(s), err
+func (f Accept_Future) Struct() (Accept, error) {
+	p, err := f.Future.Ptr()
+	return Accept(p.Struct()), err
 }
-
 func (p Accept_Future) Provision() *capnp.Future {
 	return p.Future.Field(0, nil)
 }
@@ -1985,15 +1958,13 @@ func NewJoin_List(s *capnp.Segment, sz int32) (Join_List, error) {
 // Join_Future is a wrapper for a Join promised by a client call.
 type Join_Future struct{ *capnp.Future }
 
-func (p Join_Future) Struct() (Join, error) {
-	s, err := p.Future.Struct()
-	return Join(s), err
+func (f Join_Future) Struct() (Join, error) {
+	p, err := f.Future.Ptr()
+	return Join(p.Struct()), err
 }
-
 func (p Join_Future) Target() MessageTarget_Future {
 	return MessageTarget_Future{Future: p.Future.Field(0, nil)}
 }
-
 func (p Join_Future) KeyPart() *capnp.Future {
 	return p.Future.Field(1, nil)
 }
@@ -2123,11 +2094,10 @@ func NewMessageTarget_List(s *capnp.Segment, sz int32) (MessageTarget_List, erro
 // MessageTarget_Future is a wrapper for a MessageTarget promised by a client call.
 type MessageTarget_Future struct{ *capnp.Future }
 
-func (p MessageTarget_Future) Struct() (MessageTarget, error) {
-	s, err := p.Future.Struct()
-	return MessageTarget(s), err
+func (f MessageTarget_Future) Struct() (MessageTarget, error) {
+	p, err := f.Future.Ptr()
+	return MessageTarget(p.Struct()), err
 }
-
 func (p MessageTarget_Future) PromisedAnswer() PromisedAnswer_Future {
 	return PromisedAnswer_Future{Future: p.Future.Field(0, nil)}
 }
@@ -2226,11 +2196,10 @@ func NewPayload_List(s *capnp.Segment, sz int32) (Payload_List, error) {
 // Payload_Future is a wrapper for a Payload promised by a client call.
 type Payload_Future struct{ *capnp.Future }
 
-func (p Payload_Future) Struct() (Payload, error) {
-	s, err := p.Future.Struct()
-	return Payload(s), err
+func (f Payload_Future) Struct() (Payload, error) {
+	p, err := f.Future.Ptr()
+	return Payload(p.Struct()), err
 }
-
 func (p Payload_Future) Content() *capnp.Future {
 	return p.Future.Field(0, nil)
 }
@@ -2441,15 +2410,13 @@ func NewCapDescriptor_List(s *capnp.Segment, sz int32) (CapDescriptor_List, erro
 // CapDescriptor_Future is a wrapper for a CapDescriptor promised by a client call.
 type CapDescriptor_Future struct{ *capnp.Future }
 
-func (p CapDescriptor_Future) Struct() (CapDescriptor, error) {
-	s, err := p.Future.Struct()
-	return CapDescriptor(s), err
+func (f CapDescriptor_Future) Struct() (CapDescriptor, error) {
+	p, err := f.Future.Ptr()
+	return CapDescriptor(p.Struct()), err
 }
-
 func (p CapDescriptor_Future) ReceiverAnswer() PromisedAnswer_Future {
 	return PromisedAnswer_Future{Future: p.Future.Field(0, nil)}
 }
-
 func (p CapDescriptor_Future) ThirdPartyHosted() ThirdPartyCapDescriptor_Future {
 	return ThirdPartyCapDescriptor_Future{Future: p.Future.Field(0, nil)}
 }
@@ -2545,9 +2512,9 @@ func NewPromisedAnswer_List(s *capnp.Segment, sz int32) (PromisedAnswer_List, er
 // PromisedAnswer_Future is a wrapper for a PromisedAnswer promised by a client call.
 type PromisedAnswer_Future struct{ *capnp.Future }
 
-func (p PromisedAnswer_Future) Struct() (PromisedAnswer, error) {
-	s, err := p.Future.Struct()
-	return PromisedAnswer(s), err
+func (f PromisedAnswer_Future) Struct() (PromisedAnswer, error) {
+	p, err := f.Future.Ptr()
+	return PromisedAnswer(p.Struct()), err
 }
 
 type PromisedAnswer_Op capnp.Struct
@@ -2648,9 +2615,9 @@ func NewPromisedAnswer_Op_List(s *capnp.Segment, sz int32) (PromisedAnswer_Op_Li
 // PromisedAnswer_Op_Future is a wrapper for a PromisedAnswer_Op promised by a client call.
 type PromisedAnswer_Op_Future struct{ *capnp.Future }
 
-func (p PromisedAnswer_Op_Future) Struct() (PromisedAnswer_Op, error) {
-	s, err := p.Future.Struct()
-	return PromisedAnswer_Op(s), err
+func (f PromisedAnswer_Op_Future) Struct() (PromisedAnswer_Op, error) {
+	p, err := f.Future.Ptr()
+	return PromisedAnswer_Op(p.Struct()), err
 }
 
 type ThirdPartyCapDescriptor capnp.Struct
@@ -2731,11 +2698,10 @@ func NewThirdPartyCapDescriptor_List(s *capnp.Segment, sz int32) (ThirdPartyCapD
 // ThirdPartyCapDescriptor_Future is a wrapper for a ThirdPartyCapDescriptor promised by a client call.
 type ThirdPartyCapDescriptor_Future struct{ *capnp.Future }
 
-func (p ThirdPartyCapDescriptor_Future) Struct() (ThirdPartyCapDescriptor, error) {
-	s, err := p.Future.Struct()
-	return ThirdPartyCapDescriptor(s), err
+func (f ThirdPartyCapDescriptor_Future) Struct() (ThirdPartyCapDescriptor, error) {
+	p, err := f.Future.Ptr()
+	return ThirdPartyCapDescriptor(p.Struct()), err
 }
-
 func (p ThirdPartyCapDescriptor_Future) Id() *capnp.Future {
 	return p.Future.Field(0, nil)
 }
@@ -2859,9 +2825,9 @@ func NewException_List(s *capnp.Segment, sz int32) (Exception_List, error) {
 // Exception_Future is a wrapper for a Exception promised by a client call.
 type Exception_Future struct{ *capnp.Future }
 
-func (p Exception_Future) Struct() (Exception, error) {
-	s, err := p.Future.Struct()
-	return Exception(s), err
+func (f Exception_Future) Struct() (Exception, error) {
+	p, err := f.Future.Ptr()
+	return Exception(p.Struct()), err
 }
 
 type Exception_Type uint16

--- a/std/capnp/rpctwoparty/rpc-twoparty.capnp.go
+++ b/std/capnp/rpctwoparty/rpc-twoparty.capnp.go
@@ -119,9 +119,9 @@ func NewVatId_List(s *capnp.Segment, sz int32) (VatId_List, error) {
 // VatId_Future is a wrapper for a VatId promised by a client call.
 type VatId_Future struct{ *capnp.Future }
 
-func (p VatId_Future) Struct() (VatId, error) {
-	s, err := p.Future.Struct()
-	return VatId(s), err
+func (f VatId_Future) Struct() (VatId, error) {
+	p, err := f.Future.Ptr()
+	return VatId(p.Struct()), err
 }
 
 type ProvisionId capnp.Struct
@@ -191,9 +191,9 @@ func NewProvisionId_List(s *capnp.Segment, sz int32) (ProvisionId_List, error) {
 // ProvisionId_Future is a wrapper for a ProvisionId promised by a client call.
 type ProvisionId_Future struct{ *capnp.Future }
 
-func (p ProvisionId_Future) Struct() (ProvisionId, error) {
-	s, err := p.Future.Struct()
-	return ProvisionId(s), err
+func (f ProvisionId_Future) Struct() (ProvisionId, error) {
+	p, err := f.Future.Ptr()
+	return ProvisionId(p.Struct()), err
 }
 
 type RecipientId capnp.Struct
@@ -256,9 +256,9 @@ func NewRecipientId_List(s *capnp.Segment, sz int32) (RecipientId_List, error) {
 // RecipientId_Future is a wrapper for a RecipientId promised by a client call.
 type RecipientId_Future struct{ *capnp.Future }
 
-func (p RecipientId_Future) Struct() (RecipientId, error) {
-	s, err := p.Future.Struct()
-	return RecipientId(s), err
+func (f RecipientId_Future) Struct() (RecipientId, error) {
+	p, err := f.Future.Ptr()
+	return RecipientId(p.Struct()), err
 }
 
 type ThirdPartyCapId capnp.Struct
@@ -321,9 +321,9 @@ func NewThirdPartyCapId_List(s *capnp.Segment, sz int32) (ThirdPartyCapId_List, 
 // ThirdPartyCapId_Future is a wrapper for a ThirdPartyCapId promised by a client call.
 type ThirdPartyCapId_Future struct{ *capnp.Future }
 
-func (p ThirdPartyCapId_Future) Struct() (ThirdPartyCapId, error) {
-	s, err := p.Future.Struct()
-	return ThirdPartyCapId(s), err
+func (f ThirdPartyCapId_Future) Struct() (ThirdPartyCapId, error) {
+	p, err := f.Future.Ptr()
+	return ThirdPartyCapId(p.Struct()), err
 }
 
 type JoinKeyPart capnp.Struct
@@ -409,9 +409,9 @@ func NewJoinKeyPart_List(s *capnp.Segment, sz int32) (JoinKeyPart_List, error) {
 // JoinKeyPart_Future is a wrapper for a JoinKeyPart promised by a client call.
 type JoinKeyPart_Future struct{ *capnp.Future }
 
-func (p JoinKeyPart_Future) Struct() (JoinKeyPart, error) {
-	s, err := p.Future.Struct()
-	return JoinKeyPart(s), err
+func (f JoinKeyPart_Future) Struct() (JoinKeyPart, error) {
+	p, err := f.Future.Ptr()
+	return JoinKeyPart(p.Struct()), err
 }
 
 type JoinResult capnp.Struct
@@ -501,11 +501,10 @@ func NewJoinResult_List(s *capnp.Segment, sz int32) (JoinResult_List, error) {
 // JoinResult_Future is a wrapper for a JoinResult promised by a client call.
 type JoinResult_Future struct{ *capnp.Future }
 
-func (p JoinResult_Future) Struct() (JoinResult, error) {
-	s, err := p.Future.Struct()
-	return JoinResult(s), err
+func (f JoinResult_Future) Struct() (JoinResult, error) {
+	p, err := f.Future.Ptr()
+	return JoinResult(p.Struct()), err
 }
-
 func (p JoinResult_Future) Cap() *capnp.Future {
 	return p.Future.Field(0, nil)
 }

--- a/std/capnp/schema/schema.capnp.go
+++ b/std/capnp/schema/schema.capnp.go
@@ -630,69 +630,61 @@ func NewNode_List(s *capnp.Segment, sz int32) (Node_List, error) {
 // Node_Future is a wrapper for a Node promised by a client call.
 type Node_Future struct{ *capnp.Future }
 
-func (p Node_Future) Struct() (Node, error) {
-	s, err := p.Future.Struct()
-	return Node(s), err
+func (f Node_Future) Struct() (Node, error) {
+	p, err := f.Future.Ptr()
+	return Node(p.Struct()), err
 }
-
 func (p Node_Future) StructNode() Node_structNode_Future { return Node_structNode_Future{p.Future} }
 
 // Node_structNode_Future is a wrapper for a Node_structNode promised by a client call.
 type Node_structNode_Future struct{ *capnp.Future }
 
-func (p Node_structNode_Future) Struct() (Node_structNode, error) {
-	s, err := p.Future.Struct()
-	return Node_structNode(s), err
+func (f Node_structNode_Future) Struct() (Node_structNode, error) {
+	p, err := f.Future.Ptr()
+	return Node_structNode(p.Struct()), err
 }
-
 func (p Node_Future) Enum() Node_enum_Future { return Node_enum_Future{p.Future} }
 
 // Node_enum_Future is a wrapper for a Node_enum promised by a client call.
 type Node_enum_Future struct{ *capnp.Future }
 
-func (p Node_enum_Future) Struct() (Node_enum, error) {
-	s, err := p.Future.Struct()
-	return Node_enum(s), err
+func (f Node_enum_Future) Struct() (Node_enum, error) {
+	p, err := f.Future.Ptr()
+	return Node_enum(p.Struct()), err
 }
-
 func (p Node_Future) Interface() Node_interface_Future { return Node_interface_Future{p.Future} }
 
 // Node_interface_Future is a wrapper for a Node_interface promised by a client call.
 type Node_interface_Future struct{ *capnp.Future }
 
-func (p Node_interface_Future) Struct() (Node_interface, error) {
-	s, err := p.Future.Struct()
-	return Node_interface(s), err
+func (f Node_interface_Future) Struct() (Node_interface, error) {
+	p, err := f.Future.Ptr()
+	return Node_interface(p.Struct()), err
 }
-
 func (p Node_Future) Const() Node_const_Future { return Node_const_Future{p.Future} }
 
 // Node_const_Future is a wrapper for a Node_const promised by a client call.
 type Node_const_Future struct{ *capnp.Future }
 
-func (p Node_const_Future) Struct() (Node_const, error) {
-	s, err := p.Future.Struct()
-	return Node_const(s), err
+func (f Node_const_Future) Struct() (Node_const, error) {
+	p, err := f.Future.Ptr()
+	return Node_const(p.Struct()), err
 }
-
 func (p Node_const_Future) Type() Type_Future {
 	return Type_Future{Future: p.Future.Field(3, nil)}
 }
-
 func (p Node_const_Future) Value() Value_Future {
 	return Value_Future{Future: p.Future.Field(4, nil)}
 }
-
 func (p Node_Future) Annotation() Node_annotation_Future { return Node_annotation_Future{p.Future} }
 
 // Node_annotation_Future is a wrapper for a Node_annotation promised by a client call.
 type Node_annotation_Future struct{ *capnp.Future }
 
-func (p Node_annotation_Future) Struct() (Node_annotation, error) {
-	s, err := p.Future.Struct()
-	return Node_annotation(s), err
+func (f Node_annotation_Future) Struct() (Node_annotation, error) {
+	p, err := f.Future.Ptr()
+	return Node_annotation(p.Struct()), err
 }
-
 func (p Node_annotation_Future) Type() Type_Future {
 	return Type_Future{Future: p.Future.Field(3, nil)}
 }
@@ -774,9 +766,9 @@ func NewNode_Parameter_List(s *capnp.Segment, sz int32) (Node_Parameter_List, er
 // Node_Parameter_Future is a wrapper for a Node_Parameter promised by a client call.
 type Node_Parameter_Future struct{ *capnp.Future }
 
-func (p Node_Parameter_Future) Struct() (Node_Parameter, error) {
-	s, err := p.Future.Struct()
-	return Node_Parameter(s), err
+func (f Node_Parameter_Future) Struct() (Node_Parameter, error) {
+	p, err := f.Future.Ptr()
+	return Node_Parameter(p.Struct()), err
 }
 
 type Node_NestedNode capnp.Struct
@@ -864,9 +856,9 @@ func NewNode_NestedNode_List(s *capnp.Segment, sz int32) (Node_NestedNode_List, 
 // Node_NestedNode_Future is a wrapper for a Node_NestedNode promised by a client call.
 type Node_NestedNode_Future struct{ *capnp.Future }
 
-func (p Node_NestedNode_Future) Struct() (Node_NestedNode, error) {
-	s, err := p.Future.Struct()
-	return Node_NestedNode(s), err
+func (f Node_NestedNode_Future) Struct() (Node_NestedNode, error) {
+	p, err := f.Future.Ptr()
+	return Node_NestedNode(p.Struct()), err
 }
 
 type Node_SourceInfo capnp.Struct
@@ -978,9 +970,9 @@ func NewNode_SourceInfo_List(s *capnp.Segment, sz int32) (Node_SourceInfo_List, 
 // Node_SourceInfo_Future is a wrapper for a Node_SourceInfo promised by a client call.
 type Node_SourceInfo_Future struct{ *capnp.Future }
 
-func (p Node_SourceInfo_Future) Struct() (Node_SourceInfo, error) {
-	s, err := p.Future.Struct()
-	return Node_SourceInfo(s), err
+func (f Node_SourceInfo_Future) Struct() (Node_SourceInfo, error) {
+	p, err := f.Future.Ptr()
+	return Node_SourceInfo(p.Struct()), err
 }
 
 type Node_SourceInfo_Member capnp.Struct
@@ -1060,9 +1052,9 @@ func NewNode_SourceInfo_Member_List(s *capnp.Segment, sz int32) (Node_SourceInfo
 // Node_SourceInfo_Member_Future is a wrapper for a Node_SourceInfo_Member promised by a client call.
 type Node_SourceInfo_Member_Future struct{ *capnp.Future }
 
-func (p Node_SourceInfo_Member_Future) Struct() (Node_SourceInfo_Member, error) {
-	s, err := p.Future.Struct()
-	return Node_SourceInfo_Member(s), err
+func (f Node_SourceInfo_Member_Future) Struct() (Node_SourceInfo_Member, error) {
+	p, err := f.Future.Ptr()
+	return Node_SourceInfo_Member(p.Struct()), err
 }
 
 type Field capnp.Struct
@@ -1364,47 +1356,42 @@ func NewField_List(s *capnp.Segment, sz int32) (Field_List, error) {
 // Field_Future is a wrapper for a Field promised by a client call.
 type Field_Future struct{ *capnp.Future }
 
-func (p Field_Future) Struct() (Field, error) {
-	s, err := p.Future.Struct()
-	return Field(s), err
+func (f Field_Future) Struct() (Field, error) {
+	p, err := f.Future.Ptr()
+	return Field(p.Struct()), err
 }
-
 func (p Field_Future) Slot() Field_slot_Future { return Field_slot_Future{p.Future} }
 
 // Field_slot_Future is a wrapper for a Field_slot promised by a client call.
 type Field_slot_Future struct{ *capnp.Future }
 
-func (p Field_slot_Future) Struct() (Field_slot, error) {
-	s, err := p.Future.Struct()
-	return Field_slot(s), err
+func (f Field_slot_Future) Struct() (Field_slot, error) {
+	p, err := f.Future.Ptr()
+	return Field_slot(p.Struct()), err
 }
-
 func (p Field_slot_Future) Type() Type_Future {
 	return Type_Future{Future: p.Future.Field(2, nil)}
 }
-
 func (p Field_slot_Future) DefaultValue() Value_Future {
 	return Value_Future{Future: p.Future.Field(3, nil)}
 }
-
 func (p Field_Future) Group() Field_group_Future { return Field_group_Future{p.Future} }
 
 // Field_group_Future is a wrapper for a Field_group promised by a client call.
 type Field_group_Future struct{ *capnp.Future }
 
-func (p Field_group_Future) Struct() (Field_group, error) {
-	s, err := p.Future.Struct()
-	return Field_group(s), err
+func (f Field_group_Future) Struct() (Field_group, error) {
+	p, err := f.Future.Ptr()
+	return Field_group(p.Struct()), err
 }
-
 func (p Field_Future) Ordinal() Field_ordinal_Future { return Field_ordinal_Future{p.Future} }
 
 // Field_ordinal_Future is a wrapper for a Field_ordinal promised by a client call.
 type Field_ordinal_Future struct{ *capnp.Future }
 
-func (p Field_ordinal_Future) Struct() (Field_ordinal, error) {
-	s, err := p.Future.Struct()
-	return Field_ordinal(s), err
+func (f Field_ordinal_Future) Struct() (Field_ordinal, error) {
+	p, err := f.Future.Ptr()
+	return Field_ordinal(p.Struct()), err
 }
 
 type Enumerant capnp.Struct
@@ -1516,9 +1503,9 @@ func NewEnumerant_List(s *capnp.Segment, sz int32) (Enumerant_List, error) {
 // Enumerant_Future is a wrapper for a Enumerant promised by a client call.
 type Enumerant_Future struct{ *capnp.Future }
 
-func (p Enumerant_Future) Struct() (Enumerant, error) {
-	s, err := p.Future.Struct()
-	return Enumerant(s), err
+func (f Enumerant_Future) Struct() (Enumerant, error) {
+	p, err := f.Future.Ptr()
+	return Enumerant(p.Struct()), err
 }
 
 type Superclass capnp.Struct
@@ -1612,11 +1599,10 @@ func NewSuperclass_List(s *capnp.Segment, sz int32) (Superclass_List, error) {
 // Superclass_Future is a wrapper for a Superclass promised by a client call.
 type Superclass_Future struct{ *capnp.Future }
 
-func (p Superclass_Future) Struct() (Superclass, error) {
-	s, err := p.Future.Struct()
-	return Superclass(s), err
+func (f Superclass_Future) Struct() (Superclass, error) {
+	p, err := f.Future.Ptr()
+	return Superclass(p.Struct()), err
 }
-
 func (p Superclass_Future) Brand() Brand_Future {
 	return Brand_Future{Future: p.Future.Field(0, nil)}
 }
@@ -1817,15 +1803,13 @@ func NewMethod_List(s *capnp.Segment, sz int32) (Method_List, error) {
 // Method_Future is a wrapper for a Method promised by a client call.
 type Method_Future struct{ *capnp.Future }
 
-func (p Method_Future) Struct() (Method, error) {
-	s, err := p.Future.Struct()
-	return Method(s), err
+func (f Method_Future) Struct() (Method, error) {
+	p, err := f.Future.Ptr()
+	return Method(p.Struct()), err
 }
-
 func (p Method_Future) ParamBrand() Brand_Future {
 	return Brand_Future{Future: p.Future.Field(2, nil)}
 }
-
 func (p Method_Future) ResultBrand() Brand_Future {
 	return Brand_Future{Future: p.Future.Field(3, nil)}
 }
@@ -2397,77 +2381,67 @@ func NewType_List(s *capnp.Segment, sz int32) (Type_List, error) {
 // Type_Future is a wrapper for a Type promised by a client call.
 type Type_Future struct{ *capnp.Future }
 
-func (p Type_Future) Struct() (Type, error) {
-	s, err := p.Future.Struct()
-	return Type(s), err
+func (f Type_Future) Struct() (Type, error) {
+	p, err := f.Future.Ptr()
+	return Type(p.Struct()), err
 }
-
 func (p Type_Future) List() Type_list_Future { return Type_list_Future{p.Future} }
 
 // Type_list_Future is a wrapper for a Type_list promised by a client call.
 type Type_list_Future struct{ *capnp.Future }
 
-func (p Type_list_Future) Struct() (Type_list, error) {
-	s, err := p.Future.Struct()
-	return Type_list(s), err
+func (f Type_list_Future) Struct() (Type_list, error) {
+	p, err := f.Future.Ptr()
+	return Type_list(p.Struct()), err
 }
-
 func (p Type_list_Future) ElementType() Type_Future {
 	return Type_Future{Future: p.Future.Field(0, nil)}
 }
-
 func (p Type_Future) Enum() Type_enum_Future { return Type_enum_Future{p.Future} }
 
 // Type_enum_Future is a wrapper for a Type_enum promised by a client call.
 type Type_enum_Future struct{ *capnp.Future }
 
-func (p Type_enum_Future) Struct() (Type_enum, error) {
-	s, err := p.Future.Struct()
-	return Type_enum(s), err
+func (f Type_enum_Future) Struct() (Type_enum, error) {
+	p, err := f.Future.Ptr()
+	return Type_enum(p.Struct()), err
 }
-
 func (p Type_enum_Future) Brand() Brand_Future {
 	return Brand_Future{Future: p.Future.Field(0, nil)}
 }
-
 func (p Type_Future) StructType() Type_structType_Future { return Type_structType_Future{p.Future} }
 
 // Type_structType_Future is a wrapper for a Type_structType promised by a client call.
 type Type_structType_Future struct{ *capnp.Future }
 
-func (p Type_structType_Future) Struct() (Type_structType, error) {
-	s, err := p.Future.Struct()
-	return Type_structType(s), err
+func (f Type_structType_Future) Struct() (Type_structType, error) {
+	p, err := f.Future.Ptr()
+	return Type_structType(p.Struct()), err
 }
-
 func (p Type_structType_Future) Brand() Brand_Future {
 	return Brand_Future{Future: p.Future.Field(0, nil)}
 }
-
 func (p Type_Future) Interface() Type_interface_Future { return Type_interface_Future{p.Future} }
 
 // Type_interface_Future is a wrapper for a Type_interface promised by a client call.
 type Type_interface_Future struct{ *capnp.Future }
 
-func (p Type_interface_Future) Struct() (Type_interface, error) {
-	s, err := p.Future.Struct()
-	return Type_interface(s), err
+func (f Type_interface_Future) Struct() (Type_interface, error) {
+	p, err := f.Future.Ptr()
+	return Type_interface(p.Struct()), err
 }
-
 func (p Type_interface_Future) Brand() Brand_Future {
 	return Brand_Future{Future: p.Future.Field(0, nil)}
 }
-
 func (p Type_Future) AnyPointer() Type_anyPointer_Future { return Type_anyPointer_Future{p.Future} }
 
 // Type_anyPointer_Future is a wrapper for a Type_anyPointer promised by a client call.
 type Type_anyPointer_Future struct{ *capnp.Future }
 
-func (p Type_anyPointer_Future) Struct() (Type_anyPointer, error) {
-	s, err := p.Future.Struct()
-	return Type_anyPointer(s), err
+func (f Type_anyPointer_Future) Struct() (Type_anyPointer, error) {
+	p, err := f.Future.Ptr()
+	return Type_anyPointer(p.Struct()), err
 }
-
 func (p Type_anyPointer_Future) Unconstrained() Type_anyPointer_unconstrained_Future {
 	return Type_anyPointer_unconstrained_Future{p.Future}
 }
@@ -2475,11 +2449,10 @@ func (p Type_anyPointer_Future) Unconstrained() Type_anyPointer_unconstrained_Fu
 // Type_anyPointer_unconstrained_Future is a wrapper for a Type_anyPointer_unconstrained promised by a client call.
 type Type_anyPointer_unconstrained_Future struct{ *capnp.Future }
 
-func (p Type_anyPointer_unconstrained_Future) Struct() (Type_anyPointer_unconstrained, error) {
-	s, err := p.Future.Struct()
-	return Type_anyPointer_unconstrained(s), err
+func (f Type_anyPointer_unconstrained_Future) Struct() (Type_anyPointer_unconstrained, error) {
+	p, err := f.Future.Ptr()
+	return Type_anyPointer_unconstrained(p.Struct()), err
 }
-
 func (p Type_anyPointer_Future) Parameter() Type_anyPointer_parameter_Future {
 	return Type_anyPointer_parameter_Future{p.Future}
 }
@@ -2487,11 +2460,10 @@ func (p Type_anyPointer_Future) Parameter() Type_anyPointer_parameter_Future {
 // Type_anyPointer_parameter_Future is a wrapper for a Type_anyPointer_parameter promised by a client call.
 type Type_anyPointer_parameter_Future struct{ *capnp.Future }
 
-func (p Type_anyPointer_parameter_Future) Struct() (Type_anyPointer_parameter, error) {
-	s, err := p.Future.Struct()
-	return Type_anyPointer_parameter(s), err
+func (f Type_anyPointer_parameter_Future) Struct() (Type_anyPointer_parameter, error) {
+	p, err := f.Future.Ptr()
+	return Type_anyPointer_parameter(p.Struct()), err
 }
-
 func (p Type_anyPointer_Future) ImplicitMethodParameter() Type_anyPointer_implicitMethodParameter_Future {
 	return Type_anyPointer_implicitMethodParameter_Future{p.Future}
 }
@@ -2499,9 +2471,9 @@ func (p Type_anyPointer_Future) ImplicitMethodParameter() Type_anyPointer_implic
 // Type_anyPointer_implicitMethodParameter_Future is a wrapper for a Type_anyPointer_implicitMethodParameter promised by a client call.
 type Type_anyPointer_implicitMethodParameter_Future struct{ *capnp.Future }
 
-func (p Type_anyPointer_implicitMethodParameter_Future) Struct() (Type_anyPointer_implicitMethodParameter, error) {
-	s, err := p.Future.Struct()
-	return Type_anyPointer_implicitMethodParameter(s), err
+func (f Type_anyPointer_implicitMethodParameter_Future) Struct() (Type_anyPointer_implicitMethodParameter, error) {
+	p, err := f.Future.Ptr()
+	return Type_anyPointer_implicitMethodParameter(p.Struct()), err
 }
 
 type Brand capnp.Struct
@@ -2587,9 +2559,9 @@ func NewBrand_List(s *capnp.Segment, sz int32) (Brand_List, error) {
 // Brand_Future is a wrapper for a Brand promised by a client call.
 type Brand_Future struct{ *capnp.Future }
 
-func (p Brand_Future) Struct() (Brand, error) {
-	s, err := p.Future.Struct()
-	return Brand(s), err
+func (f Brand_Future) Struct() (Brand, error) {
+	p, err := f.Future.Ptr()
+	return Brand(p.Struct()), err
 }
 
 type Brand_Scope capnp.Struct
@@ -2717,9 +2689,9 @@ func NewBrand_Scope_List(s *capnp.Segment, sz int32) (Brand_Scope_List, error) {
 // Brand_Scope_Future is a wrapper for a Brand_Scope promised by a client call.
 type Brand_Scope_Future struct{ *capnp.Future }
 
-func (p Brand_Scope_Future) Struct() (Brand_Scope, error) {
-	s, err := p.Future.Struct()
-	return Brand_Scope(s), err
+func (f Brand_Scope_Future) Struct() (Brand_Scope, error) {
+	p, err := f.Future.Ptr()
+	return Brand_Scope(p.Struct()), err
 }
 
 type Brand_Binding capnp.Struct
@@ -2840,11 +2812,10 @@ func NewBrand_Binding_List(s *capnp.Segment, sz int32) (Brand_Binding_List, erro
 // Brand_Binding_Future is a wrapper for a Brand_Binding promised by a client call.
 type Brand_Binding_Future struct{ *capnp.Future }
 
-func (p Brand_Binding_Future) Struct() (Brand_Binding, error) {
-	s, err := p.Future.Struct()
-	return Brand_Binding(s), err
+func (f Brand_Binding_Future) Struct() (Brand_Binding, error) {
+	p, err := f.Future.Ptr()
+	return Brand_Binding(p.Struct()), err
 }
-
 func (p Brand_Binding_Future) Type() Type_Future {
 	return Type_Future{Future: p.Future.Field(0, nil)}
 }
@@ -3235,11 +3206,10 @@ func NewValue_List(s *capnp.Segment, sz int32) (Value_List, error) {
 // Value_Future is a wrapper for a Value promised by a client call.
 type Value_Future struct{ *capnp.Future }
 
-func (p Value_Future) Struct() (Value, error) {
-	s, err := p.Future.Struct()
-	return Value(s), err
+func (f Value_Future) Struct() (Value, error) {
+	p, err := f.Future.Ptr()
+	return Value(p.Struct()), err
 }
-
 func (p Value_Future) List() *capnp.Future {
 	return p.Future.Field(0, nil)
 }
@@ -3365,15 +3335,13 @@ func NewAnnotation_List(s *capnp.Segment, sz int32) (Annotation_List, error) {
 // Annotation_Future is a wrapper for a Annotation promised by a client call.
 type Annotation_Future struct{ *capnp.Future }
 
-func (p Annotation_Future) Struct() (Annotation, error) {
-	s, err := p.Future.Struct()
-	return Annotation(s), err
+func (f Annotation_Future) Struct() (Annotation, error) {
+	p, err := f.Future.Ptr()
+	return Annotation(p.Struct()), err
 }
-
 func (p Annotation_Future) Brand() Brand_Future {
 	return Brand_Future{Future: p.Future.Field(1, nil)}
 }
-
 func (p Annotation_Future) Value() Value_Future {
 	return Value_Future{Future: p.Future.Field(0, nil)}
 }
@@ -3535,9 +3503,9 @@ func NewCapnpVersion_List(s *capnp.Segment, sz int32) (CapnpVersion_List, error)
 // CapnpVersion_Future is a wrapper for a CapnpVersion promised by a client call.
 type CapnpVersion_Future struct{ *capnp.Future }
 
-func (p CapnpVersion_Future) Struct() (CapnpVersion, error) {
-	s, err := p.Future.Struct()
-	return CapnpVersion(s), err
+func (f CapnpVersion_Future) Struct() (CapnpVersion, error) {
+	p, err := f.Future.Ptr()
+	return CapnpVersion(p.Struct()), err
 }
 
 type CodeGeneratorRequest capnp.Struct
@@ -3693,11 +3661,10 @@ func NewCodeGeneratorRequest_List(s *capnp.Segment, sz int32) (CodeGeneratorRequ
 // CodeGeneratorRequest_Future is a wrapper for a CodeGeneratorRequest promised by a client call.
 type CodeGeneratorRequest_Future struct{ *capnp.Future }
 
-func (p CodeGeneratorRequest_Future) Struct() (CodeGeneratorRequest, error) {
-	s, err := p.Future.Struct()
-	return CodeGeneratorRequest(s), err
+func (f CodeGeneratorRequest_Future) Struct() (CodeGeneratorRequest, error) {
+	p, err := f.Future.Ptr()
+	return CodeGeneratorRequest(p.Struct()), err
 }
-
 func (p CodeGeneratorRequest_Future) CapnpVersion() CapnpVersion_Future {
 	return CapnpVersion_Future{Future: p.Future.Field(2, nil)}
 }
@@ -3811,9 +3778,9 @@ func NewCodeGeneratorRequest_RequestedFile_List(s *capnp.Segment, sz int32) (Cod
 // CodeGeneratorRequest_RequestedFile_Future is a wrapper for a CodeGeneratorRequest_RequestedFile promised by a client call.
 type CodeGeneratorRequest_RequestedFile_Future struct{ *capnp.Future }
 
-func (p CodeGeneratorRequest_RequestedFile_Future) Struct() (CodeGeneratorRequest_RequestedFile, error) {
-	s, err := p.Future.Struct()
-	return CodeGeneratorRequest_RequestedFile(s), err
+func (f CodeGeneratorRequest_RequestedFile_Future) Struct() (CodeGeneratorRequest_RequestedFile, error) {
+	p, err := f.Future.Ptr()
+	return CodeGeneratorRequest_RequestedFile(p.Struct()), err
 }
 
 type CodeGeneratorRequest_RequestedFile_Import capnp.Struct
@@ -3901,9 +3868,9 @@ func NewCodeGeneratorRequest_RequestedFile_Import_List(s *capnp.Segment, sz int3
 // CodeGeneratorRequest_RequestedFile_Import_Future is a wrapper for a CodeGeneratorRequest_RequestedFile_Import promised by a client call.
 type CodeGeneratorRequest_RequestedFile_Import_Future struct{ *capnp.Future }
 
-func (p CodeGeneratorRequest_RequestedFile_Import_Future) Struct() (CodeGeneratorRequest_RequestedFile_Import, error) {
-	s, err := p.Future.Struct()
-	return CodeGeneratorRequest_RequestedFile_Import(s), err
+func (f CodeGeneratorRequest_RequestedFile_Import_Future) Struct() (CodeGeneratorRequest_RequestedFile_Import, error) {
+	p, err := f.Future.Ptr()
+	return CodeGeneratorRequest_RequestedFile_Import(p.Struct()), err
 }
 
 const schema_a93fc509624c72d9 = "x\xda\xacz{\x90\x1c\xd5u\xf79\xb7\xe7\xb1\xaff" +

--- a/std/capnp/schema/schema.capnp.go
+++ b/std/capnp/schema/schema.capnp.go
@@ -166,7 +166,6 @@ func (s Node) NewParameters(n int32) (Node_Parameter_List, error) {
 	err = capnp.Struct(s).SetPtr(5, l.ToPtr())
 	return l, err
 }
-
 func (s Node) IsGeneric() bool {
 	return capnp.Struct(s).Bit(288)
 }
@@ -198,7 +197,6 @@ func (s Node) NewNestedNodes(n int32) (Node_NestedNode_List, error) {
 	err = capnp.Struct(s).SetPtr(1, l.ToPtr())
 	return l, err
 }
-
 func (s Node) Annotations() (Annotation_List, error) {
 	p, err := capnp.Struct(s).Ptr(2)
 	return Annotation_List(p.List()), err
@@ -222,7 +220,6 @@ func (s Node) NewAnnotations(n int32) (Annotation_List, error) {
 	err = capnp.Struct(s).SetPtr(2, l.ToPtr())
 	return l, err
 }
-
 func (s Node) SetFile() {
 	capnp.Struct(s).SetUint16(12, 0)
 
@@ -316,7 +313,6 @@ func (s Node_structNode) NewFields(n int32) (Field_List, error) {
 	err = capnp.Struct(s).SetPtr(3, l.ToPtr())
 	return l, err
 }
-
 func (s Node) Enum() Node_enum { return Node_enum(s) }
 
 func (s Node) SetEnum() {
@@ -357,7 +353,6 @@ func (s Node_enum) NewEnumerants(n int32) (Enumerant_List, error) {
 	err = capnp.Struct(s).SetPtr(3, l.ToPtr())
 	return l, err
 }
-
 func (s Node) Interface() Node_interface { return Node_interface(s) }
 
 func (s Node) SetInterface() {
@@ -398,7 +393,6 @@ func (s Node_interface) NewMethods(n int32) (Method_List, error) {
 	err = capnp.Struct(s).SetPtr(3, l.ToPtr())
 	return l, err
 }
-
 func (s Node_interface) Superclasses() (Superclass_List, error) {
 	p, err := capnp.Struct(s).Ptr(4)
 	return Superclass_List(p.List()), err
@@ -422,7 +416,6 @@ func (s Node_interface) NewSuperclasses(n int32) (Superclass_List, error) {
 	err = capnp.Struct(s).SetPtr(4, l.ToPtr())
 	return l, err
 }
-
 func (s Node) Const() Node_const { return Node_const(s) }
 
 func (s Node) SetConst() {
@@ -1212,7 +1205,6 @@ func (s Field) NewAnnotations(n int32) (Annotation_List, error) {
 	err = capnp.Struct(s).SetPtr(1, l.ToPtr())
 	return l, err
 }
-
 func (s Field) DiscriminantValue() uint16 {
 	return capnp.Struct(s).Uint16(2) ^ 65535
 }
@@ -1725,7 +1717,6 @@ func (s Method) NewImplicitParameters(n int32) (Node_Parameter_List, error) {
 	err = capnp.Struct(s).SetPtr(4, l.ToPtr())
 	return l, err
 }
-
 func (s Method) ParamStructType() uint64 {
 	return capnp.Struct(s).Uint64(8)
 }
@@ -2709,7 +2700,6 @@ func (s Brand_Scope) NewBind(n int32) (Brand_Binding_List, error) {
 	err = capnp.Struct(s).SetPtr(0, l.ToPtr())
 	return l, err
 }
-
 func (s Brand_Scope) SetInherit() {
 	capnp.Struct(s).SetUint16(8, 1)
 
@@ -3644,7 +3634,6 @@ func (s CodeGeneratorRequest) NewNodes(n int32) (Node_List, error) {
 	err = capnp.Struct(s).SetPtr(0, l.ToPtr())
 	return l, err
 }
-
 func (s CodeGeneratorRequest) SourceInfo() (Node_SourceInfo_List, error) {
 	p, err := capnp.Struct(s).Ptr(3)
 	return Node_SourceInfo_List(p.List()), err
@@ -3668,7 +3657,6 @@ func (s CodeGeneratorRequest) NewSourceInfo(n int32) (Node_SourceInfo_List, erro
 	err = capnp.Struct(s).SetPtr(3, l.ToPtr())
 	return l, err
 }
-
 func (s CodeGeneratorRequest) RequestedFiles() (CodeGeneratorRequest_RequestedFile_List, error) {
 	p, err := capnp.Struct(s).Ptr(1)
 	return CodeGeneratorRequest_RequestedFile_List(p.List()), err

--- a/std/capnp/stream/stream.capnp.go
+++ b/std/capnp/stream/stream.capnp.go
@@ -68,9 +68,9 @@ func NewStreamResult_List(s *capnp.Segment, sz int32) (StreamResult_List, error)
 // StreamResult_Future is a wrapper for a StreamResult promised by a client call.
 type StreamResult_Future struct{ *capnp.Future }
 
-func (p StreamResult_Future) Struct() (StreamResult, error) {
-	s, err := p.Future.Struct()
-	return StreamResult(s), err
+func (f StreamResult_Future) Struct() (StreamResult, error) {
+	p, err := f.Future.Ptr()
+	return StreamResult(p.Struct()), err
 }
 
 const schema_86c366a91393f3f8 = "x\xda\x12\x88p`1\xe4\xcdgb`\x0a\x94ae" +


### PR DESCRIPTION
This PR adds code generation for the `AnyList` type.  To do so, it adds a `capnp.Future.List()` method that is analogous to `capnp.Future.Struct()`.

Note:  in a future effort, we should probably rename the `Struct()` method on generated `*_Future` types to something like `Wait()`.