### PR TITLE
Avoid use of fmt in the main package.

### DIFF
--- a/answer.go
+++ b/answer.go
@@ -540,6 +540,13 @@ func (pc PipelineClient) Brand() Brand {
 func (pc PipelineClient) Shutdown() {
 }
 
+func (pc PipelineClient) String() string {
+	return "PipelineClient{transform: " +
+		str.Slice(pc.transform) +
+		", promise: 0x" + str.PtrToHex(pc.p) +
+		"}"
+}
+
 // A PipelineOp describes a step in transforming a pipeline.
 // It maps closely with the PromisedAnswer.Op struct in rpc.capnp.
 type PipelineOp struct {

--- a/capability.go
+++ b/capability.go
@@ -3,7 +3,6 @@ package capnp
 import (
 	"context"
 	"errors"
-	"fmt"
 	"runtime"
 	"strconv"
 	"sync"
@@ -606,9 +605,9 @@ func (c Client) String() string {
 	}
 	var s string
 	if c.h.isResolved() {
-		s = fmt.Sprintf("<client %T@%p>", c.h.ClientHook, c.h)
+		s = "<client " + c.h.ClientHook.String() + ">"
 	} else {
-		s = fmt.Sprintf("<unresolved client %T@%p>", c.h.ClientHook, c.h)
+		s = "<unresolved client " + c.h.ClientHook.String() + ">"
 	}
 	c.h.mu.Unlock()
 	c.mu.Unlock()
@@ -876,6 +875,9 @@ type ClientHook interface {
 	// Shutdown is undefined.  It is expected for the ClientHook to reject
 	// any outstanding call futures.
 	Shutdown()
+
+	// String formats the hook as a string (same as fmt.Stringer)
+	String() string
 }
 
 // Send is the input to ClientHook.Send.
@@ -1047,6 +1049,10 @@ func (ec errorClient) Brand() Brand {
 }
 
 func (ec errorClient) Shutdown() {
+}
+
+func (ec errorClient) String() string {
+	return "errorClient{" + ec.e.Error() + "}"
 }
 
 var closedSignal = make(chan struct{})

--- a/capability_test.go
+++ b/capability_test.go
@@ -268,6 +268,10 @@ type dummyHook struct {
 	shutdowns int
 }
 
+func (dh *dummyHook) String() string {
+	return "&dummyHook{}"
+}
+
 func (dh *dummyHook) Send(_ context.Context, s Send) (*Answer, ReleaseFunc) {
 	dh.calls++
 	return ImmediateAnswer(s.Method, newEmptyStruct()), func() {}

--- a/flowcontrol/fixed.go
+++ b/flowcontrol/fixed.go
@@ -2,8 +2,8 @@ package flowcontrol
 
 import (
 	"context"
-	"fmt"
 
+	"capnproto.org/go/capnp/v3/internal/str"
 	"golang.org/x/sync/semaphore"
 )
 
@@ -26,7 +26,9 @@ func (fl *fixedLimiter) StartMessage(ctx context.Context, size uint64) (gotRespo
 	//        reservation on the semaphore. We can't return an error because it
 	//        is currently ignored by the caller.
 	if int64(size) > fl.size {
-		panic(fmt.Sprintf("StartMessage(): message size %d is too large (max %d)", size, fl.size))
+		panic("StartMessage(): message size " +
+			str.Utod(size) +
+			" is too large (max " + str.Itod(fl.size) + ")")
 	}
 
 	if err = fl.sem.Acquire(ctx, int64(size)); err == nil {

--- a/internal/str/str.go
+++ b/internal/str/str.go
@@ -2,7 +2,12 @@
 // of environments that care about minimizing executable size.
 package str
 
-import "strconv"
+import (
+	"strconv"
+	"strings"
+
+	"unsafe" // Only for formatting pointers as integers; we don't actually do anything unsafe.
+)
 
 // Utod formats unsigned integers as decimals.
 func Utod[T Uint](n T) string {
@@ -17,6 +22,10 @@ func Itod[T Int](n T) string {
 // UToHex returns n formatted in hexidecimal.
 func UToHex[T Uint](n T) string {
 	return strconv.FormatUint(uint64(n), 16)
+}
+
+func PtrToHex[T any](p *T) string {
+	return UToHex(uintptr(unsafe.Pointer(p)))
 }
 
 // ZeroPad pads value to the left with zeros, making the resulting string
@@ -34,8 +43,27 @@ func ZeroPad(count int, value string) string {
 	return string(buf)
 }
 
+// Slice formats a slice of values which themselves implement Stringer.
+func Slice[T Stringer](s []T) string {
+	var b strings.Builder
+	b.WriteRune('{')
+	for i, v := range s {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		b.WriteString(v.String())
+	}
+	b.WriteRune('}')
+	return b.String()
+}
+
+// Stringer is equivalent to fmt.Stringer
+type Stringer interface {
+	String() string
+}
+
 type Uint interface {
-	~uint8 | ~uint16 | ~uint32 | ~uint64 | ~uint
+	~uint8 | ~uint16 | ~uint32 | ~uint64 | ~uint | ~uintptr
 }
 
 type Int interface {

--- a/rpc/export.go
+++ b/rpc/export.go
@@ -208,6 +208,10 @@ type embargo struct {
 	lifted chan struct{}
 }
 
+func (e embargo) String() string {
+	return "embargo{c: " + e.c.String() + ", 0x" + str.PtrToHex(e.p) + "}"
+}
+
 // embargo creates a new embargoed client, stealing the reference.
 //
 // The caller must be holding onto c.mu.

--- a/rpc/import.go
+++ b/rpc/import.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 
 	"capnproto.org/go/capnp/v3"
+	"capnproto.org/go/capnp/v3/internal/str"
 	"capnproto.org/go/capnp/v3/internal/syncutil"
 	rpccp "capnproto.org/go/capnp/v3/std/capnp/rpc"
 )
@@ -82,6 +83,10 @@ type importClient struct {
 	c          *Conn
 	id         importID
 	generation uint64
+}
+
+func (ic *importClient) String() string {
+	return "importClient{c: 0x" + str.PtrToHex(ic.c) + ", id: " + str.Utod(ic.id) + "}"
 }
 
 func (ic *importClient) Send(ctx context.Context, s capnp.Send) (*capnp.Answer, capnp.ReleaseFunc) {

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -332,6 +332,10 @@ type bootstrapClient struct {
 	cancel context.CancelFunc
 }
 
+func (bc bootstrapClient) String() string {
+	return "bootstrapClient{c: " + bc.c.String() + "}"
+}
+
 func (bc bootstrapClient) Send(ctx context.Context, s capnp.Send) (*capnp.Answer, capnp.ReleaseFunc) {
 	return bc.c.SendCall(ctx, s)
 }

--- a/server/server.go
+++ b/server/server.go
@@ -10,6 +10,7 @@ import (
 	"capnproto.org/go/capnp/v3"
 	"capnproto.org/go/capnp/v3/exc"
 	"capnproto.org/go/capnp/v3/exp/mpsc"
+	"capnproto.org/go/capnp/v3/internal/str"
 )
 
 // A Method describes a single capability method on a server object.
@@ -102,6 +103,10 @@ type Server struct {
 
 	// Handler for custom behavior of unknown methods
 	HandleUnknownMethod func(m capnp.Method) *Method
+}
+
+func (s *Server) String() string {
+	return "*Server@0x" + str.PtrToHex(s)
 }
 
 // New returns a client hook that makes calls to a set of methods.


### PR DESCRIPTION
This adds a String() method to ClientHook so we can avoid using fmt for that, then removes the last use of fmt in the main package, per #364.

Before closing that issue, I think I'd still like to get it out of the flowcontrol package hierarchy at least, and maybe elsewhere if practical.