### PR TITLE
sendMessage: better names for parameters.

### DIFF
--- a/rpc/answer.go
+++ b/rpc/answer.go
@@ -119,7 +119,7 @@ func (c *Conn) newReturn(ctx context.Context) (_ rpccp.Return, sendMsg func(), _
 		c.sender.Send(asyncSend{
 			send:    send,
 			release: releaser.Decr,
-			callback: func(err error) {
+			onSent: func(err error) {
 				if err != nil {
 					c.er.ReportError(fmt.Errorf("send return: %w", err))
 				}


### PR DESCRIPTION
And similar for the callback field in asyncSend; this has been bothering me.