### PR TITLE
Panic on flowcontrol deadlock

### DIFF
--- a/flowcontrol/fixed.go
+++ b/flowcontrol/fixed.go
@@ -26,8 +26,7 @@ func (fl *fixedLimiter) StartMessage(ctx context.Context, size uint64) (gotRespo
 	//        reservation on the semaphore. We can't return an error because it
 	//        is currently ignored by the caller.
 	if int64(size) > fl.size {
-		const s = "StartMessage(): message size %d is too large (max %d)"
-		panic(fmt.Sprintf(s, size, fl.size))
+		panic(fmt.Sprintf("StartMessage(): message size %d is too large (max %d)", size, fl.size))
 	}
 
 	if err = fl.sem.Acquire(ctx, int64(size)); err == nil {

--- a/flowcontrol/fixed.go
+++ b/flowcontrol/fixed.go
@@ -30,12 +30,11 @@ func (fl *fixedLimiter) StartMessage(ctx context.Context, size uint64) (gotRespo
 		panic(fmt.Sprintf(s, size, fl.size))
 	}
 
-	if err = fl.sem.Acquire(ctx, int64(size)); err != nil {
-		return nil, err
+	if err = fl.sem.Acquire(ctx, int64(size)); err == nil {
+		gotResponse = func() { fl.sem.Release(int64(size)) }
 	}
-	return func() {
-		fl.sem.Release(int64(size))
-	}, nil
+
+	return
 }
 
 func (fixedLimiter) Release() {}

--- a/flowcontrol/fixed_test.go
+++ b/flowcontrol/fixed_test.go
@@ -47,3 +47,11 @@ func TestFixed(t *testing.T) {
 	got1()
 
 }
+
+func TestFixeLimiterPanics(t *testing.T) {
+	t.Parallel()
+
+	assert.Panics(t, func() {
+		NewFixedLimiter(1024).StartMessage(context.Background(), 1025)
+	}, "should panic if reservation would cause deadlock")
+}

--- a/flowcontrol/fixed_test.go
+++ b/flowcontrol/fixed_test.go
@@ -6,17 +6,20 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFixed(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	lim := NewFixedLimiter(10)
 
 	// Start a couple messages:
 	got4, err := lim.StartMessage(ctx, 4)
-	assert.Nil(t, err, "Limiter returned an error")
+	require.NoError(t, err, "Limiter returned an error")
 	got6, err := lim.StartMessage(ctx, 6)
-	assert.Nil(t, err, "Limiter returned an error")
+	require.NoError(t, err, "Limiter returned an error")
 
 	// We're now exactly at the limit, so if we try again it should block:
 	func() {
@@ -24,14 +27,13 @@ func TestFixed(t *testing.T) {
 		defer cancel()
 
 		_, err = lim.StartMessage(ctxTimeout, 1)
-		assert.NotNil(t, err, "Limiter didn't return an error")
-		assert.Equal(t, err, ctxTimeout.Err(), "Error wasn't from the context")
+		assert.ErrorIs(t, err, context.DeadlineExceeded, "should return context error")
 	}()
 
 	// Ok, finish one of them and then it should go through again:
 	got4()
 	got1, err := lim.StartMessage(ctx, 1)
-	assert.Nil(t, err, "Limiter returned an error")
+	require.NoError(t, err, "Limiter returned an error")
 
 	// There are 10 - (6 + 1) = 3 bytes remaining. It should therefore block
 	// if we ask for four:
@@ -40,12 +42,10 @@ func TestFixed(t *testing.T) {
 		defer cancel()
 
 		_, err = lim.StartMessage(ctxTimeout, 4)
-		assert.NotNil(t, err, "Limiter didn't return an error")
-		assert.Equal(t, err, ctxTimeout.Err(), "Error wasn't from the context")
+		assert.ErrorIs(t, err, context.DeadlineExceeded, "should return context error")
 	}()
 	got6()
 	got1()
-
 }
 
 func TestFixeLimiterPanics(t *testing.T) {


### PR DESCRIPTION
Fixes issue where `fixedLimiter` would silently deadlock when the size of a message exceeds the maximum total reservations.

Minor code cleanup included in separate commits.