### PR TITLE
CI: only run the tests repeatedly, not compile them.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -31,4 +31,5 @@ jobs:
       - name: Run RPC tests repeatedly
         run: |
           cd rpc
-          for i in `seq 500`; do go test; done
+          go test -c
+          for i in `seq 500`; do ./rpc.test; done


### PR DESCRIPTION
This patch tweaks CI so that the phase that runs the rpc tests repeatedly still only builds them once -- this should speed things up with no real downside.