### PR TITLE
Release list fixes & broader use

### DIFF
--- a/rpc/releaselist.go
+++ b/rpc/releaselist.go
@@ -4,11 +4,12 @@ import "capnproto.org/go/capnp/v3"
 
 type releaseList []capnp.ReleaseFunc
 
-func (rl releaseList) Release() {
-	for i, r := range rl {
+func (rl *releaseList) Release() {
+	funcs := *rl
+	for i, r := range funcs {
 		if r != nil {
 			r()
-			rl[i] = nil
+			funcs[i] = nil
 		}
 	}
 }


### PR DESCRIPTION
This patch fixes a bug I caught in releaseList: because `.Release()` is defined on a non-pointer receiver, doing `defer rl.Release()` dereferences rl *up front*, so future calls to `.Add()` don't actaully affect the slice that gets passed to `.Release()`. So this patch makes the receiver a pointer to avoid this.

It also expands the use of defer for releaseLists (the bug was caught in the process of doing so).

Finally, I made a simplification to the locking in handleFinish, to use defer for the unlock. Maybe this should have been its own PR, but... oh well.