### PR TITLE
Move calls to ans.releaseMsg() inside ans.destroy()

### DIFF
--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -1132,9 +1132,6 @@ func (c *Conn) handleFinish(ctx context.Context, id answerID, releaseResultCaps 
 	// Return sent and finish received: time to destroy answer.
 	rl, err := ans.destroy()
 	c.mu.Unlock()
-	if ans.releaseMsg != nil {
-		ans.releaseMsg()
-	}
 	rl.release()
 	if err != nil {
 		return rpcerr.Annotate(err, "incoming finish: release result caps")


### PR DESCRIPTION
These always go together, so let's remove some boilerplate.

---

Note, this is stacked on top of #370, because it touches nearby code and I didn't want to deal with conflicts. That should be merged first.

