### PR TITLE
Remove unused context parameter.

### DIFF
--- a/rpc/answer.go
+++ b/rpc/answer.go
@@ -98,7 +98,7 @@ func errorAnswer(c *Conn, id answerID, err error) *answer {
 // newReturn creates a new Return message. The returned Releaser will release the message when
 // all references to it are dropped; the caller is responsible for one reference. This will not
 // happen before the message is sent, as the returned send function retains a reference.
-func (c *Conn) newReturn(ctx context.Context) (_ rpccp.Return, sendMsg func(), _ *rc.Releaser, _ error) {
+func (c *Conn) newReturn() (_ rpccp.Return, sendMsg func(), _ *rc.Releaser, _ error) {
 	outMsg, err := c.transport.NewMessage()
 	if err != nil {
 		return rpccp.Return{}, nil, nil, rpcerr.Failedf("create return: %w", err)

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -619,7 +619,7 @@ func (c *Conn) handleBootstrap(ctx context.Context, id answerID) error {
 	)
 
 	syncutil.Without(&c.lk, func() {
-		ans.ret, ans.sendMsg, ans.msgReleaser, err = c.newReturn(ctx)
+		ans.ret, ans.sendMsg, ans.msgReleaser, err = c.newReturn()
 		if err == nil {
 			ans.ret.SetAnswerId(uint32(id))
 			ans.ret.SetReleaseParamCaps(false)
@@ -694,7 +694,7 @@ func (c *Conn) handleCall(ctx context.Context, call rpccp.Call, releaseCall capn
 
 	// Create return message.
 	c.lk.Unlock()
-	ret, send, retReleaser, err := c.newReturn(ctx)
+	ret, send, retReleaser, err := c.newReturn()
 	if err != nil {
 		err = rpcerr.Annotate(err, "incoming call")
 		syncutil.With(&c.lk, func() {


### PR DESCRIPTION
No functional change.