### PR TITLE
Fix a bug pertaining to casting struct lists to pointer lists

### DIFF
--- a/list.go
+++ b/list.go
@@ -188,7 +188,12 @@ func (p List) primitiveElem(i int, expectedSize ObjectSize) (address, error) {
 		// This is programmer error, not input error.
 		panic("list element out of bounds")
 	}
-	if p.flags&isBitList != 0 || p.flags&isCompositeList == 0 && p.size != expectedSize || p.flags&isCompositeList != 0 && (p.size.DataSize < expectedSize.DataSize || p.size.PointerCount < expectedSize.PointerCount) {
+	if p.flags&isBitList != 0 ||
+		p.flags&isCompositeList == 0 && p.size != expectedSize ||
+		p.flags&isCompositeList != 0 &&
+			(p.size.DataSize < expectedSize.DataSize ||
+				p.size.PointerCount < expectedSize.PointerCount) {
+
 		return 0, errorf("mismatched list element size")
 	}
 	addr, ok := p.off.element(int32(i), p.size.totalSize())
@@ -351,6 +356,7 @@ func (p PointerList) At(i int) (Ptr, error) {
 	if err != nil {
 		return Ptr{}, err
 	}
+	addr += address(p.size.DataSize)
 	return p.seg.readPtr(addr, p.depthLimit)
 }
 


### PR DESCRIPTION
Yesterday Kenton looped me in on https://capnproto.org/news/2022-11-30-CVE-2022-46149-security-advisory.html so I could see if we were affected too. We aren't, but I found a different (non-security) bug in the relevant area of the code.

See the comment on the test.

The change to the if condition is just formatting; I found it difficult to read when trying to understand it.
