### PR TITLE
Simplify rpc/answer.Return()

### DIFF
--- a/rpc/answer.go
+++ b/rpc/answer.go
@@ -199,11 +199,12 @@ func (ans *answer) Return(e error) {
 		case <-ans.c.bgctx.Done():
 		default:
 			ans.c.tasks.Done() // added by handleCall
+			ans.c.lk.Unlock()
+
 			if err := ans.c.shutdown(err); err != nil {
 				ans.c.er.ReportError(err)
 			}
 
-			ans.c.lk.Unlock()
 			ans.pcalls.Wait()
 			return
 		}

--- a/rpc/answer.go
+++ b/rpc/answer.go
@@ -186,11 +186,12 @@ func (ans *answer) Return(e error) {
 	rl := &releaseList{}
 	defer rl.Release()
 
+	defer ans.pcalls.Wait()
+
 	ans.c.lk.Lock()
 	if e != nil {
 		ans.sendException(rl, e)
 		ans.c.lk.Unlock()
-		ans.pcalls.Wait()
 		ans.c.tasks.Done() // added by handleCall
 		return
 	}
@@ -202,11 +203,10 @@ func (ans *answer) Return(e error) {
 			ans.c.er.ReportError(err)
 		}
 
-		ans.pcalls.Wait()
 		return
 	}
 	ans.c.lk.Unlock()
-	ans.pcalls.Wait()
+
 	ans.c.tasks.Done() // added by handleCall
 }
 

