### PR TITLE
Pool buffers when decoding

### DIFF
--- a/exp/bufferpool/pool.go
+++ b/exp/bufferpool/pool.go
@@ -15,10 +15,9 @@ type Pool struct {
 	buckets [nBuckets]sync.Pool
 }
 
-// Get a buffer of the given length. its capacity may be larger than the
+// Get a buffer of the given length. Its capacity may be larger than the
 // requested size.
 func (p *Pool) Get(size int) []byte {
-
 	for i := 0; i < nBuckets; i++ {
 		capacity := 1 << i
 		if capacity >= size {

--- a/exp/bufferpool/pool.go
+++ b/exp/bufferpool/pool.go
@@ -1,0 +1,53 @@
+// Package bufferpool supports object pooling for byte buffers.
+package bufferpool
+
+import "sync"
+
+const (
+	nBuckets = 20
+)
+
+// A default global pool.
+var Default Pool
+
+// A pool of buffers, in variable sizes.
+type Pool struct {
+	buckets [nBuckets]sync.Pool
+}
+
+// Get a buffer of the given length. its capacity may be larger than the
+// requested size.
+func (p *Pool) Get(size int) []byte {
+
+	for i := 0; i < nBuckets; i++ {
+		capacity := 1 << i
+		if capacity >= size {
+			var ret []byte
+			item := p.buckets[i].Get()
+			if item == nil {
+				ret = make([]byte, capacity)
+			} else {
+				ret = item.([]byte)
+			}
+			ret = ret[:size]
+			return ret
+		}
+	}
+	return make([]byte, size)
+}
+
+// Return a buffer to the pool. Zeros the slice (but not the full backing array)
+// before making it available for future use.
+func (p *Pool) Put(buf []byte) {
+	for i := 0; i < len(buf); i++ {
+		buf[i] = 0
+	}
+
+	capacity := cap(buf)
+	for i := 0; i < nBuckets; i++ {
+		if (1 << i) == capacity {
+			p.buckets[i].Put(buf[:capacity])
+			return
+		}
+	}
+}

--- a/rpc/bench_test.go
+++ b/rpc/bench_test.go
@@ -2,6 +2,7 @@ package rpc_test
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"testing"
 
@@ -12,7 +13,29 @@ import (
 	"capnproto.org/go/capnp/v3/std/capnp/stream"
 )
 
+type benchmarkStreamingConfig struct {
+	FlowLimit    int64
+	MessageCount int
+	MessageSize  int
+}
+
 func BenchmarkStreaming(b *testing.B) {
+	cfg := benchmarkStreamingConfig{
+		MessageSize: 32,
+	}
+	for i := 0; i < 10; i++ {
+		cfg.MessageSize *= 2
+		cfg.MessageCount = 1 << 16
+		cfg.FlowLimit = int64(cfg.MessageSize) * (1 << 12)
+		b.Run(fmt.Sprintf("MessageSize=0x%x,MessageCount=0x%x,FlowLimit=0x%x",
+			cfg.MessageSize, cfg.MessageCount, cfg.FlowLimit),
+			func(b *testing.B) {
+				benchmarkStreaming(b, &cfg)
+			})
+	}
+}
+
+func benchmarkStreaming(b *testing.B, cfg *benchmarkStreamingConfig) {
 	ctx := context.Background()
 	p1, p2 := net.Pipe()
 	srv := testcp.StreamTest_ServerToClient(nullStream{})
@@ -28,11 +51,14 @@ func BenchmarkStreaming(b *testing.B) {
 		futures      []stream.StreamResult_Future
 		releaseFuncs []capnp.ReleaseFunc
 	)
-	bootstrap.SetFlowLimiter(flowcontrol.NewFixedLimiter(1 << 9))
+	bootstrap.SetFlowLimiter(flowcontrol.NewFixedLimiter(cfg.FlowLimit))
+	data := make([]byte, cfg.MessageSize)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		for j := 0; j < 1<<16; j++ {
-			fut, rel := bootstrap.Push(ctx, nil)
+		for j := 0; j < cfg.MessageCount; j++ {
+			fut, rel := bootstrap.Push(ctx, func(p testcp.StreamTest_push_Params) error {
+				return p.SetData(data)
+			})
 			futures = append(futures, fut)
 			releaseFuncs = append(releaseFuncs, rel)
 		}

--- a/rpc/transport/pipe.go
+++ b/rpc/transport/pipe.go
@@ -72,6 +72,8 @@ func (p *pipe) Decode() (*capnp.Message, error) {
 
 }
 
+func (*pipe) ReleaseMessage(*capnp.Message) {}
+
 func (p *pipe) Close() error {
 	close(p.closed)
 	syncutil.With(&p.sendMu, func() {


### PR DESCRIPTION
This reduces memory allocation substantially, however the running time
of the benchmark is actually slightly higher, so we should analyze this
a bit before deciding to keep it -- perhaps test it out on some real
workloads. Full results below

Marking this as a draft until we decide what to do. Also, this includes #362, which should be merged first.

Before
------

```
goos: linux
goarch: amd64
pkg: capnproto.org/go/capnp/v3/rpc
cpu: 11th Gen Intel(R) Core(TM) i5-1135G7 @ 2.40GHz
BenchmarkStreaming/MessageSize=0x40,MessageCount=0x10000,FlowLimit=0x40000-8         	       1	1260956046 ns/op
BenchmarkStreaming/MessageSize=0x80,MessageCount=0x10000,FlowLimit=0x80000-8         	       1	1265583297 ns/op
BenchmarkStreaming/MessageSize=0x100,MessageCount=0x10000,FlowLimit=0x100000-8       	       1	1255628601 ns/op
BenchmarkStreaming/MessageSize=0x200,MessageCount=0x10000,FlowLimit=0x200000-8       	       1	1251080129 ns/op
BenchmarkStreaming/MessageSize=0x400,MessageCount=0x10000,FlowLimit=0x400000-8       	       1	1408313704 ns/op
BenchmarkStreaming/MessageSize=0x800,MessageCount=0x10000,FlowLimit=0x800000-8       	       1	1466526073 ns/op
BenchmarkStreaming/MessageSize=0x1000,MessageCount=0x10000,FlowLimit=0x1000000-8     	       1	1474721308 ns/op
BenchmarkStreaming/MessageSize=0x2000,MessageCount=0x10000,FlowLimit=0x2000000-8     	       1	1547092192 ns/op
BenchmarkStreaming/MessageSize=0x4000,MessageCount=0x10000,FlowLimit=0x4000000-8     	       1	1701996495 ns/op
BenchmarkStreaming/MessageSize=0x8000,MessageCount=0x10000,FlowLimit=0x8000000-8     	       1	2092478622 ns/op
PASS
ok  	capnproto.org/go/capnp/v3/rpc	15.106s

$ go tool pprof before.cpu
File: rpc.test
Type: cpu
Time: Nov 30, 2022 at 11:57pm (EST)
Duration: 15.03s, Total samples = 26.59s (176.94%)
Entering interactive mode (type "help" for commands, "o" for options)
(pprof) top
Showing nodes accounting for 10120ms, 38.06% of 26590ms total
Dropped 344 nodes (cum <= 132.95ms)
Showing top 10 nodes out of 208
      flat  flat%   sum%        cum   cum%
    2360ms  8.88%  8.88%     5170ms 19.44%  runtime.scanobject
    1330ms  5.00% 13.88%     4590ms 17.26%  runtime.selectgo
    1290ms  4.85% 18.73%     3180ms 11.96%  runtime.lock2
     970ms  3.65% 22.38%     1250ms  4.70%  runtime.findObject
     840ms  3.16% 25.54%      840ms  3.16%  runtime.procyield
     810ms  3.05% 28.58%      810ms  3.05%  runtime.unlock2
     790ms  2.97% 31.55%      790ms  2.97%  runtime.memmove
     590ms  2.22% 33.77%      590ms  2.22%  runtime.memclrNoHeapPointers
     580ms  2.18% 35.95%      580ms  2.18%  runtime.futex
     560ms  2.11% 38.06%     2650ms  9.97%  runtime.mallocgc

$ go tool pprof before.mem
File: rpc.test
Type: alloc_space
Time: Nov 30, 2022 at 11:57pm (EST)
Entering interactive mode (type "help" for commands, "o" for options)
(pprof) top
Showing nodes accounting for 7714MB, 84.26% of 9154.70MB total
Dropped 81 nodes (cum <= 45.77MB)
Showing top 10 nodes out of 63
      flat  flat%   sum%        cum   cum%
 5191.47MB 56.71% 56.71%  5283.48MB 57.71%  capnproto.org/go/capnp/v3.(*Decoder).Decode
  841.50MB  9.19% 65.90%   841.50MB  9.19%  capnproto.org/go/capnp/v3.(*MultiSegmentArena).Allocate
  461.59MB  5.04% 70.94%   519.59MB  5.68%  capnproto.org/go/capnp/v3.NewPromise (inline)
  272.04MB  2.97% 73.91%   335.10MB  3.66%  capnproto.org/go/capnp/v3.NewMessage
  191.05MB  2.09% 76.00%   191.05MB  2.09%  capnproto.org/go/capnp/v3.(*Metadata).Put
  184.01MB  2.01% 78.01%   520.10MB  5.68%  capnproto.org/go/capnp/v3/rpc/transport.(*transport).NewMessage
  177.28MB  1.94% 79.95%   944.59MB 10.32%  capnproto.org/go/capnp/v3/rpc.(*Conn).handleCall
  148.04MB  1.62% 81.56%   179.54MB  1.96%  capnproto.org/go/capnp/v3.ImmediateAnswer
  126.02MB  1.38% 82.94%   247.04MB  2.70%  capnproto.org/go/capnp/v3/server.(*Server).start
  121.01MB  1.32% 84.26%   121.01MB  1.32%  capnproto.org/go/capnp/v3/server.newAnswerQueue (inline)
```

After
-----

```
goos: linux
goarch: amd64
pkg: capnproto.org/go/capnp/v3/rpc
cpu: 11th Gen Intel(R) Core(TM) i5-1135G7 @ 2.40GHz
BenchmarkStreaming/MessageSize=0x40,MessageCount=0x10000,FlowLimit=0x40000-8         	       1	1276445845 ns/op
BenchmarkStreaming/MessageSize=0x80,MessageCount=0x10000,FlowLimit=0x80000-8         	       1	1260460080 ns/op
BenchmarkStreaming/MessageSize=0x100,MessageCount=0x10000,FlowLimit=0x100000-8       	       1	1257739314 ns/op
BenchmarkStreaming/MessageSize=0x200,MessageCount=0x10000,FlowLimit=0x200000-8       	       1	1252336832 ns/op
BenchmarkStreaming/MessageSize=0x400,MessageCount=0x10000,FlowLimit=0x400000-8       	       1	1400403218 ns/op
BenchmarkStreaming/MessageSize=0x800,MessageCount=0x10000,FlowLimit=0x800000-8       	       1	1467410938 ns/op
BenchmarkStreaming/MessageSize=0x1000,MessageCount=0x10000,FlowLimit=0x1000000-8     	       1	1623752766 ns/op
BenchmarkStreaming/MessageSize=0x2000,MessageCount=0x10000,FlowLimit=0x2000000-8     	       1	1932131814 ns/op
BenchmarkStreaming/MessageSize=0x4000,MessageCount=0x10000,FlowLimit=0x4000000-8     	       1	2376092946 ns/op
BenchmarkStreaming/MessageSize=0x8000,MessageCount=0x10000,FlowLimit=0x8000000-8     	       1	3521464582 ns/op
PASS
ok  	capnproto.org/go/capnp/v3/rpc	17.850s

$ go tool pprof after.cpu
File: rpc.test
Type: cpu
Time: Nov 30, 2022 at 11:58pm (EST)
Duration: 17.73s, Total samples = 28.40s (160.15%)
Entering interactive mode (type "help" for commands, "o" for options)
(pprof) top
Showing nodes accounting for 9950ms, 35.04% of 28400ms total
Dropped 320 nodes (cum <= 142ms)
Showing top 10 nodes out of 204
      flat  flat%   sum%        cum   cum%
    1510ms  5.32%  5.32%     5130ms 18.06%  runtime.selectgo
    1500ms  5.28% 10.60%     3280ms 11.55%  runtime.lock2
    1370ms  4.82% 15.42%     3560ms 12.54%  runtime.scanobject
    1220ms  4.30% 19.72%     1350ms  4.75%  capnproto.org/go/capnp/v3/exp/bufferpool.(*Pool).Put
     860ms  3.03% 22.75%      860ms  3.03%  runtime.unlock2
     720ms  2.54% 25.28%      720ms  2.54%  runtime.futex
     720ms  2.54% 27.82%     2620ms  9.23%  runtime.mallocgc
     700ms  2.46% 30.28%      700ms  2.46%  runtime.procyield
     680ms  2.39% 32.68%      870ms  3.06%  runtime.findObject
     670ms  2.36% 35.04%      670ms  2.36%  runtime.memmove

$ go tool pprof after.mem
File: rpc.test
Type: alloc_space
Time: Nov 30, 2022 at 11:58pm (EST)
Entering interactive mode (type "help" for commands, "o" for options)
(pprof) top
Showing nodes accounting for 3020.16MB, 63.56% of 4751.89MB total
Dropped 76 nodes (cum <= 23.76MB)
Showing top 10 nodes out of 79
      flat  flat%   sum%        cum   cum%
  867.65MB 18.26% 18.26%   867.65MB 18.26%  capnproto.org/go/capnp/v3.(*MultiSegmentArena).Allocate
  481.09MB 10.12% 28.38%   539.09MB 11.34%  capnproto.org/go/capnp/v3.NewPromise (inline)
  319.05MB  6.71% 35.10%   342.57MB  7.21%  capnproto.org/go/capnp/v3.NewMessage
  299.05MB  6.29% 41.39%   515.19MB 10.84%  capnproto.org/go/capnp/v3.(*Decoder).Decode
  224.55MB  4.73% 46.12%   224.55MB  4.73%  capnproto.org/go/capnp/v3.(*Message).setSegment
  179.51MB  3.78% 49.89%   522.58MB 11.00%  capnproto.org/go/capnp/v3/rpc/transport.(*transport).NewMessage
  177.05MB  3.73% 53.62%   177.05MB  3.73%  capnproto.org/go/capnp/v3.(*Metadata).Put
  163.66MB  3.44% 57.06%   957.60MB 20.15%  capnproto.org/go/capnp/v3/rpc.(*Conn).handleCall
  158.02MB  3.33% 60.39%   158.02MB  3.33%  capnproto.org/go/capnp/v3/server.newAnswerQueue (inline)
  150.54MB  3.17% 63.56%   184.04MB  3.87%  capnproto.org/go/capnp/v3.ImmediateAnswer
```