### PR TITLE
Clean up/fix locking in handleReturn

### DIFF
--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -978,37 +978,27 @@ func (c *Conn) handleReturn(ctx context.Context, ret rpccp.Return, release capnp
 		c.er.ReportError(rpcerr.Annotate(pr.err, "incoming return"))
 	}
 
+	if q.bootstrapPromise == nil && pr.err == nil {
+		// The result of the message contains actual data (not just a
+		// client or an error), so we save the ReleaseFunc for later:
+		q.release = release
+	}
+	c.lk.Unlock()
 	// We're going to potentially block fulfilling some promises so fork
 	// off a goroutine to avoid blocking the receive loop.
-	//
-	// TODO(cleanup): This is a bit weird in that we hold the lock across
-	// the go statement, and do the unlock in the new goroutine, but before
-	// we actually block. This was less weird when the go statement wasn't
-	// there, and we should rework this so it's easier to understand what's
-	// going on.
 	go func() {
-		switch {
-		case q.bootstrapPromise != nil:
-			syncutil.Without(&c.lk, func() {
-				q.p.Resolve(pr.result, pr.err)
-				q.bootstrapPromise.Fulfill(q.p.Answer().Client())
-				q.p.ReleaseClients()
-				release()
-			})
-		case pr.err != nil:
-			// TODO(someday): send unimplemented message back to remote if
-			// pr.unimplemented == true.
-			syncutil.Without(&c.lk, func() {
-				q.p.Reject(pr.err)
-				release()
-			})
-		default:
-			q.release = release
-			syncutil.Without(&c.lk, func() {
-				q.p.Fulfill(pr.result)
-			})
+		q.p.Resolve(pr.result, pr.err)
+		if q.bootstrapPromise != nil {
+			q.bootstrapPromise.Fulfill(q.p.Answer().Client())
+			q.p.ReleaseClients()
+			// We can release now; root pointer of the result is a client, so the
+			// message won't be accessed:
+			release()
+		} else if pr.err != nil {
+			// We can release now; the result is an error, so data from the message
+			// won't be accessed:
+			release()
 		}
-		c.lk.Unlock()
 
 		// Send disembargoes.  Failing to send one of these just never lifts
 		// the embargo on our side, but doesn't cause a leak.


### PR DESCRIPTION
This cleans up/fixes some of the locking towards the end of handleReturn; previously this was super convoluted, in part because we'd just put the whole rest of the function in a giant `go func() {...}()` at some point to solve a deadlock without cleaning it up in a more structural way; see the now-deleted `TODO(cleanup)`.

This also adds a few comments related to the reasoning behind some conditionals, which are a bit obtuse. I think this probably could be cleaned up further, but this maintains the existing behavior while documenting it a bit better at least.

Finally, while doing the above I noticed that sendMessage() was being called without holding c.lk, so I added a call to syncutil.With to fix that.

After this patch there are only three remaining calls to `syncutil.Without` in the rpc package.