### PR TITLE
Fix #337

### DIFF
--- a/capability.go
+++ b/capability.go
@@ -492,7 +492,7 @@ func (c Client) State() ClientState {
 	return ClientState{
 		Brand:     h.Brand(),
 		IsPromise: !resolved,
-		Metadata:  &resolveHook(c.h).metadata,
+		Metadata:  &c.h.metadata,
 	}
 }
 


### PR DESCRIPTION
resolveHook requires the caller to be holding the lock on the clientHook when invoking it, which this call site was not, so we were seeing a double-unlock on return.

...but the call is actually redundant anyway, since startCall will have already invoked resolveHook, so we can just skip it.