### PR TITLE
Refactor use of releaseList

### DIFF
--- a/rpc/answer.go
+++ b/rpc/answer.go
@@ -194,8 +194,7 @@ func (ans *answer) Return(e error) {
 		return
 	}
 	rl := &releaseList{}
-	err := ans.sendReturn(rl)
-	if err != nil {
+	if err := ans.sendReturn(rl); err != nil {
 		select {
 		case <-ans.c.bgctx.Done():
 		default:

--- a/rpc/answer.go
+++ b/rpc/answer.go
@@ -187,7 +187,7 @@ func (ans *answer) Return(e error) {
 	if e != nil {
 		rl := ans.sendException(e)
 		ans.c.lk.Unlock()
-		rl.release()
+		rl.Release()
 		ans.pcalls.Wait()
 		ans.c.tasks.Done() // added by handleCall
 		return
@@ -203,13 +203,13 @@ func (ans *answer) Return(e error) {
 			}
 
 			ans.c.lk.Unlock()
-			rl.release()
+			rl.Release()
 			ans.pcalls.Wait()
 			return
 		}
 	}
 	ans.c.lk.Unlock()
-	rl.release()
+	rl.Release()
 	ans.pcalls.Wait()
 	ans.c.tasks.Done() // added by handleCall
 }

--- a/rpc/export.go
+++ b/rpc/export.go
@@ -78,9 +78,8 @@ func (c *Conn) releaseExport(id exportID, count uint32) (capnp.Client, error) {
 	}
 }
 
-func (c *Conn) releaseExportRefs(refs map[exportID]uint32) (releaseList, error) {
+func (c *Conn) releaseExportRefs(rl *releaseList, refs map[exportID]uint32) error {
 	n := len(refs)
-	var rl releaseList
 	var firstErr error
 	for id, count := range refs {
 		client, err := c.releaseExport(id, count)
@@ -95,13 +94,10 @@ func (c *Conn) releaseExportRefs(refs map[exportID]uint32) (releaseList, error) 
 			n--
 			continue
 		}
-		if rl == nil {
-			rl = make(releaseList, 0, n)
-		}
-		rl = append(rl, client.Release)
+		rl.Add(client.Release)
 		n--
 	}
-	return rl, firstErr
+	return firstErr
 }
 
 // sendCap writes a capability descriptor, returning an export ID if

--- a/rpc/export.go
+++ b/rpc/export.go
@@ -307,14 +307,3 @@ func (sl *senderLoopback) buildDisembargo(msg rpccp.Message) error {
 	}
 	return nil
 }
-
-type releaseList []capnp.ReleaseFunc
-
-func (rl releaseList) release() {
-	for _, r := range rl {
-		r()
-	}
-	for i := range rl {
-		rl[i] = func() {}
-	}
-}

