### PR TITLE
Fix 394

### DIFF
--- a/capability.go
+++ b/capability.go
@@ -874,8 +874,9 @@ func (r Recv) Reject(e error) {
 type Returner interface {
 	// AllocResults allocates the results struct that will be sent using
 	// Return.  It can be called at most once, and only before calling
-	// Return.  The struct returned by AllocResults cannot be used after
-	// Return is called.
+	// Return.  The struct returned by AllocResults must not be mutated
+	// after Return is called, and may not be accessed after
+	// ReleaseResults is called.
 	AllocResults(sz ObjectSize) (Struct, error)
 
 	// Return resolves the method call successfully if e is nil, or failure
@@ -885,6 +886,13 @@ type Returner interface {
 	// and after it returns, no new calls can be sent to the PipelineCaller
 	// returned from Recv.
 	Return(e error)
+
+	// ReleaseResults relinquishes the caller's access to the message
+	// containing the results; once this is called the message may be
+	// released or reused, and it is not safe to access.
+	//
+	// If AllocResults has not been called, then this is a no-op.
+	ReleaseResults()
 }
 
 // A ReleaseFunc tells the RPC system that a parameter or result struct

--- a/capability_test.go
+++ b/capability_test.go
@@ -311,6 +311,9 @@ func (dr *dummyReturner) Return(e error) {
 	dr.err = e
 }
 
+func (dr *dummyReturner) ReleaseResults() {
+}
+
 func TestToInterface(t *testing.T) {
 	_, seg, err := NewMessage(SingleSegment(nil))
 	if err != nil {

--- a/rpc/answer.go
+++ b/rpc/answer.go
@@ -155,6 +155,7 @@ func (ans *answer) AllocResults(sz capnp.ObjectSize) (capnp.Struct, error) {
 	if err := ans.results.SetContent(s.ToPtr()); err != nil {
 		return capnp.Struct{}, rpcerr.WrapFailed("alloc results", err)
 	}
+	ans.msgReleaser.Incr()
 	return s, nil
 }
 
@@ -209,6 +210,12 @@ func (ans *answer) Return(e error) {
 
 	if err = ans.c.shutdown(err); err != nil {
 		ans.c.er.ReportError(err)
+	}
+}
+
+func (ans *answer) ReleaseResults() {
+	if ans.results.IsValid() {
+		ans.msgReleaser.Decr()
 	}
 }
 

--- a/rpc/import.go
+++ b/rpc/import.go
@@ -190,6 +190,7 @@ func (ic *importClient) Recv(ctx context.Context, r capnp.Recv) capnp.PipelineCa
 
 func returnAnswer(ret capnp.Returner, ans *capnp.Answer, finish func()) {
 	defer finish()
+	defer ret.ReleaseResults()
 	result, err := ans.Struct()
 	if err != nil {
 		ret.Return(err)

--- a/server/server.go
+++ b/server/server.go
@@ -222,6 +222,7 @@ func (srv *Server) handleCall(ctx context.Context, c *Call) {
 		c.aq.reject(err)
 	}
 	c.recv.Returner.Return(err)
+	c.recv.Returner.ReleaseResults()
 }
 
 func (srv *Server) start(ctx context.Context, m *Method, r capnp.Recv) capnp.PipelineCaller {

--- a/server/server.go
+++ b/server/server.go
@@ -216,12 +216,12 @@ func (srv *Server) handleCall(ctx context.Context, c *Call) {
 	err := c.method.Impl(ctx, c)
 
 	c.recv.ReleaseArgs()
+	c.recv.Returner.Return(err)
 	if err == nil {
 		c.aq.fulfill(c.results)
 	} else {
 		c.aq.reject(err)
 	}
-	c.recv.Returner.Return(err)
 	c.recv.Returner.ReleaseResults()
 }
 


### PR DESCRIPTION
N.b. this is stacked on top of #416; review & merge that first.

The last commit is the core of this; we want to do the Return *before* we fulfill the answerQueue, so that the captable is not being constructed while other goroutines are reading the message. We tried to fix it this way before, but because the contract for Return() says that the message may not be accessed after calling it, doing so caused #349.

Therefore, the prior commit splits releasing the message into a separate new method on Returner, so that we can now do the ordering:

- Return()
- fulfill()
- ReleaseResults()

Which should solve the data race without causing other problems.