### PR TITLE
fix: panic error when release cs hook in case cs.hook is nil

### DIFF
--- a/capability.go
+++ b/capability.go
@@ -692,6 +692,10 @@ func (cs ClientSnapshot) AddRef() ClientSnapshot {
 
 // Release the reference to the hook.
 func (cs *ClientSnapshot) Release() {
+	if cs.hook == nil {
+		return
+	}
+
 	cs.hook.Release()
 }
 


### PR DESCRIPTION
This aims to address issue #572, as previously noted by @QuangTung97. In production, we sometimes handle around 10 million requests, and roughly 1% of them may panic when cs.hooks is nil. I haven’t been able to reproduce the issue in tests yet, but I suspect it may be caused by the defer tgt.Release() call at line 959 in /rpc/rpc.go.
<img width="951" height="622" alt="image" src="https://github.com/user-attachments/assets/60f5a5bf-06a7-4beb-8a47-9c039ed4d536" />
