### PR TITLE
Add handler for unknown method

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -102,7 +102,7 @@ type Server struct {
 	callQueue *mpsc.Queue[*Call]
 
 	// Handler for custom behavior of unknown methods
-	HandleUnknownMethod func(ctx context.Context, m capnp.Method) *Method
+	HandleUnknownMethod func(m capnp.Method) *Method
 }
 
 // New returns a client hook that makes calls to a set of methods.
@@ -154,7 +154,7 @@ func (srv *Server) Send(ctx context.Context, s capnp.Send) (*capnp.Answer, capnp
 func (srv *Server) Recv(ctx context.Context, r capnp.Recv) capnp.PipelineCaller {
 	mm := srv.methods.find(r.Method)
 	if mm == nil && srv.HandleUnknownMethod != nil {
-		mm = srv.HandleUnknownMethod(ctx, r.Method)
+		mm = srv.HandleUnknownMethod(r.Method)
 	}
 	if mm == nil {
 		r.Reject(capnp.Unimplemented("unimplemented"))

--- a/server/server.go
+++ b/server/server.go
@@ -102,7 +102,7 @@ type Server struct {
 	callQueue *mpsc.Queue[*Call]
 
 	// Handler for custom behavior of unknown methods
-	HandleUnknownMethod func(ctx context.Context, r capnp.Recv) *Method
+	HandleUnknownMethod func(ctx context.Context, m capnp.Method) *Method
 }
 
 // New returns a client hook that makes calls to a set of methods.
@@ -154,7 +154,7 @@ func (srv *Server) Send(ctx context.Context, s capnp.Send) (*capnp.Answer, capnp
 func (srv *Server) Recv(ctx context.Context, r capnp.Recv) capnp.PipelineCaller {
 	mm := srv.methods.find(r.Method)
 	if mm == nil && srv.HandleUnknownMethod != nil {
-		mm = srv.HandleUnknownMethod(ctx, r)
+		mm = srv.HandleUnknownMethod(ctx, r.Method)
 	}
 	if mm == nil {
 		r.Reject(capnp.Unimplemented("unimplemented"))

--- a/server/server.go
+++ b/server/server.go
@@ -129,6 +129,9 @@ func New(methods []Method, brand any, shutdown Shutdowner) *Server {
 // Send starts a method call.
 func (srv *Server) Send(ctx context.Context, s capnp.Send) (*capnp.Answer, capnp.ReleaseFunc) {
 	mm := srv.methods.find(s.Method)
+	if mm == nil && srv.HandleUnknownMethod != nil {
+		mm = srv.HandleUnknownMethod(s.Method)
+	}
 	if mm == nil {
 		return capnp.ErrorAnswer(s.Method, capnp.Unimplemented("unimplemented")), func() {}
 	}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -111,7 +111,7 @@ func TestServerCall(t *testing.T) {
 			sm.Impl = func(ctx context.Context, call *server.Call) error {
 				echoArgs := air.Echo_echo_Params(call.Args())
 				inText, err := echoArgs.In()
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				proxyReceived.Store(inText)
 				// pretend we received an answer
 				echo := air.Echo_echo{Call: call}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -109,14 +109,13 @@ func TestServerCall(t *testing.T) {
 				Impl:   nil,
 			}
 			sm.Impl = func(ctx context.Context, call *server.Call) error {
-				t.Log("welcome to blank")
 				echoArgs := air.Echo_echo_Params(call.Args())
 				inText, err := echoArgs.In()
 				assert.NoError(t, err)
 				proxyReceived.Store(inText)
 				// pretend we received an answer
 				echo := air.Echo_echo{Call: call}
-				resp, err := echo.AllocResults()
+				resp, _ := echo.AllocResults()
 				err = resp.SetOut(inText)
 				return err
 			}
@@ -147,11 +146,9 @@ func TestServerCall(t *testing.T) {
 		resp, err := ans.Struct()
 		answerOut, _ := resp.Out()
 		rxValue := proxyReceived.Load()
-		assert.Equal(t, echoText, rxValue)
+		require.Equal(t, echoText, rxValue)
 		assert.Equal(t, echoText, answerOut)
-		if err != nil {
-			t.Error("echo.Echo() error != <nil>; want success")
-		}
+		assert.NoError(t, err, "echo.Echo() error != <nil>; want success")
 	})
 }
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -3,7 +3,6 @@ package server_test
 import (
 	"context"
 	"errors"
-	"net"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -13,7 +12,6 @@ import (
 
 	"capnproto.org/go/capnp/v3"
 	air "capnproto.org/go/capnp/v3/internal/aircraftlib"
-	"capnproto.org/go/capnp/v3/rpc"
 	"capnproto.org/go/capnp/v3/server"
 
 	"github.com/stretchr/testify/assert"
@@ -122,20 +120,7 @@ func TestServerCall(t *testing.T) {
 			return &sm
 		}
 		blankBoot := capnp.NewClient(srv)
-		lis, err := net.Listen("tcp", ":0")
-		defer lis.Close()
-		require.NoError(t, err)
-		go rpc.Serve(lis, blankBoot)
-
-		// invoke the proxy server with the echo client
-		addr := lis.Addr().String()
-		conn, err := net.Dial("tcp", addr)
-		assert.NoError(t, err)
-		transport := rpc.NewStreamTransport(conn)
-		rpcConn := rpc.NewConn(transport, nil)
-		defer rpcConn.Close()
-		blankClient := rpcConn.Bootstrap(context.Background())
-		echoClient := air.Echo(blankClient)
+		echoClient := air.Echo(blankBoot)
 		defer echoClient.Release()
 
 		ans, finish := echoClient.Echo(context.Background(), func(p air.Echo_echo_Params) error {


### PR DESCRIPTION
This is a proposed solution to be able to customize the handling of unknown methods. The default behavior is unchanged but a hook allows customized behavior.

The hook can be used to dynamically create a method and have it invoked as if it existed all along.
I was able to use this in a proxy service that dynamically obtains capabilities/methods from other services and forwards requests to those services. 