### PR TITLE
Fix #420

### DIFF
--- a/capability.go
+++ b/capability.go
@@ -882,7 +882,9 @@ type Returner interface {
 	AllocResults(sz ObjectSize) (Struct, error)
 
 	// PrepareReturn finalizes the return message. The method call will
-	// resolve successfully if e is nil, or otherwise it will fail.
+	// resolve successfully if e is nil, or otherwise it will return an
+	// exception to the caller.
+	//
 	// PrepareReturn must be called once.
 	//
 	// After PrepareReturn is invoked, no goroutine may modify the message

--- a/capability.go
+++ b/capability.go
@@ -857,7 +857,8 @@ func (r Recv) AllocResults(sz ObjectSize) (Struct, error) {
 // Return ends the method call successfully, releasing the arguments.
 func (r Recv) Return() {
 	r.ReleaseArgs()
-	r.Returner.Return(nil)
+	r.Returner.PrepareReturn(nil)
+	r.Returner.Return()
 }
 
 // Reject ends the method call with an error, releasing the arguments.
@@ -866,7 +867,8 @@ func (r Recv) Reject(e error) {
 		panic("Reject(nil)")
 	}
 	r.ReleaseArgs()
-	r.Returner.Return(e)
+	r.Returner.PrepareReturn(e)
+	r.Returner.Return()
 }
 
 // A Returner allocates and sends the results from a received
@@ -879,13 +881,21 @@ type Returner interface {
 	// ReleaseResults is called.
 	AllocResults(sz ObjectSize) (Struct, error)
 
-	// Return resolves the method call successfully if e is nil, or failure
-	// otherwise.  Return must be called once.
+	// PrepareReturn finalizes the return message. The method call will
+	// resolve successfully if e is nil, or otherwise it will fail.
+	// PrepareReturn must be called once.
+	//
+	// After PrepareReturn is invoked, no goroutine may modify the message
+	// containing the results.
+	PrepareReturn(e error)
+
+	// Return resolves the method call, using the results finalized in
+	// PrepareReturn. Return must be called once.
 	//
 	// Return must wait for all ongoing pipelined calls to be delivered,
 	// and after it returns, no new calls can be sent to the PipelineCaller
 	// returned from Recv.
-	Return(e error)
+	Return()
 
 	// ReleaseResults relinquishes the caller's access to the message
 	// containing the results; once this is called the message may be

--- a/capability_test.go
+++ b/capability_test.go
@@ -306,9 +306,12 @@ func (dr *dummyReturner) AllocResults(sz ObjectSize) (Struct, error) {
 	return dr.s, err
 }
 
-func (dr *dummyReturner) Return(e error) {
-	dr.returned = true
+func (dr *dummyReturner) PrepareReturn(e error) {
 	dr.err = e
+}
+
+func (dr *dummyReturner) Return() {
+	dr.returned = true
 }
 
 func (dr *dummyReturner) ReleaseResults() {

--- a/rpc/import.go
+++ b/rpc/import.go
@@ -193,19 +193,23 @@ func returnAnswer(ret capnp.Returner, ans *capnp.Answer, finish func()) {
 	defer ret.ReleaseResults()
 	result, err := ans.Struct()
 	if err != nil {
-		ret.Return(err)
+		ret.PrepareReturn(err)
+		ret.Return()
 		return
 	}
 	recvResult, err := ret.AllocResults(result.Size())
 	if err != nil {
-		ret.Return(err)
+		ret.PrepareReturn(err)
+		ret.Return()
 		return
 	}
 	if err := recvResult.CopyFrom(result); err != nil {
-		ret.Return(err)
+		ret.PrepareReturn(err)
+		ret.Return()
 		return
 	}
-	ret.Return(nil)
+	ret.PrepareReturn(nil)
+	ret.Return()
 }
 
 func (ic *importClient) Brand() capnp.Brand {

--- a/server/server.go
+++ b/server/server.go
@@ -217,12 +217,12 @@ func (srv *Server) handleCall(ctx context.Context, c *Call) {
 
 	c.recv.ReleaseArgs()
 	c.recv.Returner.PrepareReturn(err)
-	c.recv.Returner.Return()
 	if err == nil {
 		c.aq.fulfill(c.results)
 	} else {
 		c.aq.reject(err)
 	}
+	c.recv.Returner.Return()
 	c.recv.Returner.ReleaseResults()
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -216,7 +216,8 @@ func (srv *Server) handleCall(ctx context.Context, c *Call) {
 	err := c.method.Impl(ctx, c)
 
 	c.recv.ReleaseArgs()
-	c.recv.Returner.Return(err)
+	c.recv.Returner.PrepareReturn(err)
+	c.recv.Returner.Return()
 	if err == nil {
 		c.aq.fulfill(c.results)
 	} else {


### PR DESCRIPTION
This fixes #420 (without re-introducing #394, or #349). Per the last commit:

> 420 was a regression introduced by our fix for 394; if we Return()
before we fulfill(), this can result in out of order message delivery,
since incoming calls can be made directly on clients in the result
before all queued calls are drained.
>
> Previously, if we fulfilled() before Return(), we would get a data race
as fillPayloadCapTable modified the message while pipelined calls read
it. Having split Return(error) into PrepareReturn(error) and Return(),
it is now safe to move just the latter after the call to fulfill().

I am now unable to reproduce any of the referenced issues.