### PR TITLE
Conn: wrap fields protected by mu in struct.

### DIFF
--- a/rpc/answer.go
+++ b/rpc/answer.go
@@ -321,7 +321,7 @@ func (ans *answer) sendException(ex error) releaseList {
 // shutdown has its own strategy for cleaning up an answer.
 func (ans *answer) destroy() (releaseList, error) {
 	defer syncutil.Without(&ans.c.mu, ans.msgReleaser.Decr)
-	delete(ans.c.answers, ans.id)
+	delete(ans.c.lk.answers, ans.id)
 	if !ans.flags.Contains(releaseResultCapsFlag) || len(ans.exportRefs) == 0 {
 		return nil, nil
 

--- a/rpc/export.go
+++ b/rpc/export.go
@@ -41,12 +41,12 @@ func (c *Conn) clearExportID(m *capnp.Metadata) {
 }
 
 // findExport returns the export entry with the given ID or nil if
-// couldn't be found.
+// couldn't be found. The caller must be holding c.mu
 func (c *Conn) findExport(id exportID) *expent {
-	if int64(id) >= int64(len(c.exports)) {
+	if int64(id) >= int64(len(c.lk.exports)) {
 		return nil
 	}
-	return c.exports[id] // might be nil
+	return c.lk.exports[id] // might be nil
 }
 
 // releaseExport decreases the number of wire references to an export
@@ -63,8 +63,8 @@ func (c *Conn) releaseExport(id exportID, count uint32) (capnp.Client, error) {
 	switch {
 	case count == ent.wireRefs:
 		client := ent.client
-		c.exports[id] = nil
-		c.exportID.remove(uint32(id))
+		c.lk.exports[id] = nil
+		c.lk.exportID.remove(uint32(id))
 		metadata := client.State().Metadata
 		syncutil.With(metadata, func() {
 			c.clearExportID(metadata)
@@ -116,7 +116,7 @@ func (c *Conn) sendCap(d rpccp.CapDescriptor, client capnp.Client) (_ exportID, 
 	state := client.State()
 	bv := state.Brand.Value
 	if ic, ok := bv.(*importClient); ok && ic.c == c {
-		if ent := c.imports[ic.id]; ent != nil && ent.generation == ic.generation {
+		if ent := c.lk.imports[ic.id]; ent != nil && ent.generation == ic.generation {
 			d.SetReceiverHosted(uint32(ic.id))
 			return 0, false, nil
 		}
@@ -149,7 +149,7 @@ func (c *Conn) sendCap(d rpccp.CapDescriptor, client capnp.Client) (_ exportID, 
 	defer state.Metadata.Unlock()
 	id, ok := c.findExportID(state.Metadata)
 	if ok {
-		ent := c.exports[id]
+		ent := c.lk.exports[id]
 		ent.wireRefs++
 		d.SetSenderHosted(uint32(id))
 		return id, true, nil
@@ -160,11 +160,11 @@ func (c *Conn) sendCap(d rpccp.CapDescriptor, client capnp.Client) (_ exportID, 
 		client:   client.AddRef(),
 		wireRefs: 1,
 	}
-	id = exportID(c.exportID.next())
-	if int64(id) == int64(len(c.exports)) {
-		c.exports = append(c.exports, ee)
+	id = exportID(c.lk.exportID.next())
+	if int64(id) == int64(len(c.lk.exports)) {
+		c.lk.exports = append(c.lk.exports, ee)
 	} else {
-		c.exports[id] = ee
+		c.lk.exports[id] = ee
 	}
 	c.setExportID(state.Metadata, id)
 	d.SetSenderHosted(uint32(id))
@@ -217,28 +217,28 @@ type embargo struct {
 //
 // The caller must be holding onto c.mu.
 func (c *Conn) embargo(client capnp.Client) (embargoID, capnp.Client) {
-	id := embargoID(c.embargoID.next())
+	id := embargoID(c.lk.embargoID.next())
 	e := &embargo{
 		c:      client,
 		lifted: make(chan struct{}),
 	}
-	if int64(id) == int64(len(c.embargoes)) {
-		c.embargoes = append(c.embargoes, e)
+	if int64(id) == int64(len(c.lk.embargoes)) {
+		c.lk.embargoes = append(c.lk.embargoes, e)
 	} else {
-		c.embargoes[id] = e
+		c.lk.embargoes[id] = e
 	}
 	var c2 capnp.Client
-	c2, c.embargoes[id].p = capnp.NewPromisedClient(c.embargoes[id])
+	c2, c.lk.embargoes[id].p = capnp.NewPromisedClient(c.lk.embargoes[id])
 	return id, c2
 }
 
 // findEmbargo returns the embargo entry with the given ID or nil if
-// couldn't be found.
+// couldn't be found. Must be holding c.mu
 func (c *Conn) findEmbargo(id embargoID) *embargo {
-	if int64(id) >= int64(len(c.embargoes)) {
+	if int64(id) >= int64(len(c.lk.embargoes)) {
 		return nil
 	}
-	return c.embargoes[id] // might be nil
+	return c.lk.embargoes[id] // might be nil
 }
 
 // lift disembargoes the client.  It must be called only once.

--- a/rpc/question.go
+++ b/rpc/question.go
@@ -87,7 +87,7 @@ type questionKey struct {
 // handleCancel rejects the question's promise upon cancelation of its
 // Context.
 //
-// The caller MUST NOT hold q.c.mu.
+// The caller MUST NOT hold q.c.lk.
 func (q *question) handleCancel(ctx context.Context) {
 	var rejectErr error
 	select {
@@ -99,8 +99,8 @@ func (q *question) handleCancel(ctx context.Context) {
 		return
 	}
 
-	q.c.mu.Lock()
-	defer q.c.mu.Unlock()
+	q.c.lk.Lock()
+	defer q.c.lk.Unlock()
 
 	// Promise already fulfilled?
 	if q.flags&finished != 0 {
@@ -119,7 +119,7 @@ func (q *question) handleCancel(ctx context.Context) {
 		return nil
 	}, func(err error) {
 		if err == nil {
-			syncutil.With(&q.c.mu, func() { q.flags |= finishSent })
+			syncutil.With(&q.c.lk, func() { q.flags |= finishSent })
 		} else if q.c.bgctx.Err() == nil {
 			q.c.er.ReportError(rpcerr.Annotate(err, "send finish"))
 		}
@@ -134,8 +134,8 @@ func (q *question) handleCancel(ctx context.Context) {
 }
 
 func (q *question) PipelineSend(ctx context.Context, transform []capnp.PipelineOp, s capnp.Send) (*capnp.Answer, capnp.ReleaseFunc) {
-	q.c.mu.Lock()
-	defer q.c.mu.Unlock()
+	q.c.lk.Lock()
+	defer q.c.lk.Unlock()
 
 	if !q.c.startTask() {
 		return capnp.ErrorAnswer(s.Method, ExcClosed), func() {}
@@ -151,17 +151,17 @@ func (q *question) PipelineSend(ctx context.Context, transform []capnp.PipelineO
 	q.mark(transform)
 	q2 := q.c.newQuestion(s.Method)
 
-	syncutil.Without(&q.c.mu, func() {
+	syncutil.Without(&q.c.lk, func() {
 		// Send call message.
 		q.c.sendMessage(ctx, func(m rpccp.Message) error {
 			return q.c.newPipelineCallMessage(m, q.id, transform, q2.id, s)
 		}, func(err error) {
 			if err != nil {
-				syncutil.With(&q.c.mu, func() {
+				syncutil.With(&q.c.lk, func() {
 					q.c.lk.questions[q2.id] = nil
 				})
 				q2.p.Reject(rpcerr.Failedf("send message: %w", err))
-				syncutil.With(&q.c.mu, func() {
+				syncutil.With(&q.c.lk, func() {
 					q.c.lk.questionID.remove(uint32(q2.id))
 				})
 				return
@@ -230,7 +230,7 @@ func (c *Conn) newPipelineCallMessage(msg rpccp.Message, tgt questionID, transfo
 	if err := s.PlaceArgs(args); err != nil {
 		return rpcerr.Failedf("place arguments: %w", err)
 	}
-	syncutil.With(&c.mu, func() {
+	syncutil.With(&c.lk, func() {
 		// TODO(soon): save param refs
 		_, err = c.fillPayloadCapTable(payload)
 	})
@@ -264,7 +264,7 @@ func (q *question) PipelineRecv(ctx context.Context, transform []capnp.PipelineO
 }
 
 // mark adds the promised answer transform to the set of pipelined
-// questions sent.  The caller must be holding onto q.c.mu.
+// questions sent.  The caller must be holding onto q.c.lk.
 func (q *question) mark(xform []capnp.PipelineOp) {
 	for _, x := range q.called {
 		if transformsEqual(x, xform) {


### PR DESCRIPTION
Per the comment, this makes it much easier to tell at a call site whether you need to be holding the lock. In the process of doing this, I also added comments on two methods where the need to hold the lock was not documented, and also pulled the `closed` channel out of this section -- it is not actually supposed to be protected by Conn.mu