### PR TITLE
answer.destroy: avoid syncutil.Without

### DIFF
--- a/rpc/export.go
+++ b/rpc/export.go
@@ -98,7 +98,7 @@ func (c *Conn) releaseExportRefs(refs map[exportID]uint32) (releaseList, error) 
 		if rl == nil {
 			rl = make(releaseList, 0, n)
 		}
-		rl = append(rl, client)
+		rl = append(rl, client.Release)
 		n--
 	}
 	return rl, firstErr
@@ -308,13 +308,13 @@ func (sl *senderLoopback) buildDisembargo(msg rpccp.Message) error {
 	return nil
 }
 
-type releaseList []capnp.Client
+type releaseList []capnp.ReleaseFunc
 
 func (rl releaseList) release() {
-	for _, c := range rl {
-		c.Release()
+	for _, r := range rl {
+		r()
 	}
 	for i := range rl {
-		rl[i] = capnp.Client{}
+		rl[i] = func() {}
 	}
 }

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -1296,7 +1296,11 @@ func (c *Conn) recvPayload(payload rpccp.Payload) (_ capnp.Ptr, locals uintSet, 
 		var err error
 		mtab[i], err = c.recvCap(ptab.At(i))
 		if err != nil {
-			releaseList(mtab[:i]).release()
+			// FIXME: is it safe to release these while holding c.lk? In general,
+			// it's possible for Client.Release() to deadlock.
+			for _, client := range mtab[:i] {
+				client.Release()
+			}
 			return capnp.Ptr{}, nil, rpcerr.Annotate(err, fmt.Sprintf("read payload: capability %d", i))
 		}
 		if c.isLocalClient(mtab[i]) {


### PR DESCRIPTION
Instead, this reworks releaseList so that it's a list of arbitrary ReleaseFuncs, instead of just clients, and has destroy add msgReleaser.Decr to the releaseList it's already returning.