### PR TITLE
Rename server.Call.Ack() -> .Go()

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -376,8 +376,8 @@ implemented Calculator:
 	})
 	val := result.Value().Get()
 
-A note about message ordering: when implementing a server method, you
-are responsible for acknowledging delivery of a method call.  Failure to
-do so can cause deadlocks.  See the server.Ack function for more details.
+A note about message ordering: by default, only one method per server will
+be invoked at a time; when implementing a server method which blocks or takes
+a long time, you calling the server.Go function to unblock future calls.
 */
 package capnp // import "capnproto.org/go/capnp/v3"

--- a/rpc/flow_test.go
+++ b/rpc/flow_test.go
@@ -139,7 +139,7 @@ func TestFixedFlowLimit(t *testing.T) {
 type slowStreamTestServer struct{}
 
 func (slowStreamTestServer) Push(ctx context.Context, p testcapnp.StreamTest_push) error {
-	p.Ack()
+	p.Go()
 	// Take a while processing this, so calls can build up
 	time.Sleep(200 * time.Millisecond)
 	return nil

--- a/rpc/level0_test.go
+++ b/rpc/level0_test.go
@@ -1440,7 +1440,7 @@ func TestRecvCancel(t *testing.T) {
 	retcapShutdown := make(chan struct{})
 	srv := newServer(func(ctx context.Context, call *server.Call) error {
 		// Wait until canceled
-		call.Ack()
+		call.Go()
 		<-ctx.Done()
 		close(callCancel)
 

--- a/rpc/level1_test.go
+++ b/rpc/level1_test.go
@@ -796,7 +796,7 @@ func TestIssue3(t *testing.T) {
 			},
 		})
 		defer release()
-		call.Ack()
+		call.Go()
 		callbackResult, err := ans.Struct()
 		if err != nil {
 			return fmt.Errorf("callback: %v", err)

--- a/rpc/shutdown_test.go
+++ b/rpc/shutdown_test.go
@@ -53,7 +53,7 @@ type dropPingServer struct {
 }
 
 func (s dropPingServer) EchoNum(ctx context.Context, p testcapnp.PingPong_echoNum) error {
-	p.Ack()
+	p.Go()
 	close(s.readyCh)
 	<-ctx.Done()
 	return nil


### PR DESCRIPTION
Also improve some of the docs involving it.

Fixes #289