### PR TITLE
Add Release() method to capnp.Arena.

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -1261,7 +1261,6 @@ func TestDataTextCopyOptimization(t *testing.T) {
 // is when special casing Text and Data
 //
 // run this test with capnp.go:1334-1341 commented in/out to compare.
-//
 func BenchmarkTextMovementBetweenSegments(b *testing.B) {
 	buf := make([]byte, 1<<21)
 	buf2 := make([]byte, 1<<21)
@@ -1889,6 +1888,8 @@ func (ta testArena) Data(id capnp.SegmentID) ([]byte, error) {
 func (ta testArena) Allocate(capnp.Size, map[capnp.SegmentID]*capnp.Segment) (capnp.SegmentID, []byte, error) {
 	return 0, nil, errors.New("test arena: can't allocate")
 }
+
+func (ta testArena) Release() {}
 
 func TestPointerTraverseDefense(t *testing.T) {
 	t.Parallel()

--- a/message.go
+++ b/message.go
@@ -407,13 +407,11 @@ type Arena interface {
 	// returned byte slice.
 	Allocate(minsz Size, segs map[SegmentID]*Segment) (SegmentID, []byte, error)
 
-	// Return this arena to an internal sync.Pool of arenas that can be
-	// re-used, which can help reduce memory allocations.
-	//
-	// All segments will be zeroed before re-use.
+	// Release all resources associated with the Arena, allowing it to
+	// be reused in another message.
 	//
 	// Calling Release is optional; if not done, the garbage collector
-	// will release the memory per usual.
+	// will release resources per usual.
 	Release()
 }
 

--- a/message.go
+++ b/message.go
@@ -407,11 +407,14 @@ type Arena interface {
 	// returned byte slice.
 	Allocate(minsz Size, segs map[SegmentID]*Segment) (SegmentID, []byte, error)
 
-	// Release all resources associated with the Arena, allowing it to
-	// be reused in another message.
+	// Release all resources associated with the Arena. Callers MUST NOT
+	// use the Arena after it has been released.
 	//
-	// Calling Release is optional; if not done, the garbage collector
-	// will release resources per usual.
+	// Calling Release() is OPTIONAL, but may reduce allocations.
+	//
+	// Implementations MAY use Release() as a signal to return resources
+	// to free lists, or otherwise reuse the Arena.   However, they MUST
+	// NOT assume Release() will be called.
 	Release()
 }
 

--- a/message.go
+++ b/message.go
@@ -406,6 +406,15 @@ type Arena interface {
 	// arena is responsible for preserving the existing data in the
 	// returned byte slice.
 	Allocate(minsz Size, segs map[SegmentID]*Segment) (SegmentID, []byte, error)
+
+	// Return this arena to an internal sync.Pool of arenas that can be
+	// re-used, which can help reduce memory allocations.
+	//
+	// All segments will be zeroed before re-use.
+	//
+	// Calling Release is optional; if not done, the garbage collector
+	// will release the memory per usual.
+	Release()
 }
 
 // SingleSegmentArena is an Arena implementation that stores message data
@@ -418,7 +427,10 @@ type SingleSegmentArena []byte
 // Callers MAY use b to populate the segment for reading, or to reserve
 // memory of a specific size.
 func SingleSegment(b []byte) *SingleSegmentArena {
-	return (*SingleSegmentArena)(&b)
+	if b == nil {
+		return singleSegmentPool.Get().(*SingleSegmentArena)
+	}
+	return singleSegment(b)
 }
 
 func (ssa SingleSegmentArena) NumSegments() int64 {
@@ -457,6 +469,39 @@ func (ssa SingleSegmentArena) String() string {
 	return "single-segment arena [len=" + str.Itod(len(ssa)) + " cap=" + str.Itod(cap(ssa)) + "]"
 }
 
+// Return this arena to an internal sync.Pool of arenas that can be
+// re-used. Any time SingleSegment(nil) is called, arenas from this
+// pool will be used if available, which can help reduce memory
+// allocations.
+//
+// All segments will be zeroed before re-use.
+//
+// Calling Release is optional; if not done the garbage collector
+// will release the memory per usual.
+func (ssa *SingleSegmentArena) Release() {
+	// Clear the memory, so there's no junk in here for the next use:
+	for i := range *ssa {
+		(*ssa)[i] = 0
+	}
+
+	// Truncate the segment, since we use the length as the marker for
+	// what's allocated:
+	(*ssa) = (*ssa)[:0]
+
+	singleSegmentPool.Put(ssa)
+}
+
+// Like SingleSegment, but doesn't use the pool
+func singleSegment(b []byte) *SingleSegmentArena {
+	return (*SingleSegmentArena)(&b)
+}
+
+var singleSegmentPool = sync.Pool{
+	New: func() any {
+		return singleSegment(nil)
+	},
+}
+
 type roSingleSegment []byte
 
 func (ss roSingleSegment) NumSegments() int64 {
@@ -477,6 +522,8 @@ func (ss roSingleSegment) Allocate(sz Size, segs map[SegmentID]*Segment) (Segmen
 func (ss roSingleSegment) String() string {
 	return "read-only single-segment arena [len=" + str.Itod(len(ss)) + "]"
 }
+
+func (ss roSingleSegment) Release() {}
 
 // MultiSegment is an arena that stores object data across multiple []byte
 // buffers, allocating new buffers of exponentially-increasing size when


### PR DESCRIPTION
Exports the `Release()` method from the public `Arena` interface, to support pooling of arenas.  Adds `Release()` method to `SingleSegmentArena`, and other private arena types.