### PR TITLE
Minor cleanup: use the 'any' alias introduced in go 1.18

### DIFF
--- a/capability.go
+++ b/capability.go
@@ -498,7 +498,7 @@ func (c Client) State() ClientState {
 
 // A Brand is an opaque value used to identify a capability.
 type Brand struct {
-	Value interface{}
+	Value any
 }
 
 // ClientState is a snapshot of a client's identity.

--- a/capnpc-go/capnpc-go_test.go
+++ b/capnpc-go/capnpc-go_test.go
@@ -421,13 +421,13 @@ func traceGenerator(g *generator) (getCalls func() []renderCall) {
 	return func() []renderCall { return tr.calls }
 }
 
-func (tr *traceRenderer) Render(params interface{}) error {
+func (tr *traceRenderer) Render(params any) error {
 	tr.calls = append(tr.calls, renderCall{params})
 	return tr.renderer.Render(params)
 }
 
 type renderCall struct {
-	params interface{}
+	params any
 }
 
 func (rc renderCall) String() string {

--- a/error.go
+++ b/error.go
@@ -33,10 +33,10 @@ func IsDisconnected(e error) bool {
 	return exc.TypeOf(e) == exc.Disconnected
 }
 
-func errorf(format string, args ...interface{}) error {
+func errorf(format string, args ...any) error {
 	return capnperr.Failedf(format, args...)
 }
 
-func annotatef(err error, format string, args ...interface{}) error {
+func annotatef(err error, format string, args ...any) error {
 	return capnperr.Annotatef(err, format, args...)
 }

--- a/exc/exc.go
+++ b/exc/exc.go
@@ -84,7 +84,7 @@ func (f Annotator) Failed(err error) *Exception {
 	return f.New(Failed, err)
 }
 
-func (f Annotator) Failedf(format string, args ...interface{}) *Exception {
+func (f Annotator) Failedf(format string, args ...any) *Exception {
 	return f.Failed(fmt.Errorf(format, args...))
 }
 
@@ -92,7 +92,7 @@ func (f Annotator) Disconnected(err error) *Exception {
 	return f.New(Disconnected, err)
 }
 
-func (f Annotator) Disconnectedf(format string, args ...interface{}) *Exception {
+func (f Annotator) Disconnectedf(format string, args ...any) *Exception {
 	return f.Disconnected(fmt.Errorf(format, args...))
 }
 
@@ -100,7 +100,7 @@ func (f Annotator) Unimplemented(err error) *Exception {
 	return f.New(Unimplemented, err)
 }
 
-func (f Annotator) Unimplementedf(format string, args ...interface{}) *Exception {
+func (f Annotator) Unimplementedf(format string, args ...any) *Exception {
 	return f.Unimplemented(fmt.Errorf(format, args...))
 }
 
@@ -108,6 +108,6 @@ func (f Annotator) Annotate(err error, msg string) *Exception {
 	return Annotate(string(f), msg, err)
 }
 
-func (f Annotator) Annotatef(err error, format string, args ...interface{}) *Exception {
+func (f Annotator) Annotatef(err error, format string, args ...any) *Exception {
 	return f.Annotate(err, fmt.Sprintf(format, args...))
 }

--- a/metadata.go
+++ b/metadata.go
@@ -4,7 +4,7 @@ import (
 	"sync"
 )
 
-// Metadata is a morally a map[interface{}]interface{} which implements
+// Metadata is a morally a map[any]any which implements
 // sync.Locker; it is used by the rpc system to attach bookkeeping
 // information to various objects.
 //
@@ -12,7 +12,7 @@ import (
 // after its first use.
 type Metadata struct {
 	mu     sync.Mutex
-	values map[interface{}]interface{}
+	values map[any]any
 }
 
 // Lock the metadata map.
@@ -27,24 +27,24 @@ func (m *Metadata) Unlock() {
 
 // Look up key in the map. Returns the value, and a boolean which is
 // false if the key was not present.
-func (m *Metadata) Get(key interface{}) (value interface{}, ok bool) {
+func (m *Metadata) Get(key any) (value any, ok bool) {
 	value, ok = m.values[key]
 	return
 }
 
 // Insert the key, value pair into the map.
-func (m *Metadata) Put(key, value interface{}) {
+func (m *Metadata) Put(key, value any) {
 	m.values[key] = value
 }
 
 // Delete the key from the map.
-func (m *Metadata) Delete(key interface{}) {
+func (m *Metadata) Delete(key any) {
 	delete(m.values, key)
 }
 
 // Allocate and return a freshly initialized Metadata.
 func NewMetadata() *Metadata {
 	return &Metadata{
-		values: make(map[interface{}]interface{}),
+		values: make(map[any]any),
 	}
 }

--- a/pogs/embed_test.go
+++ b/pogs/embed_test.go
@@ -287,7 +287,7 @@ func TestExtract_EmbedCollide(t *testing.T) {
 
 	tests := []struct {
 		name string
-		want interface{}
+		want any
 	}{
 		{"top", &VerOneDataTop{Val: 123}},
 		{"no tags", &VerOneDataNoTags{}},
@@ -311,7 +311,7 @@ func TestExtract_EmbedCollide(t *testing.T) {
 func TestInsert_EmbedCollide(t *testing.T) {
 	tests := []struct {
 		name string
-		in   interface{}
+		in   any
 		val  int16
 	}{
 		{"top", &VerOneDataTop{Val: 123, VerVal: VerVal{456}}, 123},

--- a/pogs/extract.go
+++ b/pogs/extract.go
@@ -12,7 +12,7 @@ import (
 )
 
 // Extract copies s into val, a pointer to a Go struct.
-func Extract(val interface{}, typeID uint64, s capnp.Struct) error {
+func Extract(val any, typeID uint64, s capnp.Struct) error {
 	e := new(extracter)
 	err := e.extractStruct(reflect.ValueOf(val), typeID, s)
 	if err != nil {

--- a/pogs/insert.go
+++ b/pogs/insert.go
@@ -12,7 +12,7 @@ import (
 )
 
 // Insert copies val, a pointer to a Go struct, into s.
-func Insert(typeID uint64, s capnp.Struct, val interface{}) error {
+func Insert(typeID uint64, s capnp.Struct, val any) error {
 	ins := new(inserter)
 	err := ins.insertStruct(typeID, s, reflect.ValueOf(val))
 	if err != nil {

--- a/rpc/level0_test.go
+++ b/rpc/level0_test.go
@@ -1866,7 +1866,7 @@ func finishTest(t errorfer, conn *rpc.Conn, p2 rpc.Transport) {
 }
 
 type errorfer interface {
-	Errorf(string, ...interface{})
+	Errorf(string, ...any)
 }
 
 func newServer(impl func(context.Context, *server.Call) error, shutdown shutdownFunc) capnp.Client {
@@ -2067,7 +2067,7 @@ func canceledContext(parent context.Context) context.Context {
 
 type testErrorReporter struct {
 	tb interface {
-		Log(...interface{})
+		Log(...any)
 		Fail()
 	}
 	fail bool

--- a/server/server.go
+++ b/server/server.go
@@ -81,7 +81,7 @@ type Shutdowner interface {
 // capnp.ClientHook interface.
 type Server struct {
 	methods  sortedMethods
-	brand    interface{}
+	brand    any
 	shutdown Shutdowner
 
 	// Cancels handleCallsCtx
@@ -106,7 +106,7 @@ type Server struct {
 // If shutdown is nil then the server's shutdown is a no-op.  The server
 // guarantees message delivery order by blocking each call on the
 // return of the previous call or a call to Call.Go.
-func New(methods []Method, brand interface{}, shutdown Shutdowner) *Server {
+func New(methods []Method, brand any, shutdown Shutdowner) *Server {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	srv := &Server{
@@ -247,13 +247,13 @@ func (srv *Server) Shutdown() {
 // IsServer reports whether a brand returned by capnp.Client.Brand
 // originated from Server.Brand, and returns the brand argument passed
 // to New.
-func IsServer(brand capnp.Brand) (_ interface{}, ok bool) {
+func IsServer(brand capnp.Brand) (_ any, ok bool) {
 	sb, ok := brand.Value.(serverBrand)
 	return sb.x, ok
 }
 
 type serverBrand struct {
-	x interface{}
+	x any
 }
 
 func sendArgsToStruct(s capnp.Send) (capnp.Struct, error) {
@@ -328,6 +328,6 @@ func newError(msg string) error {
 	return exc.New(exc.Failed, "capnp server", msg)
 }
 
-func errorf(format string, args ...interface{}) error {
+func errorf(format string, args ...any) error {
 	return newError(fmt.Sprintf(format, args...))
 }


### PR DESCRIPTION
...instead of interface{}