### PR TITLE
Use refcounting for results

### DIFF
--- a/internal/rc/rc.go
+++ b/internal/rc/rc.go
@@ -1,0 +1,30 @@
+package rc
+
+import "sync/atomic"
+
+type Releaser struct {
+	release  func()
+	refcount int32
+}
+
+func NewReleaser(init int32, release func()) *Releaser {
+	return &Releaser{
+		release:  release,
+		refcount: init,
+	}
+}
+
+func (rc *Releaser) Decr() {
+	newCount := atomic.AddInt32(&rc.refcount, -1)
+	if newCount == 0 {
+		rc.release()
+		rc.release = nil
+	}
+}
+
+func (rc *Releaser) Incr() {
+	newCount := atomic.AddInt32(&rc.refcount, 1)
+	if newCount == 1 {
+		panic("Incremented an already-zero refcount")
+	}
+}

--- a/internal/rc/rc.go
+++ b/internal/rc/rc.go
@@ -19,6 +19,8 @@ func (rc *Releaser) Decr() {
 	if newCount == 0 {
 		rc.release()
 		rc.release = nil
+	} else if newCount < 0 {
+		panic("Decremented an already-zero refcount")
 	}
 }
 

--- a/rpc/answer.go
+++ b/rpc/answer.go
@@ -229,7 +229,7 @@ func (ans *answer) sendReturn() (releaseList, error) {
 	ans.exportRefs, err = ans.c.fillPayloadCapTable(ans.results)
 	if err != nil {
 		// We're not going to send the message after all, so don't forget to release it.
-		ans.releaseMsg()
+		ans.msgReleaser.Decr()
 		ans.c.er.ReportError(rpcerr.Annotate(err, "send return"))
 	}
 	// Continue.  Don't fail to send return if cap table isn't fully filled.
@@ -237,7 +237,7 @@ func (ans *answer) sendReturn() (releaseList, error) {
 	select {
 	case <-ans.c.bgctx.Done():
 		// We're not going to send the message after all, so don't forget to release it.
-		ans.releaseMsg()
+		ans.msgReleaser.Decr()
 	default:
 		fin := ans.flags.Contains(finishReceived)
 		if ans.promise != nil {

--- a/rpc/answer.go
+++ b/rpc/answer.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"fmt"
 	"sync"
-	"sync/atomic"
 
 	"capnproto.org/go/capnp/v3"
 	"capnproto.org/go/capnp/v3/exc"
+	"capnproto.org/go/capnp/v3/internal/rc"
 	"capnproto.org/go/capnp/v3/internal/syncutil"
 	rpccp "capnproto.org/go/capnp/v3/std/capnp/rpc"
 )
@@ -33,9 +33,9 @@ type answer struct {
 	// sendMsg sends the return message.  The caller MUST NOT hold ans.c.mu.
 	sendMsg func()
 
-	// releaseMsg releases the return message.  The caller MUST NOT hold
-	// ans.c.mu.
-	releaseMsg capnp.ReleaseFunc
+	// msgReleaser releases the return message when its refcount hits zero.
+	// The caller MUST NOT hold ans.c.mu.
+	msgReleaser *rc.Releaser
 
 	// results is the memoized answer to ret.Results().
 	// Set by AllocResults and setBootstrap, but contents can only be read
@@ -95,8 +95,10 @@ func errorAnswer(c *Conn, id answerID, err error) *answer {
 	}
 }
 
-// newReturn creates a new Return message.
-func (c *Conn) newReturn(ctx context.Context) (rpccp.Return, func(), capnp.ReleaseFunc, error) {
+// newReturn creates a new Return message. The returned Releaser will release the message when
+// all references to it are dropped; the caller is responsible for one reference. This will not
+// happen before the message is sent, as the returned send function retains a reference.
+func (c *Conn) newReturn(ctx context.Context) (_ rpccp.Return, sendMsg func(), _ *rc.Releaser, _ error) {
 	msg, send, releaseMsg, err := c.transport.NewMessage()
 	if err != nil {
 		return rpccp.Return{}, nil, nil, rpcerr.Failedf("create return: %w", err)
@@ -111,24 +113,19 @@ func (c *Conn) newReturn(ctx context.Context) (rpccp.Return, func(), capnp.Relea
 	// until the local vat is done with it.  We therefore implement a simple
 	// ref-counting mechanism such that 'release' must be called twice before
 	// 'releaseMsg' is called.
-	ref := int32(2)
-	release := func() {
-		if atomic.AddInt32(&ref, -1) == 0 {
-			releaseMsg()
-		}
-	}
+	releaser := rc.NewReleaser(2, releaseMsg)
 
 	return ret, func() {
 		c.sender.Send(asyncSend{
 			send:    send,
-			release: release,
+			release: releaser.Decr,
 			callback: func(err error) {
 				if err != nil {
 					c.er.ReportError(fmt.Errorf("send return: %w", err))
 				}
 			},
 		})
-	}, release, nil
+	}, releaser, nil
 }
 
 // setPipelineCaller sets ans.pcall to pcall if the answer has not
@@ -319,7 +316,7 @@ func (ans *answer) sendException(ex error) releaseList {
 //
 // shutdown has its own strategy for cleaning up an answer.
 func (ans *answer) destroy() (releaseList, error) {
-	defer syncutil.Without(&ans.c.mu, ans.releaseMsg)
+	defer syncutil.Without(&ans.c.mu, ans.msgReleaser.Decr)
 	delete(ans.c.answers, ans.id)
 	if !ans.flags.Contains(releaseResultCapsFlag) || len(ans.exportRefs) == 0 {
 		return nil, nil

--- a/rpc/answer.go
+++ b/rpc/answer.go
@@ -48,12 +48,6 @@ type answer struct {
 	// lifetime.
 	flags answerFlags
 
-	// resultCapTable is the CapTable for results.  It is not kept in the
-	// results message because CapTable cannot be used once results are
-	// sent.  However, the capabilities need to be retained for promised
-	// answer targets.
-	resultCapTable []capnp.Client
-
 	// exportRefs is the number of references to exports placed in the
 	// results.
 	exportRefs map[exportID]uint32
@@ -170,11 +164,11 @@ func (ans *answer) AllocResults(sz capnp.ObjectSize) (capnp.Struct, error) {
 // setBootstrap sets the results to an interface pointer, stealing the
 // reference.
 func (ans *answer) setBootstrap(c capnp.Client) error {
-	if ans.ret.HasResults() || len(ans.ret.Message().CapTable) > 0 || len(ans.resultCapTable) > 0 {
+	if ans.ret.HasResults() || len(ans.ret.Message().CapTable) > 0 {
 		panic("setBootstrap called after creating results")
 	}
 	// Add the capability to the table early to avoid leaks if setBootstrap fails.
-	ans.resultCapTable = []capnp.Client{c}
+	ans.ret.Message().CapTable = []capnp.Client{c}
 
 	var err error
 	ans.results, err = ans.ret.NewResults()
@@ -192,9 +186,6 @@ func (ans *answer) setBootstrap(c capnp.Client) error {
 //
 // The caller MUST NOT hold ans.c.mu.
 func (ans *answer) Return(e error) {
-	if ans.results.IsValid() {
-		ans.resultCapTable = ans.results.Message().CapTable
-	}
 	ans.c.mu.Lock()
 	if e != nil {
 		rl := ans.sendException(e)
@@ -231,15 +222,14 @@ func (ans *answer) Return(e error) {
 // Finish with releaseResultCaps set to true, then sendReturn returns
 // the number of references to be subtracted from each export.
 //
-// The caller MUST be holding onto ans.c.mu.  The result's capability table
-// MUST have been extracted into ans.resultCapTable before calling sendReturn.
-// sendReturn MUST NOT be called if sendException was previously called.
+// The caller MUST be holding onto ans.c.mu. sendReturn MUST NOT be
+// called if sendException was previously called.
 func (ans *answer) sendReturn() (releaseList, error) {
 	ans.pcall = nil
 	ans.flags |= resultsReady
 
 	var err error
-	ans.exportRefs, err = ans.c.fillPayloadCapTable(ans.results, ans.resultCapTable)
+	ans.exportRefs, err = ans.c.fillPayloadCapTable(ans.results)
 	if err != nil {
 		ans.c.er.ReportError(rpcerr.Annotate(err, "send return"))
 	}
@@ -278,9 +268,8 @@ func (ans *answer) sendReturn() (releaseList, error) {
 
 // sendException sends an exception on the answer's return message.
 //
-// The caller MUST be holding onto ans.c.mu.  The result's capability table
-// MUST have been extracted into ans.resultCapTable before calling sendException.
-// sendException MUST NOT be called if sendReturn was previously called.
+// The caller MUST be holding onto ans.c.mu. sendException MUST NOT
+// be called if sendReturn was previously called.
 func (ans *answer) sendException(ex error) releaseList {
 	ans.err = ex
 	ans.pcall = nil
@@ -332,11 +321,9 @@ func (ans *answer) sendException(ex error) releaseList {
 func (ans *answer) destroy() (releaseList, error) {
 	defer syncutil.Without(&ans.c.mu, ans.releaseMsg)
 	delete(ans.c.answers, ans.id)
-	rl := releaseList(ans.resultCapTable)
 	if !ans.flags.Contains(releaseResultCapsFlag) || len(ans.exportRefs) == 0 {
-		return rl, nil
+		return nil, nil
 
 	}
-	exportReleases, err := ans.c.releaseExportRefs(ans.exportRefs)
-	return append(rl, exportReleases...), err
+	return ans.c.releaseExportRefs(ans.exportRefs)
 }

--- a/rpc/export.go
+++ b/rpc/export.go
@@ -176,8 +176,12 @@ func (c *Conn) sendCap(d rpccp.CapDescriptor, client capnp.Client) (_ exportID, 
 // reference counts that have been added to the exports table.
 //
 // The caller must be holding onto c.mu.
-func (c *Conn) fillPayloadCapTable(payload rpccp.Payload, clients []capnp.Client) (map[exportID]uint32, error) {
-	if !payload.IsValid() || len(clients) == 0 {
+func (c *Conn) fillPayloadCapTable(payload rpccp.Payload) (map[exportID]uint32, error) {
+	if !payload.IsValid() {
+		return nil, nil
+	}
+	clients := payload.Message().CapTable
+	if len(clients) == 0 {
 		return nil, nil
 	}
 	list, err := payload.NewCapTable(int32(len(clients)))

--- a/rpc/import.go
+++ b/rpc/import.go
@@ -161,14 +161,12 @@ func (c *Conn) newImportCallMessage(msg rpccp.Message, imp importID, qid questio
 	if s.PlaceArgs == nil {
 		return nil
 	}
-	m := args.Message()
 	if err := s.PlaceArgs(args); err != nil {
 		return rpcerr.Failedf("place arguments: %w", err)
 	}
-	clients := m.CapTable
 	syncutil.With(&c.mu, func() {
 		// TODO(soon): save param refs
-		_, err = c.fillPayloadCapTable(payload, clients)
+		_, err = c.fillPayloadCapTable(payload)
 	})
 	if err != nil {
 		return rpcerr.Annotatef(err, "build call message")

--- a/rpc/question.go
+++ b/rpc/question.go
@@ -227,14 +227,12 @@ func (c *Conn) newPipelineCallMessage(msg rpccp.Message, tgt questionID, transfo
 	if s.PlaceArgs == nil {
 		return nil
 	}
-	m := args.Message()
 	if err := s.PlaceArgs(args); err != nil {
 		return rpcerr.Failedf("place arguments: %w", err)
 	}
-	clients := m.CapTable
 	syncutil.With(&c.mu, func() {
 		// TODO(soon): save param refs
-		_, err = c.fillPayloadCapTable(payload, clients)
+		_, err = c.fillPayloadCapTable(payload)
 	})
 
 	if err != nil {

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -1132,9 +1132,6 @@ func (c *Conn) handleFinish(ctx context.Context, id answerID, releaseResultCaps 
 	// Return sent and finish received: time to destroy answer.
 	rl, err := ans.destroy()
 	c.mu.Unlock()
-	if ans.releaseMsg != nil {
-		ans.releaseMsg()
-	}
 	rl.release()
 	if err != nil {
 		return rpcerr.Annotate(err, "incoming finish: release result caps")


### PR DESCRIPTION
Stacked on top of #373.

---

There is no functional change here yet; this just factors the recounting
we were already doing into a package, and exposes the ability to
refcount to other parts of the code.

This is a stepping stone towards addressing https://github.com/capnproto/go-capnproto2/issues/349; the idea is that the
method receiver should get a reference to this too to keep it alive for
the right amount of time.