### PR TITLE
Expand streaming benchmark.

### DIFF
--- a/rpc/bench_test.go
+++ b/rpc/bench_test.go
@@ -2,6 +2,7 @@ package rpc_test
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"testing"
 
@@ -12,7 +13,29 @@ import (
 	"capnproto.org/go/capnp/v3/std/capnp/stream"
 )
 
+type benchmarkStreamingConfig struct {
+	FlowLimit    int64
+	MessageCount int
+	MessageSize  int
+}
+
 func BenchmarkStreaming(b *testing.B) {
+	cfg := benchmarkStreamingConfig{
+		MessageSize: 32,
+	}
+	for i := 0; i < 10; i++ {
+		cfg.MessageSize *= 2
+		cfg.MessageCount = 1 << 16
+		cfg.FlowLimit = int64(cfg.MessageSize) * (1 << 12)
+		b.Run(fmt.Sprintf("MessageSize=0x%x,MessageCount=0x%x,FlowLimit=0x%x",
+			cfg.MessageSize, cfg.MessageCount, cfg.FlowLimit),
+			func(b *testing.B) {
+				benchmarkStreaming(b, &cfg)
+			})
+	}
+}
+
+func benchmarkStreaming(b *testing.B, cfg *benchmarkStreamingConfig) {
 	ctx := context.Background()
 	p1, p2 := net.Pipe()
 	srv := testcp.StreamTest_ServerToClient(nullStream{})
@@ -28,11 +51,14 @@ func BenchmarkStreaming(b *testing.B) {
 		futures      []stream.StreamResult_Future
 		releaseFuncs []capnp.ReleaseFunc
 	)
-	bootstrap.SetFlowLimiter(flowcontrol.NewFixedLimiter(1 << 9))
+	bootstrap.SetFlowLimiter(flowcontrol.NewFixedLimiter(cfg.FlowLimit))
+	data := make([]byte, cfg.MessageSize)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		for j := 0; j < 1<<16; j++ {
-			fut, rel := bootstrap.Push(ctx, nil)
+		for j := 0; j < cfg.MessageCount; j++ {
+			fut, rel := bootstrap.Push(ctx, func(p testcp.StreamTest_push_Params) error {
+				return p.SetData(data)
+			})
 			futures = append(futures, fut)
 			releaseFuncs = append(releaseFuncs, rel)
 		}


### PR DESCRIPTION
Test with different message sizes & limits.

Before the message sizes we were seeing were tiny, giving the impression that things like NewPromise() were comparable. Now we test with a number of different message sizes (from 64B through 128MiB).

The profiler is now telling me more intuitive things, like we're allocating a lot of memory in Decoder.Decode().