### PR TITLE
transport: Use a sync.Pool in NewMessage() 

### DIFF
--- a/rpc/bench_test.go
+++ b/rpc/bench_test.go
@@ -6,9 +6,55 @@ import (
 	"testing"
 
 	"capnproto.org/go/capnp/v3"
+	"capnproto.org/go/capnp/v3/flowcontrol"
 	"capnproto.org/go/capnp/v3/rpc"
 	testcp "capnproto.org/go/capnp/v3/rpc/internal/testcapnp"
+	"capnproto.org/go/capnp/v3/std/capnp/stream"
 )
+
+func BenchmarkStreaming(b *testing.B) {
+	ctx := context.Background()
+	p1, p2 := net.Pipe()
+	srv := testcp.StreamTest_ServerToClient(nullStream{})
+	conn1 := rpc.NewConn(rpc.NewStreamTransport(p1), &rpc.Options{
+		BootstrapClient: capnp.Client(srv),
+	})
+	defer conn1.Close()
+	conn2 := rpc.NewConn(rpc.NewStreamTransport(p2), nil)
+	defer conn2.Close()
+	bootstrap := testcp.StreamTest(conn2.Bootstrap(ctx))
+	defer bootstrap.Release()
+	var (
+		futures      []stream.StreamResult_Future
+		releaseFuncs []capnp.ReleaseFunc
+	)
+	bootstrap.SetFlowLimiter(flowcontrol.NewFixedLimiter(1 << 9))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for j := 0; j < 1<<16; j++ {
+			fut, rel := bootstrap.Push(ctx, nil)
+			futures = append(futures, fut)
+			releaseFuncs = append(releaseFuncs, rel)
+		}
+	}
+	for i, fut := range futures {
+		_, err := fut.Struct()
+		if err != nil {
+			b.Errorf("Error waiting on future #%v: %v", i, err)
+		}
+	}
+	for _, rel := range releaseFuncs {
+		rel()
+	}
+}
+
+// nullStream implements testcp.StreamTest, ignoring the data it is sent.
+type nullStream struct {
+}
+
+func (nullStream) Push(context.Context, testcp.StreamTest_push) error {
+	return nil
+}
 
 func BenchmarkPingPong(b *testing.B) {
 	p1, p2 := net.Pipe()

--- a/rpc/bench_test.go
+++ b/rpc/bench_test.go
@@ -2,18 +2,18 @@ package rpc_test
 
 import (
 	"context"
+	"net"
 	"testing"
 
 	"capnproto.org/go/capnp/v3"
 	"capnproto.org/go/capnp/v3/rpc"
 	testcp "capnproto.org/go/capnp/v3/rpc/internal/testcapnp"
-	"capnproto.org/go/capnp/v3/rpc/transport"
 )
 
 func BenchmarkPingPong(b *testing.B) {
-	p1, p2 := transport.NewPipe(1)
+	p1, p2 := net.Pipe()
 	srv := testcp.PingPong_ServerToClient(pingPongServer{})
-	conn1 := rpc.NewConn(rpc.NewTransport(p2), &rpc.Options{
+	conn1 := rpc.NewConn(rpc.NewStreamTransport(p2), &rpc.Options{
 		ErrorReporter:   testErrorReporter{tb: b},
 		BootstrapClient: capnp.Client(srv),
 	})
@@ -23,7 +23,7 @@ func BenchmarkPingPong(b *testing.B) {
 			b.Error("conn1.Close:", err)
 		}
 	}()
-	conn2 := rpc.NewConn(rpc.NewTransport(p1), &rpc.Options{
+	conn2 := rpc.NewConn(rpc.NewStreamTransport(p1), &rpc.Options{
 		ErrorReporter: testErrorReporter{tb: b},
 	})
 	defer func() {


### PR DESCRIPTION
(stacked on top of #346; merge that first).

This cuts down on allocations a lot, see:

```
$ go tool pprof before.mem
File: rpc.test
Type: alloc_space
Time: Nov 23, 2022 at 9:43pm (EST)
Entering interactive mode (type "help" for commands, "o" for options)
(pprof) top
Showing nodes accounting for 632.75MB, 76.25% of 829.88MB total
Dropped 47 nodes (cum <= 4.15MB)
Showing top 10 nodes out of 70
      flat  flat%   sum%        cum   cum%
  209.20MB 25.21% 25.21%   209.20MB 25.21%  capnproto.org/go/capnp/v3.(*MultiSegmentArena).Allocate
   86.01MB 10.36% 35.57%   115.01MB 13.86%  capnproto.org/go/capnp/v3/rpc/transport.(*ctxReader).Read
   85.51MB 10.30% 45.88%   122.51MB 14.76%  capnproto.org/go/capnp/v3/rpc/transport.(*ctxWriteCloser).write
   66.01MB  7.95% 53.83%    66.01MB  7.95%  net.(*pipeDeadline).set
   50.51MB  6.09% 59.92%    57.01MB  6.87%  capnproto.org/go/capnp/v3.NewPromise (inline)
   47.51MB  5.72% 65.64%   173.52MB 20.91%  capnproto.org/go/capnp/v3.(*Decoder).Decode
      29MB  3.49% 69.14%   238.20MB 28.70%  capnproto.org/go/capnp/v3.NewMessage
      23MB  2.77% 71.91%       23MB  2.77%  capnproto.org/go/capnp/v3/internal/chanmutex.NewLocked (inline)
   20.50MB  2.47% 74.38%   258.71MB 31.17%  capnproto.org/go/capnp/v3/rpc/transport.(*transport).NewMessage
   15.50MB  1.87% 76.25%   175.08MB 21.10%  capnproto.org/go/capnp/v3/rpc.(*Conn).handleCall

$ go tool pprof after.mem
File: rpc.test
Type: alloc_space
Time: Nov 23, 2022 at 9:43pm (EST)
Entering interactive mode (type "help" for commands, "o" for options)
(pprof) top
Showing nodes accounting for 457.05MB, 72.35% of 631.73MB total
Dropped 45 nodes (cum <= 3.16MB)
Showing top 10 nodes out of 68
      flat  flat%   sum%        cum   cum%
   93.51MB 14.80% 14.80%   132.51MB 20.98%  capnproto.org/go/capnp/v3/rpc/transport.(*ctxReader).Read
   84.01MB 13.30% 28.10%   120.51MB 19.08%  capnproto.org/go/capnp/v3/rpc/transport.(*ctxWriteCloser).write
   75.51MB 11.95% 40.05%    75.51MB 11.95%  net.(*pipeDeadline).set
   46.01MB  7.28% 47.34%   187.02MB 29.60%  capnproto.org/go/capnp/v3.(*Decoder).Decode
   39.01MB  6.17% 53.51%    46.51MB  7.36%  capnproto.org/go/capnp/v3.NewPromise (inline)
      32MB  5.07% 58.58%       32MB  5.07%  capnproto.org/go/capnp/v3.NewMessage
      25MB  3.96% 62.53%       25MB  3.96%  capnproto.org/go/capnp/v3/internal/chanmutex.NewLocked (inline)
   23.50MB  3.72% 66.25%    56.01MB  8.87%  capnproto.org/go/capnp/v3/rpc/transport.(*transport).NewMessage
      20MB  3.17% 69.42%   110.02MB 17.42%  capnproto.org/go/capnp/v3/rpc.(*Conn).handleCall
   18.51MB  2.93% 72.35%    18.51MB  2.93%  capnproto.org/go/capnp/v3.(*Metadata).Put
```

Profiles are from the BenchmarkStreaming benchmark. Running time wasn't
significantly changed.

We should also try pooling buffers for messages we are reading in, which
currently still allocate on each message.