### PR TITLE
bbr.Limiter.trySend: don't take a context.

### DIFF
--- a/flowcontrol/bbr/limiter.go
+++ b/flowcontrol/bbr/limiter.go
@@ -114,7 +114,7 @@ func (l *Limiter) run(ctx context.Context) {
 		case p := <-l.chAck:
 			l.onAck(p)
 		case <-timeToSend:
-			l.trySend(ctx)
+			l.trySend()
 		case req := <-sendReqs:
 			now := l.clock.Now()
 			l.doSend(now, req)
@@ -124,9 +124,8 @@ func (l *Limiter) run(ctx context.Context) {
 	}
 }
 
-func (l *Limiter) trySend(ctx context.Context) {
+func (l *Limiter) trySend() {
 	select {
-	case <-ctx.Done():
 	case req := <-l.chSend:
 		now := l.clock.Now()
 		l.doSend(now, req)


### PR DESCRIPTION
There's no actual reason for this, since the relevant select has a default branch and therefore will never block.

This isn't the select at issue in the profile Louis showed me, but it seems worth fixing since I've noticed it.