### PR TITLE
Factor out duplicated clientPath type.

### DIFF
--- a/internal/clientpath/clientpath.go
+++ b/internal/clientpath/clientpath.go
@@ -1,0 +1,48 @@
+package clientpath
+
+import "strconv"
+
+// A PipelineOp describes a step in transforming a pipeline.
+// It maps closely with the PromisedAnswer.Op struct in rpc.capnp.
+type PipelineOp struct {
+	Field        uint16
+	DefaultValue []byte
+}
+
+// Path is an encoded version of a list of pipeline operations.
+// It is suitable as a map key.
+//
+// It specifically ignores default values, because a capability can't have a
+// default value other than null.
+type Path string
+
+// FromTransform converts a list of pipeline operations to a Path.
+func FromTransform(ops []PipelineOp) Path {
+	buf := make([]byte, 0, len(ops)*2)
+	for i := range ops {
+		f := ops[i].Field
+		buf = append(buf, byte(f&0x00ff), byte(f&0xff00>>8))
+	}
+	return Path(buf)
+}
+
+// Transform converst a Path into a list of PipelineOps.
+func (cp Path) Transform() []PipelineOp {
+	ops := make([]PipelineOp, len(cp)/2)
+	for i := range ops {
+		ops[i].Field = uint16(cp[i*2]) | uint16(cp[i*2+1])<<8
+	}
+	return ops
+}
+
+// String returns a human-readable description of op.
+func (op PipelineOp) String() string {
+	s := make([]byte, 0, 32)
+	s = append(s, "get field "...)
+	s = strconv.AppendInt(s, int64(op.Field), 10)
+	if op.DefaultValue == nil {
+		return string(s)
+	}
+	s = append(s, " with default"...)
+	return string(s)
+}

--- a/server/answer.go
+++ b/server/answer.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	"capnproto.org/go/capnp/v3"
+	"capnproto.org/go/capnp/v3/internal/clientpath"
 )
 
 // answerQueue is a queue of method calls to make after an earlier
@@ -32,7 +33,7 @@ type answerQueue struct {
 type qent struct {
 	ctx   context.Context
 	basis int // index in bases
-	path  clientPath
+	path  clientpath.Path
 	capnp.Recv
 }
 
@@ -79,7 +80,7 @@ func (aq *answerQueue) fulfill(s capnp.Struct) {
 		recv := aq.bases[ent.basis].recv
 		embargoes[i].alloc = ent.Returner
 		embargoes[i].returned = make(chan struct{})
-		embargoes[i].pcall = recv(ent.ctx, ent.path.transform(), capnp.Recv{
+		embargoes[i].pcall = recv(ent.ctx, ent.path.Transform(), capnp.Recv{
 			Method:      ent.Method,
 			Args:        ent.Args,
 			ReleaseArgs: ent.ReleaseArgs,
@@ -165,7 +166,7 @@ func (qc queueCaller) PipelineRecv(ctx context.Context, transform []capnp.Pipeli
 		qc.aq.q = append(qc.aq.q, qent{
 			ctx:   ctx,
 			basis: qc.basis,
-			path:  clientPathFromTransform(transform),
+			path:  clientpath.FromTransform(transform),
 			Recv:  r,
 		})
 		basis := len(qc.aq.q) - 1
@@ -336,28 +337,4 @@ func (re *returnEmbargoer) recv(ctx context.Context, transform []capnp.PipelineO
 		re.mu.Unlock()
 		return re.pcall.PipelineRecv(ctx, transform, r)
 	}
-}
-
-// clientPath is an encoded version of a list of pipeline operations.
-// It is suitable as a map key.
-//
-// It specifically ignores default values, because a capability can't have a
-// default value other than null.
-type clientPath string
-
-func clientPathFromTransform(ops []capnp.PipelineOp) clientPath {
-	buf := make([]byte, 0, len(ops)*2)
-	for i := range ops {
-		f := ops[i].Field
-		buf = append(buf, byte(f&0x00ff), byte(f&0xff00>>8))
-	}
-	return clientPath(buf)
-}
-
-func (cp clientPath) transform() []capnp.PipelineOp {
-	ops := make([]capnp.PipelineOp, len(cp)/2)
-	for i := range ops {
-		ops[i].Field = uint16(cp[i*2]) | uint16(cp[i*2+1])<<8
-	}
-	return ops
 }


### PR DESCRIPTION
This was previously defined privately in both server and the main capnp package.