### PR TITLE
handleCall: cleanups & locking simplifications

### DIFF
--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -663,7 +663,7 @@ func (c *Conn) handleBootstrap(ctx context.Context, id answerID) error {
 	return err
 }
 
-func makeIdempotent(f func()) func() {
+func idempotent(f func()) func() {
 	called := false
 	return func() {
 		if !called {
@@ -761,7 +761,7 @@ func (c *Conn) handleCall(ctx context.Context, call rpccp.Call, releaseCall capn
 	recv := capnp.Recv{
 		Args:        p.args,
 		Method:      p.method,
-		ReleaseArgs: makeIdempotent(releaseCall),
+		ReleaseArgs: idempotent(releaseCall),
 		Returner:    ans,
 	}
 


### PR DESCRIPTION
This gets us to a place where locking in handleCall is strictly hierarchical; there is one call to syncutil.With and then later a `lock(); defer unlock()`.

I don't love the way we're using releaseList to do the actual Recv calls, but factoring those out into one codepath turned out to be really thorny. This is at least cleaner than what we had before, and gets this into a shape where it can be easily adapted to the withLocked() design we'd discussed.

I'm also not a fan of how many codepaths have to call releaseCall, but cleaning up resource reclamation is another broader topic on my list...

This also includes a couple minor cleanups in 561756942fa69284bd6009cbfce5ff2def38d425 and 28f46dece574b1e6382f92ed99dd416e5a62a240