--- a/rpc/releaselist.go
+++ b/rpc/releaselist.go
@@ -5,11 +5,11 @@ import "capnproto.org/go/capnp/v3"
 type releaseList []capnp.ReleaseFunc
 
 func (rl releaseList) Release() {
-	for _, r := range rl {
-		r()
-	}
-	for i := range rl {
-		rl[i] = func() {}
+	for i, r := range rl {
+		if r != nil {
+			r()
+			rl[i] = nil
+		}
 	}
 }
 

--- a/rpc/releaselist.go
+++ b/rpc/releaselist.go
@@ -4,7 +4,7 @@ import "capnproto.org/go/capnp/v3"
 
 type releaseList []capnp.ReleaseFunc
 
-func (rl releaseList) release() {
+func (rl releaseList) Release() {
 	for _, r := range rl {
 		r()
 	}

--- a/rpc/releaselist.go
+++ b/rpc/releaselist.go
@@ -12,3 +12,7 @@ func (rl releaseList) Release() {
 		rl[i] = func() {}
 	}
 }
+
+func (rl *releaseList) Add(r capnp.ReleaseFunc) {
+	*rl = append(*rl, r)
+}

--- a/rpc/releaselist.go
+++ b/rpc/releaselist.go
@@ -1,0 +1,14 @@
+package rpc
+
+import "capnproto.org/go/capnp/v3"
+
+type releaseList []capnp.ReleaseFunc
+
+func (rl releaseList) release() {
+	for _, r := range rl {
+		r()
+	}
+	for i := range rl {
+		rl[i] = func() {}
+	}
+}

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -639,16 +639,16 @@ func (c *Conn) handleBootstrap(ctx context.Context, id answerID) error {
 	c.lk.answers[id] = &ans
 	if !c.bootstrap.IsValid() {
 		rl := ans.sendException(exc.New(exc.Failed, "", "vat does not expose a public/bootstrap interface"))
-		syncutil.Without(&c.lk, rl.release)
+		syncutil.Without(&c.lk, rl.Release)
 		return nil
 	}
 	if err := ans.setBootstrap(c.bootstrap.AddRef()); err != nil {
 		rl := ans.sendException(err)
-		syncutil.Without(&c.lk, rl.release)
+		syncutil.Without(&c.lk, rl.Release)
 		return nil
 	}
 	rl, err := ans.sendReturn()
-	syncutil.Without(&c.lk, rl.release)
+	syncutil.Without(&c.lk, rl.Release)
 	if err != nil {
 		// Answer cannot possibly encounter a Finish, since we still
 		// haven't returned to receive().
@@ -725,7 +725,7 @@ func (c *Conn) handleCall(ctx context.Context, call rpccp.Call, releaseCall capn
 		rl := ans.sendException(parseErr)
 		c.lk.Unlock()
 		c.er.ReportError(parseErr)
-		rl.release()
+		rl.Release()
 		releaseCall()
 		return nil
 	}
@@ -779,7 +779,7 @@ func (c *Conn) handleCall(ctx context.Context, call rpccp.Call, releaseCall capn
 			if tgtAns.err != nil {
 				rl := ans.sendException(tgtAns.err)
 				c.lk.Unlock()
-				rl.release()
+				rl.Release()
 				releaseCall()
 				return nil
 			}
@@ -792,7 +792,7 @@ func (c *Conn) handleCall(ctx context.Context, call rpccp.Call, releaseCall capn
 				err = rpcerr.Failedf("incoming call: read results from target answer: %w", err)
 				rl := ans.sendException(err)
 				c.lk.Unlock()
-				rl.release()
+				rl.Release()
 				releaseCall()
 				c.er.ReportError(err)
 				return nil
@@ -802,7 +802,7 @@ func (c *Conn) handleCall(ctx context.Context, call rpccp.Call, releaseCall capn
 				// Not reporting, as this is the caller's fault.
 				rl := ans.sendException(err)
 				c.lk.Unlock()
-				rl.release()
+				rl.Release()
 				releaseCall()
 				return nil
 			}
@@ -1137,7 +1137,7 @@ func (c *Conn) handleFinish(ctx context.Context, id answerID, releaseResultCaps 
 	// Return sent and finish received: time to destroy answer.
 	rl, err := ans.destroy()
 	c.lk.Unlock()
-	rl.release()
+	rl.Release()
 	if err != nil {
 		return rpcerr.Annotate(err, "incoming finish: release result caps")
 	}


### PR DESCRIPTION
This patch:

- Moves releaseList out of exports.go into its own file
- Uppercases .Release(); per the commit message there's an interface begging to be defined here.
- Give releaseList an .Add() method
- Changes methods that return releaseLists to accept pointers to them as arguments instead, and use .Add()
- Where possible, centralize creation & release of releaseList (see handleBootstrap()). This has the nice effect of killing a couple more uses of syncutil.Without.

There are a few more places where this could help clean things up, but the needed changes are a bit less mechanical so I left them as future work.