### PR TITLE
Fix occasional spurious test failure.

### DIFF
--- a/rpc/level0_test.go
+++ b/rpc/level0_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"net"
 	"os"
 	"runtime"
@@ -68,7 +69,9 @@ func TestSendAbort(t *testing.T) {
 			ErrorReporter: testErrorReporter{tb: t, fail: true},
 			// Give it plenty of time to actually send the message;
 			// otherwise we might time out and close the connection first.
-			AbortTimeout: time.Second,
+			// "plenty of time" here really means defer to the test suite's
+			// timeout.
+			AbortTimeout: time.Duration(math.MaxInt64),
 		})
 
 		ctx := context.Background()

--- a/rpc/level0_test.go
+++ b/rpc/level0_test.go
@@ -148,11 +148,10 @@ func TestRecvAbort(t *testing.T) {
 	})
 	require.NoError(t, err, "must send 'failed' exception")
 
-	boot := conn.Bootstrap(context.Background())
+	ctx := context.Background()
+	boot := conn.Bootstrap(ctx)
 	defer boot.Release()
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	defer cancel()
 	err = boot.Resolve(ctx)
 	require.NoError(t, err, "should resolve bootstrap capability")
 

--- a/rpc/serve_test.go
+++ b/rpc/serve_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"net"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -126,10 +125,6 @@ func TestListenAndServe(t *testing.T) {
 	}()
 
 	cancelFunc()
-	select {
-	case <-time.After(time.Second * 2):
-		t.Error("Cancelling context didn't end the listener")
-	case err = <-errChannel:
-		assert.ErrorIs(t, err, net.ErrClosed)
-	}
+	err = <-errChannel // Will hang if server does not return.
+	assert.ErrorIs(t, err, net.ErrClosed)
 }


### PR DESCRIPTION
Along the lines of 3fc50651bf0b99184418bc046b922d82b19edddc, just with a different test: occasionally, with the race detector and other tests running in parallel, I will get a timeout here. But I think that's just that there's no reason in principle this can't take more than two seconds, so under extreme circumstances it may. So this patch removes the timeout; if there's a real bug the channel receive will just hang and eventually the test-suite-wide timeout will catch it.