### PR TITLE
Don't report nil error when shutting down import client.

### DIFF
--- a/rpc/import.go
+++ b/rpc/import.go
@@ -234,7 +234,9 @@ func (ic *importClient) Shutdown() {
 			}
 			return err
 		}, func(err error) {
-			ic.c.er.ReportError(rpcerr.Annotate(err, "send release"))
+			if err != nil {
+				ic.c.er.ReportError(rpcerr.Annotate(err, "send release"))
+			}
 		})
 	})
 }

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -761,7 +761,9 @@ func (c *Conn) handleCall(ctx context.Context, call rpccp.Call, releaseCall capn
 
 				return nil
 			}, func(err error) {
-				c.er.ReportError(rpcerr.Annotate(err, "incoming call: send unimplemented"))
+				if err != nil {
+					c.er.ReportError(rpcerr.Annotate(err, "incoming call: send unimplemented"))
+				}
 			})
 		})
 

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -1560,7 +1560,10 @@ func (c *Conn) handleDisembargo(ctx context.Context, d rpccp.Disembargo, release
 			}, func(err error) {
 				defer release()
 				defer client.Release()
-				c.er.ReportError(rpcerr.Annotate(err, "incoming disembargo: send receiver loopback"))
+
+				if err != nil {
+					c.er.ReportError(rpcerr.Annotate(err, "incoming disembargo: send receiver loopback"))
+				}
 			})
 		})
 
@@ -1575,7 +1578,9 @@ func (c *Conn) handleDisembargo(ctx context.Context, d rpccp.Disembargo, release
 				return
 			}, func(err error) {
 				defer release()
-				c.er.ReportError(rpcerr.Annotate(err, "incoming disembargo: send unimplemented"))
+				if err != nil {
+					c.er.ReportError(rpcerr.Annotate(err, "incoming disembargo: send unimplemented"))
+				}
 			})
 		})
 	}


### PR DESCRIPTION
Adds a nil error check before reporting an error in `importClient.Shutdown()`. 