### PR TITLE
Remove some vestigial bits, fix #352

### DIFF
--- a/rpc/answer.go
+++ b/rpc/answer.go
@@ -231,12 +231,16 @@ func (ans *answer) sendReturn() (releaseList, error) {
 	var err error
 	ans.exportRefs, err = ans.c.fillPayloadCapTable(ans.results)
 	if err != nil {
+		// We're not going to send the message after all, so don't forget to release it.
+		ans.releaseMsg()
 		ans.c.er.ReportError(rpcerr.Annotate(err, "send return"))
 	}
 	// Continue.  Don't fail to send return if cap table isn't fully filled.
 
 	select {
 	case <-ans.c.bgctx.Done():
+		// We're not going to send the message after all, so don't forget to release it.
+		ans.releaseMsg()
 	default:
 		fin := ans.flags.Contains(finishReceived)
 		if ans.promise != nil {

--- a/rpc/answer.go
+++ b/rpc/answer.go
@@ -48,12 +48,6 @@ type answer struct {
 	// lifetime.
 	flags answerFlags
 
-	// resultCapTable is the CapTable for results.  It is not kept in the
-	// results message because CapTable cannot be used once results are
-	// sent.  However, the capabilities need to be retained for promised
-	// answer targets.
-	resultCapTable []capnp.Client
-
 	// exportRefs is the number of references to exports placed in the
 	// results.
 	exportRefs map[exportID]uint32
@@ -170,11 +164,11 @@ func (ans *answer) AllocResults(sz capnp.ObjectSize) (capnp.Struct, error) {
 // setBootstrap sets the results to an interface pointer, stealing the
 // reference.
 func (ans *answer) setBootstrap(c capnp.Client) error {
-	if ans.ret.HasResults() || len(ans.ret.Message().CapTable) > 0 || len(ans.resultCapTable) > 0 {
+	if ans.ret.HasResults() || len(ans.ret.Message().CapTable) > 0 {
 		panic("setBootstrap called after creating results")
 	}
 	// Add the capability to the table early to avoid leaks if setBootstrap fails.
-	ans.resultCapTable = []capnp.Client{c}
+	ans.ret.Message().CapTable = []capnp.Client{c}
 
 	var err error
 	ans.results, err = ans.ret.NewResults()
@@ -192,9 +186,6 @@ func (ans *answer) setBootstrap(c capnp.Client) error {
 //
 // The caller MUST NOT hold ans.c.mu.
 func (ans *answer) Return(e error) {
-	if ans.results.IsValid() {
-		ans.resultCapTable = ans.results.Message().CapTable
-	}
 	ans.c.mu.Lock()
 	if e != nil {
 		rl := ans.sendException(e)
@@ -231,15 +222,14 @@ func (ans *answer) Return(e error) {
 // Finish with releaseResultCaps set to true, then sendReturn returns
 // the number of references to be subtracted from each export.
 //
-// The caller MUST be holding onto ans.c.mu.  The result's capability table
-// MUST have been extracted into ans.resultCapTable before calling sendReturn.
-// sendReturn MUST NOT be called if sendException was previously called.
+// The caller MUST be holding onto ans.c.mu. sendReturn MUST NOT be
+// called if sendException was previously called.
 func (ans *answer) sendReturn() (releaseList, error) {
 	ans.pcall = nil
 	ans.flags |= resultsReady
 
 	var err error
-	ans.exportRefs, err = ans.c.fillPayloadCapTable(ans.results, ans.resultCapTable)
+	ans.exportRefs, err = ans.c.fillPayloadCapTable(ans.results)
 	if err != nil {
 		ans.c.er.ReportError(rpcerr.Annotate(err, "send return"))
 	}
@@ -278,9 +268,8 @@ func (ans *answer) sendReturn() (releaseList, error) {
 
 // sendException sends an exception on the answer's return message.
 //
-// The caller MUST be holding onto ans.c.mu.  The result's capability table
-// MUST have been extracted into ans.resultCapTable before calling sendException.
-// sendException MUST NOT be called if sendReturn was previously called.
+// The caller MUST be holding onto ans.c.mu. sendException MUST NOT
+// be called if sendReturn was previously called.
 func (ans *answer) sendException(ex error) releaseList {
 	ans.err = ex
 	ans.pcall = nil
@@ -332,11 +321,9 @@ func (ans *answer) sendException(ex error) releaseList {
 func (ans *answer) destroy() (releaseList, error) {
 	defer syncutil.Without(&ans.c.mu, ans.releaseMsg)
 	delete(ans.c.answers, ans.id)
-	rl := releaseList(ans.resultCapTable)
 	if !ans.flags.Contains(releaseResultCapsFlag) || len(ans.exportRefs) == 0 {
-		return rl, nil
+		return nil, nil
 
 	}
-	exportReleases, err := ans.c.releaseExportRefs(ans.exportRefs)
-	return append(rl, exportReleases...), err
+	return ans.c.releaseExportRefs(ans.exportRefs)
 }

--- a/rpc/export.go
+++ b/rpc/export.go
@@ -176,8 +176,12 @@ func (c *Conn) sendCap(d rpccp.CapDescriptor, client capnp.Client) (_ exportID, 
 // reference counts that have been added to the exports table.
 //
 // The caller must be holding onto c.mu.
-func (c *Conn) fillPayloadCapTable(payload rpccp.Payload, clients []capnp.Client) (map[exportID]uint32, error) {
-	if !payload.IsValid() || len(clients) == 0 {
+func (c *Conn) fillPayloadCapTable(payload rpccp.Payload) (map[exportID]uint32, error) {
+	if !payload.IsValid() {
+		return nil, nil
+	}
+	clients := payload.Message().CapTable
+	if len(clients) == 0 {
 		return nil, nil
 	}
 	list, err := payload.NewCapTable(int32(len(clients)))

--- a/rpc/import.go
+++ b/rpc/import.go
@@ -161,14 +161,12 @@ func (c *Conn) newImportCallMessage(msg rpccp.Message, imp importID, qid questio
 	if s.PlaceArgs == nil {
 		return nil
 	}
-	m := args.Message()
 	if err := s.PlaceArgs(args); err != nil {
 		return rpcerr.Failedf("place arguments: %w", err)
 	}
-	clients := m.CapTable
 	syncutil.With(&c.mu, func() {
 		// TODO(soon): save param refs
-		_, err = c.fillPayloadCapTable(payload, clients)
+		_, err = c.fillPayloadCapTable(payload)
 	})
 	if err != nil {
 		return rpcerr.Annotatef(err, "build call message")

--- a/rpc/question.go
+++ b/rpc/question.go
@@ -227,14 +227,12 @@ func (c *Conn) newPipelineCallMessage(msg rpccp.Message, tgt questionID, transfo
 	if s.PlaceArgs == nil {
 		return nil
 	}
-	m := args.Message()
 	if err := s.PlaceArgs(args); err != nil {
 		return rpcerr.Failedf("place arguments: %w", err)
 	}
-	clients := m.CapTable
 	syncutil.With(&c.mu, func() {
 		// TODO(soon): save param refs
-		_, err = c.fillPayloadCapTable(payload, clients)
+		_, err = c.fillPayloadCapTable(payload)
 	})
 
 	if err != nil {

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -1387,7 +1387,7 @@ func (c *Conn) handleDisembargo(ctx context.Context, d rpccp.Disembargo, release
 				return
 			}
 
-			client := iface.Client() //.AddRef()
+			client := iface.Client()
 
 			var ok bool
 			syncutil.Without(&c.mu, func() {


### PR DESCRIPTION
In particular:

- resultsCapTable has been vestigial since we stopped clearing the
  CapTable on send, and I've been meaning to delete it. Instead, we just
  use the message's cap table directly, which also simplifies some code.
- We no longer need the code that releases Clients from the result's
  CapTable -- this is done by msg.Reset when we free the message. In
  principle, this shouldn't have hurt since Client.Release() is
  idempotent, but the way we were doing it caused the data race in https://github.com/capnproto/go-capnproto2/issues/352
  Instead, we only need to release the additional items in exports if
  releaseResultCaps = true.

---

Note, this is stacked on top of #371, which should be merged first.