### PR TITLE
Add a few things to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,14 @@
 TAGS
 *~
 *.swp
+
+# Common extensions for coverage/profling outputs:
 *.out
+*.cpu
+*.mem
+
+# Test executables:
+*.test
 
 # Bazel
 /bazel-bin


### PR DESCRIPTION
I've found myself wanting these when doing perf work. Notably:

- `go test -bench` seems to actually write out and save the test executable, unlike normal `go test`
- It's nice to have separate extensions for cpu & memory profiles.