--- a/rpc/answer.go
+++ b/rpc/answer.go
@@ -195,19 +195,15 @@ func (ans *answer) Return(e error) {
 		return
 	}
 	if err := ans.sendReturn(rl); err != nil {
-		select {
-		case <-ans.c.bgctx.Done():
-		default:
-			ans.c.tasks.Done() // added by handleCall
-			ans.c.lk.Unlock()
+		ans.c.tasks.Done() // added by handleCall
+		ans.c.lk.Unlock()
 
-			if err := ans.c.shutdown(err); err != nil {
-				ans.c.er.ReportError(err)
-			}
-
-			ans.pcalls.Wait()
-			return
+		if err := ans.c.shutdown(err); err != nil {
+			ans.c.er.ReportError(err)
 		}
+
+		ans.pcalls.Wait()
+		return
 	}
 	ans.c.lk.Unlock()
 	ans.pcalls.Wait()

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -282,10 +282,6 @@ func (bc bootstrapClient) Shutdown() {
 // Close sends an abort to the remote vat and closes the underlying
 // transport.
 func (c *Conn) Close() error {
-	defer func() {
-		<-c.closed
-	}()
-
 	return c.shutdown(exc.Exception{ // NOTE:  omit "rpc" prefix
 		Type:  exc.Failed,
 		Cause: ErrConnClosed,
@@ -300,14 +296,20 @@ func (c *Conn) Done() <-chan struct{} {
 
 // shutdown tears down the connection and transport, optionally sending
 // an abort message before closing.  The caller MUST NOT hold c.lk.
+// shutdown is idempotent.
 func (c *Conn) shutdown(abortErr error) (err error) {
-	c.lk.Lock()
-	defer c.lk.Unlock()
+	alreadyClosing := false
 
-	if !c.lk.closing {
-		c.lk.closing = true
-		c.lk.bgcancel()
+	syncutil.With(&c.lk, func() {
+		alreadyClosing = c.lk.closing
+		if !alreadyClosing {
+			c.lk.closing = true
+			c.lk.bgcancel()
+			c.cancelTasks()
+		}
+	})
 
+	if !alreadyClosing {
 		readyForClose := make(chan struct{})
 		go func() {
 			defer close(c.closed)
@@ -320,31 +322,31 @@ func (c *Conn) shutdown(abortErr error) (err error) {
 			}
 		}()
 
-		c.stopTasks()
-		syncutil.Without(&c.lk, c.drainQueue)
-		c.release()
+		c.tasks.Wait()
+		c.drainQueue()
+
+		rl := &releaseList{}
+		syncutil.With(&c.lk, func() {
+			c.release(rl)
+		})
+		rl.Release()
 		c.abort(abortErr)
 		close(readyForClose)
-		<-c.closed
 	}
+	<-c.closed
 
 	return
 }
 
-// Stop all tasks and prevent new tasks from being started.
+// Cancel all tasks and prevent new tasks from being started.
+// Does not wait for tasks to finish shutting down.
 // Called by 'shutdown'.  Callers MUST hold c.lk.
-func (c *Conn) stopTasks() {
+func (c *Conn) cancelTasks() {
 	for _, a := range c.lk.answers {
 		if a != nil && a.cancel != nil {
 			a.cancel()
 		}
 	}
-
-	// Wait for work to stop.
-	c.lk.Unlock()
-	defer c.lk.Lock()
-
-	c.tasks.Wait()
 }
 
 // caller MUST NOT hold c.lk
@@ -359,9 +361,9 @@ func (c *Conn) drainQueue() {
 	}
 }
 
-// Clear all tables, releasing exported clients and unfinished answers.
-// Called by 'shutdown'.  Caller MUST hold c.lk.
-func (c *Conn) release() {
+// Clear all tables, and arrange for the releaseList to release exported clients
+// and unfinished answers. Called by 'shutdown'.  Caller MUST hold c.lk.
+func (c *Conn) release(rl *releaseList) {
 	exports := c.lk.exports
 	embargoes := c.lk.embargoes
 	answers := c.lk.answers
@@ -372,23 +374,20 @@ func (c *Conn) release() {
 	c.lk.questions = nil
 	c.lk.answers = nil
 
-	c.lk.Unlock()
-	defer c.lk.Lock()
-
-	c.releaseBootstrap()
-	c.releaseExports(exports)
-	c.liftEmbargoes(embargoes)
-	c.releaseAnswers(answers)
-	c.releaseQuestions(questions)
+	c.releaseBootstrap(rl)
+	c.releaseExports(rl, exports)
+	c.liftEmbargoes(rl, embargoes)
+	c.releaseAnswers(rl, answers)
+	c.releaseQuestions(rl, questions)
 
 }
 
-func (c *Conn) releaseBootstrap() {
-	c.bootstrap.Release()
+func (c *Conn) releaseBootstrap(rl *releaseList) {
+	rl.Add(c.bootstrap.Release)
 	c.bootstrap = capnp.Client{}
 }
 
-func (c *Conn) releaseExports(exports []*expent) {
+func (c *Conn) releaseExports(rl *releaseList, exports []*expent) {
 	for _, e := range exports {
 		if e != nil {
 			metadata := e.client.State().Metadata
@@ -396,47 +395,48 @@ func (c *Conn) releaseExports(exports []*expent) {
 				c.clearExportID(metadata)
 			})
 
-			e.client.Release()
+			rl.Add(e.client.Release)
 		}
 	}
 }
 
-func (c *Conn) liftEmbargoes(embargoes []*embargo) {
+func (c *Conn) liftEmbargoes(rl *releaseList, embargoes []*embargo) {
 	for _, e := range embargoes {
 		if e != nil {
-			e.lift()
+			rl.Add(e.lift)
 		}
 	}
 }
 
-func (c *Conn) releaseAnswers(answers map[answerID]*answer) {
+func (c *Conn) releaseAnswers(rl *releaseList, answers map[answerID]*answer) {
 	for _, a := range answers {
 		if a != nil && a.msgReleaser != nil {
-			a.msgReleaser.Decr()
+			rl.Add(a.msgReleaser.Decr)
 		}
 	}
 }
 
-func (c *Conn) releaseQuestions(questions []*question) {
+func (c *Conn) releaseQuestions(rl *releaseList, questions []*question) {
 	for _, q := range questions {
 		canceled := q != nil && q.flags&finished != 0
 		if !canceled {
 			// Only reject the question if it isn't already flagged
 			// as finished; otherwise it was rejected when the finished
 			// flag was set.
-			q.Reject(ExcClosed)
+
+			qr := q // Capture a different variable each time through the loop.
+			rl.Add(func() {
+				qr.Reject(ExcClosed)
+			})
 		}
 	}
 }
 
 // If abortErr != nil, send abort message.  IO and alloc errors are ignored.
-// Called by 'shutdown'.  Callers MUST hold c.lk.
+// Called by 'shutdown'.  Callers MUST NOT hold c.lk.
 func (c *Conn) abort(abortErr error) {
 	// send abort message?
 	if abortErr != nil {
-		c.lk.Unlock()
-		defer c.lk.Lock()
-
 		outMsg, err := c.transport.NewMessage()
 		if err != nil {
 			return


### PR DESCRIPTION
This simplifies the implementation of answer.Return(). stacked on top of #398; review and merge that first.

This patch:

- Gets rid of the unnecessary select; shutdown is idempotent, so it's fine to do it unconditionally; we don't need to check bgctx.
- Reworks the locking so that we're using synctuil.With; makes it much easier to follow.
- Moves ans.pcalls.Wait() to a defer, rather than replicating it at each return site (unfortunately we can't do the same for tasks.Done(), because it needs to be called before invoking shutdown()