### PR TITLE
findEmbargo: define on lockedConn instead of Conn.

### DIFF
--- a/rpc/export.go
+++ b/rpc/export.go
@@ -228,8 +228,8 @@ func (c *lockedConn) embargo(client capnp.Client) (embargoID, capnp.Client) {
 }
 
 // findEmbargo returns the embargo entry with the given ID or nil if
-// couldn't be found. Must be holding c.mu
-func (c *Conn) findEmbargo(id embargoID) *embargo {
+// couldn't be found.
+func (c *lockedConn) findEmbargo(id embargoID) *embargo {
 	if int64(id) >= int64(len(c.lk.embargoes)) {
 		return nil
 	}

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -1488,7 +1488,7 @@ func (c *Conn) handleDisembargo(ctx context.Context, d rpccp.Disembargo, release
 
 		id := embargoID(d.Context().ReceiverLoopback())
 		var e *embargo
-		syncutil.With(&c.lk, func() {
+		c.withLocked(func(c *lockedConn) {
 			e = c.findEmbargo(id)
 			if e != nil {
 				// TODO(soon): verify target matches the right import.


### PR DESCRIPTION
No functional change, but I apparently missed this when doing the lockedConn refactor. There are a few other call sites for syncutil.With, which we should audit & probably replace.