### PR TITLE
Tweak locking around Conn.sender

### DIFF
--- a/rpc/answer.go
+++ b/rpc/answer.go
@@ -116,7 +116,7 @@ func (c *Conn) newReturn() (_ rpccp.Return, sendMsg func(), _ *rc.Releaser, _ er
 	releaser := rc.NewReleaser(2, outMsg.Release)
 
 	return ret, func() {
-		c.sender.Send(asyncSend{
+		c.lk.sendTx.Send(asyncSend{
 			send:    outMsg.Send,
 			release: releaser.Decr,
 			onSent: func(err error) {

--- a/rpc/answer.go
+++ b/rpc/answer.go
@@ -30,7 +30,7 @@ type answer struct {
 	// entry is a placeholder until the remote vat cancels the call.
 	ret rpccp.Return
 
-	// sendMsg sends the return message.  The caller MUST NOT hold ans.c.lk.
+	// sendMsg sends the return message.  The caller MUST hold ans.c.lk.
 	sendMsg func()
 
 	// msgReleaser releases the return message when its refcount hits zero.
@@ -250,13 +250,10 @@ func (ans *answer) sendReturn(rl *releaseList) error {
 			}
 			ans.promise = nil
 		}
-		ans.c.lk.Unlock()
 		ans.sendMsg()
 		if fin {
-			ans.c.lk.Lock()
 			return ans.destroy(rl)
 		}
-		ans.c.lk.Lock()
 	}
 	ans.flags |= returnSent
 	if !ans.flags.Contains(finishReceived) {


### PR DESCRIPTION
Contrary to the comment, there was no actual need to not be holding the lock when calling answer.sendMsg, and flipping the contract allows us to remove a superfluous unlock/lock pair.

This also changes the send queue back to using `spsc` and protects it with Conn.lk, since we no longer add to the send queue when we're not holding the connection lock anyway. We'd tried this in the past, but backed it out due to the now-removed unlock/lock pair.

Doing this required splitting it into two separate fields, so the receive end could still be outside Conn.lk.