### PR TITLE
Use a sync.Pool for MultiSegmentArenas

### DIFF
--- a/message.go
+++ b/message.go
@@ -110,7 +110,7 @@ func NewSingleSegmentMessage(b []byte) (msg *Message, first *Segment) {
 	return msg, first
 }
 
-// Analogous to NewSingleSegmentMessage, but using MutliSegment.
+// Analogous to NewSingleSegmentMessage, but using MultiSegment.
 func NewMultiSegmentMessage(b [][]byte) (msg *Message, first *Segment) {
 	msg, first, err := NewMessage(MultiSegment(b))
 	if err != nil {
@@ -480,7 +480,41 @@ type MultiSegmentArena [][]byte
 // they are full.  b MAY be nil.  Callers MAY use b to populate the
 // buffer for reading or to reserve memory of a specific size.
 func MultiSegment(b [][]byte) *MultiSegmentArena {
+	if b == nil {
+		return multiSegmentPool.Get().(*MultiSegmentArena)
+	}
+	return multiSegment(b)
+}
+
+// Return this arena to an internal sync.Pool of arenas that can be
+// re-used. Any time MultiSegment(nil) is called, arenas from this
+// pool will be used if available, which can help reduce memory
+// allocations. Calling Release however is optional; if not done
+// the garbage collector will release the memory per usual.
+func (msa *MultiSegmentArena) Release() {
+	for i, v := range *msa {
+		// Clear the memory, so there's no junk in here for the next use:
+		for j, _ := range v {
+			v[j] = 0
+		}
+
+		// Truncate the segment, since we use the length as the marker for
+		// what's allocated:
+		(*msa)[i] = v[:0]
+	}
+	(*msa) = (*msa)[:0] // Hide the segments
+	multiSegmentPool.Put(msa)
+}
+
+// Like MultiSegment, but doesn't use the pool
+func multiSegment(b [][]byte) *MultiSegmentArena {
 	return (*MultiSegmentArena)(&b)
+}
+
+var multiSegmentPool = sync.Pool{
+	New: func() any {
+		return multiSegment(nil)
+	},
 }
 
 // demuxArena slices b into a multi-segment arena.  It assumes that
@@ -514,7 +548,11 @@ func (msa *MultiSegmentArena) Data(id SegmentID) ([]byte, error) {
 
 func (msa *MultiSegmentArena) Allocate(sz Size, segs map[SegmentID]*Segment) (SegmentID, []byte, error) {
 	var total int64
-	for i, data := range *msa {
+	for i := 0; i < cap(*msa); i++ {
+		if i == len(*msa) {
+			(*msa) = (*msa)[:i+1]
+		}
+		data := (*msa)[i]
 		id := SegmentID(i)
 		if s := segs[id]; s != nil {
 			data = s.data

--- a/message.go
+++ b/message.go
@@ -489,8 +489,12 @@ func MultiSegment(b [][]byte) *MultiSegmentArena {
 // Return this arena to an internal sync.Pool of arenas that can be
 // re-used. Any time MultiSegment(nil) is called, arenas from this
 // pool will be used if available, which can help reduce memory
-// allocations. Calling Release however is optional; if not done
-// the garbage collector will release the memory per usual.
+// allocations.
+//
+// All segments will be zeroed before re-use.
+//
+// Calling Release is optional; if not done the garbage collector
+// will release the memory per usual.
 func (msa *MultiSegmentArena) Release() {
 	for i, v := range *msa {
 		// Clear the memory, so there's no junk in here for the next use:


### PR DESCRIPTION
Superseeds #347. note that relative to #347 this does a bit more work in cleanup to make sure memory is properly zeroed and we don't mis-report the number of segments when we get a new arena, though these weren't caught in testing on the other PR.

Benchmark results are similar.

While working on this, I caught a bug in the transport tests: the test assume that it is safe to call the ReleaseFunc returned from NewMessage multiple times, which was incidentally true before but undocmented. This patch documents this invariant, and also ensures that it holds even when release() actually does something with the arena.