### PR TITLE
BBR: avoid busy loop

### DIFF
--- a/flowcontrol/bbr/limiter.go
+++ b/flowcontrol/bbr/limiter.go
@@ -57,11 +57,6 @@ func (l *Limiter) computeBDP() float64 {
 }
 
 func (l *Limiter) run(ctx context.Context) {
-	// Dummy already-closed channel we can use when we want a channel
-	// that is ready, without needing to create it each time.
-	timeToSendNow := make(chan time.Time)
-	close(timeToSendNow)
-
 	for {
 
 		// These channels may or may not be nil, depending on what
@@ -84,9 +79,7 @@ func (l *Limiter) run(ctx context.Context) {
 			// might be in the far future, and there is no ack on its way
 			// to save us from our ignorance. Fortunately we always want
 			// to send if there's nothing on the wire, so just do it.
-			// Note that we don't use sendReqs here, since we don't want
-			// to skip over the logic that checks for app limited flows:
-			timeToSend = timeToSendNow
+			sendReqs = l.chSend
 		} else if l.packetsInflight >= l.maxPacketsInflight ||
 			(bdp > 0 && float64(l.inflight()) >= l.cwndGain*bdp) {
 			// We're at our threshold; wait for an ack,

--- a/flowcontrol/bbr/limiter.go
+++ b/flowcontrol/bbr/limiter.go
@@ -114,7 +114,7 @@ func (l *Limiter) run(ctx context.Context) {
 		case p := <-l.chAck:
 			l.onAck(p)
 		case <-timeToSend:
-			l.trySend(ctx)
+			l.trySend()
 		case req := <-sendReqs:
 			now := l.clock.Now()
 			l.doSend(now, req)
@@ -124,9 +124,8 @@ func (l *Limiter) run(ctx context.Context) {
 	}
 }
 
-func (l *Limiter) trySend(ctx context.Context) {
+func (l *Limiter) trySend() {
 	select {
-	case <-ctx.Done():
 	case req := <-l.chSend:
 		now := l.clock.Now()
 		l.doSend(now, req)


### PR DESCRIPTION
...in the case where the connection is idle. Previously, if this branch
was taken then the select would always terminate immediately; we really
need it to block unless there's actually something to send.

This is probably a big part of the high cpu use we're seeing. Also: the requirement that the pipe be empty is probably why we are *not* seeing high CPU usage in tests.

---

Stacked on top of #445; review & merge that first.