### PR TITLE
Make `Address` type public

### DIFF
--- a/address.go
+++ b/address.go
@@ -6,51 +6,51 @@ import (
 	"capnproto.org/go/capnp/v3/internal/str"
 )
 
-// An address is an index inside a segment's data (in bytes).
+// An Address is an index inside a segment's data (in bytes).
 // It is bounded to [0, maxSegmentSize).
-type address uint32
+type Address uint32
 
 // String returns the address in hex format.
-func (a address) String() string {
+func (a Address) String() string {
 	return strconv.FormatUint(uint64(a), 16)
 }
 
 // GoString returns the address in hex format.
-func (a address) GoString() string {
+func (a Address) GoString() string {
 	return "capnp.address(%" + a.String() + ")"
 }
 
 // addSize returns the address a+sz.  ok is false if the result would
 // be an invalid address.
-func (a address) addSize(sz Size) (_ address, ok bool) {
+func (a Address) addSize(sz Size) (_ Address, ok bool) {
 	x := int64(a) + int64(sz)
 	if x > int64(maxSegmentSize) {
 		return 0xffffffff, false
 	}
-	return address(x), true
+	return Address(x), true
 }
 
 // addSizeUnchecked returns a+sz without any overflow checking.
-func (a address) addSizeUnchecked(sz Size) address {
-	return a + address(sz)
+func (a Address) addSizeUnchecked(sz Size) Address {
+	return a + Address(sz)
 }
 
 // element returns the address a+i*sz.  ok is false if the result would
 // be an invalid address.
-func (a address) element(i int32, sz Size) (_ address, ok bool) {
+func (a Address) element(i int32, sz Size) (_ Address, ok bool) {
 	x := int64(a) + int64(i)*int64(sz)
 	if x > int64(maxSegmentSize) || x < 0 {
 		return 0xffffffff, false
 	}
-	return address(x), true
+	return Address(x), true
 }
 
 // addOffset returns the address a+o.  It panics if o is invalid.
-func (a address) addOffset(o DataOffset) address {
+func (a Address) addOffset(o DataOffset) Address {
 	if o >= 1<<19 {
 		panic("data offset overflow")
 	}
-	return a + address(o)
+	return a + Address(o)
 }
 
 // A Size is a size (in bytes).

--- a/address_test.go
+++ b/address_test.go
@@ -6,9 +6,9 @@ import (
 
 func TestAddressAddSize(t *testing.T) {
 	tests := []struct {
-		a   address
+		a   Address
 		sz  Size
-		out address
+		out Address
 		ok  bool
 	}{
 		{0, 0, 0, true},
@@ -38,10 +38,10 @@ func TestAddressAddSize(t *testing.T) {
 
 func TestAddressElement(t *testing.T) {
 	tests := []struct {
-		a   address
+		a   Address
 		i   int32
 		sz  Size
-		out address
+		out Address
 		ok  bool
 	}{
 		{0, 0, 0, 0, true},

--- a/arena.go
+++ b/arena.go
@@ -32,7 +32,7 @@ type Arena interface {
 	//
 	// If Allocate returns an previously loaded segment, then the arena is
 	// responsible for preserving the existing data.
-	Allocate(minsz Size, msg *Message, seg *Segment) (*Segment, address, error)
+	Allocate(minsz Size, msg *Message, seg *Segment) (*Segment, Address, error)
 
 	// Release all resources associated with the Arena. Callers MUST NOT
 	// use the Arena after it has been released.
@@ -98,7 +98,7 @@ func (ssa *SingleSegmentArena) Segment(id SegmentID) *Segment {
 	return &ssa.seg
 }
 
-func (ssa *SingleSegmentArena) Allocate(sz Size, msg *Message, seg *Segment) (*Segment, address, error) {
+func (ssa *SingleSegmentArena) Allocate(sz Size, msg *Message, seg *Segment) (*Segment, Address, error) {
 	if seg != nil && seg != &ssa.seg {
 		return nil, 0, errors.New("segment is not associated with arena")
 	}
@@ -108,7 +108,7 @@ func (ssa *SingleSegmentArena) Allocate(sz Size, msg *Message, seg *Segment) (*S
 	}
 	ssa.seg.BindTo(msg)
 	if hasCapacity(data, sz) {
-		addr := address(len(ssa.seg.data))
+		addr := Address(len(ssa.seg.data))
 		ssa.seg.data = ssa.seg.data[:len(ssa.seg.data)+int(sz)]
 		return &ssa.seg, addr, nil
 	}
@@ -119,7 +119,7 @@ func (ssa *SingleSegmentArena) Allocate(sz Size, msg *Message, seg *Segment) (*S
 	if ssa.bp == nil {
 		return nil, 0, errors.New("cannot allocate on read-only SingleSegmentArena")
 	}
-	addr := address(len(ssa.seg.data))
+	addr := Address(len(ssa.seg.data))
 	ssa.seg.data = ssa.bp.Get(cap(data) + inc)[:len(data)+int(sz)]
 	copy(ssa.seg.data, data)
 	zeroSlice(data)
@@ -304,7 +304,7 @@ func (msa *MultiSegmentArena) Segment(id SegmentID) *Segment {
 	return msa.segs[id]
 }
 
-func (msa *MultiSegmentArena) Allocate(sz Size, msg *Message, seg *Segment) (*Segment, address, error) {
+func (msa *MultiSegmentArena) Allocate(sz Size, msg *Message, seg *Segment) (*Segment, Address, error) {
 	// Prefer allocating in seg if it has capacity.
 	if seg != nil && hasCapacity(seg.data, sz) {
 		// Membership check: validate by id and exact pointer equality.
@@ -317,7 +317,7 @@ func (msa *MultiSegmentArena) Allocate(sz Size, msg *Message, seg *Segment) (*Se
 			return nil, 0, errors.New("attempt to allocate in segment for different message")
 		}
 
-		addr := address(len(seg.data))
+		addr := Address(len(seg.data))
 		newLen := int(addr) + int(sz)
 		seg.data = seg.data[:newLen]
 		seg.BindTo(msg)
@@ -332,7 +332,7 @@ func (msa *MultiSegmentArena) Allocate(sz Size, msg *Message, seg *Segment) (*Se
 		data := msa.segs[i].data
 		if hasCapacity(data, sz) {
 			// Found segment with spare capacity.
-			addr := address(len(data))
+			addr := Address(len(data))
 			newLen := int(addr) + int(sz)
 			msa.segs[i].data = data[:newLen]
 			msa.segs[i].BindTo(msg)
@@ -465,7 +465,7 @@ func (r *ReadOnlySingleSegment) Segment(id SegmentID) *Segment {
 //
 // If Allocate returns an previously loaded segment, then the
 // arena is responsible for preserving the existing data.
-func (r *ReadOnlySingleSegment) Allocate(minsz Size, msg *Message, seg *Segment) (*Segment, address, error) {
+func (r *ReadOnlySingleSegment) Allocate(minsz Size, msg *Message, seg *Segment) (*Segment, Address, error) {
 	return nil, 0, errors.New("readOnly segment cannot allocate data")
 }
 

--- a/capability.go
+++ b/capability.go
@@ -73,7 +73,7 @@ func (i Interface) Capability() CapabilityID {
 }
 
 // value returns a raw interface pointer with the capability ID.
-func (i Interface) value(paddr address) rawPointer {
+func (i Interface) value(paddr Address) rawPointer {
 	if i.seg == nil {
 		return 0
 	}

--- a/capability_test.go
+++ b/capability_test.go
@@ -404,7 +404,7 @@ func TestInterface_value(t *testing.T) {
 		{NewInterface(seg, 0xdeadbeef), 0xdeadbeef00000003},
 	}
 	for _, test := range tests {
-		for paddr := address(0); paddr < 16; paddr++ {
+		for paddr := Address(0); paddr < 16; paddr++ {
 			if val := test.in.value(paddr); val != test.val {
 				t.Errorf("Interface{seg: %p, cap: %d}.value(%v) = %v; want %v", test.in.seg, test.in.cap, paddr, val, test.val)
 			}

--- a/codec_test.go
+++ b/codec_test.go
@@ -86,7 +86,7 @@ func (t *tooManySegsArena) Segment(id SegmentID) *Segment {
 	return nil
 }
 
-func (t *tooManySegsArena) Allocate(minsz Size, msg *Message, seg *Segment) (*Segment, address, error) {
+func (t *tooManySegsArena) Allocate(minsz Size, msg *Message, seg *Segment) (*Segment, Address, error) {
 	return nil, 0, errors.New("cannot allocate")
 }
 

--- a/list-gen.go
+++ b/list-gen.go
@@ -30,7 +30,7 @@ func (l VoidList) ToPtr() Ptr {
 	return List(l).ToPtr()
 }
 
-func (l VoidList) primitiveElem(i int, expectedSize ObjectSize) (address, error) {
+func (l VoidList) primitiveElem(i int, expectedSize ObjectSize) (Address, error) {
 	return List(l).primitiveElem(i, expectedSize)
 }
 
@@ -62,7 +62,7 @@ func (l BitList) ToPtr() Ptr {
 	return List(l).ToPtr()
 }
 
-func (l BitList) primitiveElem(i int, expectedSize ObjectSize) (address, error) {
+func (l BitList) primitiveElem(i int, expectedSize ObjectSize) (Address, error) {
 	return List(l).primitiveElem(i, expectedSize)
 }
 
@@ -94,7 +94,7 @@ func (l Float32List) ToPtr() Ptr {
 	return List(l).ToPtr()
 }
 
-func (l Float32List) primitiveElem(i int, expectedSize ObjectSize) (address, error) {
+func (l Float32List) primitiveElem(i int, expectedSize ObjectSize) (Address, error) {
 	return List(l).primitiveElem(i, expectedSize)
 }
 
@@ -126,7 +126,7 @@ func (l Float64List) ToPtr() Ptr {
 	return List(l).ToPtr()
 }
 
-func (l Float64List) primitiveElem(i int, expectedSize ObjectSize) (address, error) {
+func (l Float64List) primitiveElem(i int, expectedSize ObjectSize) (Address, error) {
 	return List(l).primitiveElem(i, expectedSize)
 }
 
@@ -158,7 +158,7 @@ func (l TextList) ToPtr() Ptr {
 	return List(l).ToPtr()
 }
 
-func (l TextList) primitiveElem(i int, expectedSize ObjectSize) (address, error) {
+func (l TextList) primitiveElem(i int, expectedSize ObjectSize) (Address, error) {
 	return List(l).primitiveElem(i, expectedSize)
 }
 
@@ -190,7 +190,7 @@ func (l DataList) ToPtr() Ptr {
 	return List(l).ToPtr()
 }
 
-func (l DataList) primitiveElem(i int, expectedSize ObjectSize) (address, error) {
+func (l DataList) primitiveElem(i int, expectedSize ObjectSize) (Address, error) {
 	return List(l).primitiveElem(i, expectedSize)
 }
 
@@ -222,7 +222,7 @@ func (l PointerList) ToPtr() Ptr {
 	return List(l).ToPtr()
 }
 
-func (l PointerList) primitiveElem(i int, expectedSize ObjectSize) (address, error) {
+func (l PointerList) primitiveElem(i int, expectedSize ObjectSize) (Address, error) {
 	return List(l).primitiveElem(i, expectedSize)
 }
 
@@ -254,7 +254,7 @@ func (l EnumList[T]) ToPtr() Ptr {
 	return List(l).ToPtr()
 }
 
-func (l EnumList[T]) primitiveElem(i int, expectedSize ObjectSize) (address, error) {
+func (l EnumList[T]) primitiveElem(i int, expectedSize ObjectSize) (Address, error) {
 	return List(l).primitiveElem(i, expectedSize)
 }
 
@@ -286,7 +286,7 @@ func (l StructList[T]) ToPtr() Ptr {
 	return List(l).ToPtr()
 }
 
-func (l StructList[T]) primitiveElem(i int, expectedSize ObjectSize) (address, error) {
+func (l StructList[T]) primitiveElem(i int, expectedSize ObjectSize) (Address, error) {
 	return List(l).primitiveElem(i, expectedSize)
 }
 
@@ -318,7 +318,7 @@ func (l CapList[T]) ToPtr() Ptr {
 	return List(l).ToPtr()
 }
 
-func (l CapList[T]) primitiveElem(i int, expectedSize ObjectSize) (address, error) {
+func (l CapList[T]) primitiveElem(i int, expectedSize ObjectSize) (Address, error) {
 	return List(l).primitiveElem(i, expectedSize)
 }
 
@@ -350,7 +350,7 @@ func (l Int8List) ToPtr() Ptr {
 	return List(l).ToPtr()
 }
 
-func (l Int8List) primitiveElem(i int, expectedSize ObjectSize) (address, error) {
+func (l Int8List) primitiveElem(i int, expectedSize ObjectSize) (Address, error) {
 	return List(l).primitiveElem(i, expectedSize)
 }
 
@@ -382,7 +382,7 @@ func (l UInt8List) ToPtr() Ptr {
 	return List(l).ToPtr()
 }
 
-func (l UInt8List) primitiveElem(i int, expectedSize ObjectSize) (address, error) {
+func (l UInt8List) primitiveElem(i int, expectedSize ObjectSize) (Address, error) {
 	return List(l).primitiveElem(i, expectedSize)
 }
 
@@ -414,7 +414,7 @@ func (l Int16List) ToPtr() Ptr {
 	return List(l).ToPtr()
 }
 
-func (l Int16List) primitiveElem(i int, expectedSize ObjectSize) (address, error) {
+func (l Int16List) primitiveElem(i int, expectedSize ObjectSize) (Address, error) {
 	return List(l).primitiveElem(i, expectedSize)
 }
 
@@ -446,7 +446,7 @@ func (l UInt16List) ToPtr() Ptr {
 	return List(l).ToPtr()
 }
 
-func (l UInt16List) primitiveElem(i int, expectedSize ObjectSize) (address, error) {
+func (l UInt16List) primitiveElem(i int, expectedSize ObjectSize) (Address, error) {
 	return List(l).primitiveElem(i, expectedSize)
 }
 
@@ -478,7 +478,7 @@ func (l Int32List) ToPtr() Ptr {
 	return List(l).ToPtr()
 }
 
-func (l Int32List) primitiveElem(i int, expectedSize ObjectSize) (address, error) {
+func (l Int32List) primitiveElem(i int, expectedSize ObjectSize) (Address, error) {
 	return List(l).primitiveElem(i, expectedSize)
 }
 
@@ -510,7 +510,7 @@ func (l UInt32List) ToPtr() Ptr {
 	return List(l).ToPtr()
 }
 
-func (l UInt32List) primitiveElem(i int, expectedSize ObjectSize) (address, error) {
+func (l UInt32List) primitiveElem(i int, expectedSize ObjectSize) (Address, error) {
 	return List(l).primitiveElem(i, expectedSize)
 }
 
@@ -542,7 +542,7 @@ func (l Int64List) ToPtr() Ptr {
 	return List(l).ToPtr()
 }
 
-func (l Int64List) primitiveElem(i int, expectedSize ObjectSize) (address, error) {
+func (l Int64List) primitiveElem(i int, expectedSize ObjectSize) (Address, error) {
 	return List(l).primitiveElem(i, expectedSize)
 }
 
@@ -574,6 +574,6 @@ func (l UInt64List) ToPtr() Ptr {
 	return List(l).ToPtr()
 }
 
-func (l UInt64List) primitiveElem(i int, expectedSize ObjectSize) (address, error) {
+func (l UInt64List) primitiveElem(i int, expectedSize ObjectSize) (Address, error) {
 	return List(l).primitiveElem(i, expectedSize)
 }

--- a/list.go
+++ b/list.go
@@ -18,7 +18,7 @@ type List ListKind
 // capture any list type.
 type ListKind = struct {
 	seg        *Segment
-	off        address    // at beginning of elements (past composite list tag word)
+	off        Address    // at beginning of elements (past composite list tag word)
 	length     int32      // always [0, 1<<29)
 	size       ObjectSize // always valid
 	depthLimit uint
@@ -184,7 +184,7 @@ func (p List) Len() int {
 
 // primitiveElem returns the address of the segment data for a list element.
 // Calling this on a bit list returns an error.
-func (p List) primitiveElem(i int, expectedSize ObjectSize) (address, error) {
+func (p List) primitiveElem(i int, expectedSize ObjectSize) (Address, error) {
 	if p.seg == nil || i < 0 || i >= int(p.length) {
 		// This is programmer error, not input error.
 		panic("list element out of bounds")
@@ -357,7 +357,7 @@ func (p PointerList) At(i int) (Ptr, error) {
 	if err != nil {
 		return Ptr{}, err
 	}
-	addr += address(p.size.DataSize)
+	addr += Address(p.size.DataSize)
 	return p.seg.readPtr(addr, p.depthLimit)
 }
 

--- a/message.go
+++ b/message.go
@@ -375,7 +375,7 @@ func (wc *writeCounter) Write(b []byte) (n int, err error) {
 // alloc allocates sz zero-filled bytes.  It prefers using s, but may
 // use a different segment in the same message if there's not sufficient
 // capacity.
-func alloc(s *Segment, sz Size) (*Segment, address, error) {
+func alloc(s *Segment, sz Size) (*Segment, Address, error) {
 	if sz > maxAllocSize() {
 		return nil, 0, errors.New("allocation: too large")
 	}

--- a/message_test.go
+++ b/message_test.go
@@ -76,7 +76,7 @@ func TestAlloc(t *testing.T) {
 		size Size
 
 		allocID SegmentID
-		addr    address
+		addr    Address
 	}
 	var tests []allocTest
 
@@ -585,7 +585,7 @@ func (ro readOnlyArena) String() string {
 	return fmt.Sprintf("readOnlyArena{%v}", ro.Arena)
 }
 
-func (readOnlyArena) Allocate(sz Size, msg *Message, seg *Segment) (*Segment, address, error) {
+func (readOnlyArena) Allocate(sz Size, msg *Message, seg *Segment) (*Segment, Address, error) {
 	return nil, 0, errReadOnlyArena
 }
 

--- a/pointer.go
+++ b/pointer.go
@@ -11,7 +11,7 @@ import (
 // The zero value is a null pointer.
 type Ptr struct {
 	seg        *Segment
-	off        address
+	off        Address
 	lenOrCap   uint32
 	size       ObjectSize
 	depthLimit uint

--- a/rawpointer.go
+++ b/rawpointer.go
@@ -11,13 +11,13 @@ type pointerOffset int32
 // resolve returns an absolute address relative to a base address.
 // For near pointers, the base is the end of the near pointer.
 // For far pointers, the base is zero (the beginning of the segment).
-func (off pointerOffset) resolve(base address) (_ address, ok bool) {
+func (off pointerOffset) resolve(base Address) (_ Address, ok bool) {
 	return base.element(int32(off), wordSize)
 }
 
 // nearPointerOffset computes the offset for a pointer at paddr to point to addr.
-func nearPointerOffset(paddr, addr address) pointerOffset {
-	return pointerOffset(addr/address(wordSize) - paddr/address(wordSize) - 1)
+func nearPointerOffset(paddr, addr Address) pointerOffset {
+	return pointerOffset(addr/Address(wordSize) - paddr/Address(wordSize) - 1)
 }
 
 // rawPointer is an encoded pointer.
@@ -45,12 +45,12 @@ func rawInterfacePointer(capability CapabilityID) rawPointer {
 }
 
 // rawFarPointer returns a pointer to a pointer in another segment.
-func rawFarPointer(segID SegmentID, off address) rawPointer {
+func rawFarPointer(segID SegmentID, off Address) rawPointer {
 	return rawPointer(farPointer) | rawPointer(off&^7) | (rawPointer(segID) << 32)
 }
 
 // rawDoubleFarPointer returns a pointer to a pointer in another segment.
-func rawDoubleFarPointer(segID SegmentID, off address) rawPointer {
+func rawDoubleFarPointer(segID SegmentID, off Address) rawPointer {
 	return rawPointer(doubleFarPointer) | rawPointer(off&^7) | (rawPointer(segID) << 32)
 }
 
@@ -171,11 +171,11 @@ func (p rawPointer) withOffset(off pointerOffset) rawPointer {
 }
 
 // farAddress returns the address of the landing pad pointer.
-func (p rawPointer) farAddress() address {
+func (p rawPointer) farAddress() Address {
 	// Far pointer offset is 29 bits, starting after the low 3 bits.
 	// It's an unsigned word offset, which would be equivalent to a
 	// logical left shift by 3.
-	return address(p) &^ 7
+	return Address(p) &^ 7
 }
 
 // farSegment returns the segment ID that the far pointer references.

--- a/rawpointer_test.go
+++ b/rawpointer_test.go
@@ -7,8 +7,8 @@ import (
 func TestPointerOffsetResolve(t *testing.T) {
 	tests := []struct {
 		off      pointerOffset
-		base     address
-		resolved address
+		base     Address
+		resolved Address
 		ok       bool
 	}{
 		{off: 0, base: 0, resolved: 0, ok: true},
@@ -164,7 +164,7 @@ func TestRawFarPointer(t *testing.T) {
 	tests := []struct {
 		ptr  rawPointer
 		typ  pointerType
-		addr address
+		addr Address
 		seg  SegmentID
 	}{
 		{0x0000000000000002, farPointer, 0, 0},

--- a/segment.go
+++ b/segment.go
@@ -44,61 +44,61 @@ func (s *Segment) Data() []byte {
 	return s.data
 }
 
-func (s *Segment) inBounds(addr address) bool {
-	return addr < address(len(s.data))
+func (s *Segment) inBounds(addr Address) bool {
+	return addr < Address(len(s.data))
 }
 
-func (s *Segment) regionInBounds(base address, sz Size) bool {
+func (s *Segment) regionInBounds(base Address, sz Size) bool {
 	end, ok := base.addSize(sz)
 	if !ok {
 		return false
 	}
-	return end <= address(len(s.data))
+	return end <= Address(len(s.data))
 }
 
 // slice returns the segment of data from base to base+sz.
 // It panics if the slice is out of bounds.
-func (s *Segment) slice(base address, sz Size) []byte {
+func (s *Segment) slice(base Address, sz Size) []byte {
 	return s.data[base:base.addSizeUnchecked(sz)]
 }
 
-func (s *Segment) readUint8(addr address) uint8 {
+func (s *Segment) readUint8(addr Address) uint8 {
 	return s.slice(addr, 1)[0]
 }
 
-func (s *Segment) readUint16(addr address) uint16 {
+func (s *Segment) readUint16(addr Address) uint16 {
 	return binary.LittleEndian.Uint16(s.slice(addr, 2))
 }
 
-func (s *Segment) readUint32(addr address) uint32 {
+func (s *Segment) readUint32(addr Address) uint32 {
 	return binary.LittleEndian.Uint32(s.slice(addr, 4))
 }
 
-func (s *Segment) readUint64(addr address) uint64 {
+func (s *Segment) readUint64(addr Address) uint64 {
 	return binary.LittleEndian.Uint64(s.slice(addr, 8))
 }
 
-func (s *Segment) readRawPointer(addr address) rawPointer {
+func (s *Segment) readRawPointer(addr Address) rawPointer {
 	return rawPointer(s.readUint64(addr))
 }
 
-func (s *Segment) writeUint8(addr address, val uint8) {
+func (s *Segment) writeUint8(addr Address, val uint8) {
 	s.slice(addr, 1)[0] = val
 }
 
-func (s *Segment) writeUint16(addr address, val uint16) {
+func (s *Segment) writeUint16(addr Address, val uint16) {
 	binary.LittleEndian.PutUint16(s.slice(addr, 2), val)
 }
 
-func (s *Segment) writeUint32(addr address, val uint32) {
+func (s *Segment) writeUint32(addr Address, val uint32) {
 	binary.LittleEndian.PutUint32(s.slice(addr, 4), val)
 }
 
-func (s *Segment) writeUint64(addr address, val uint64) {
+func (s *Segment) writeUint64(addr Address, val uint64) {
 	binary.LittleEndian.PutUint64(s.slice(addr, 8), val)
 }
 
-func (s *Segment) writeRawPointer(addr address, val rawPointer) {
+func (s *Segment) writeRawPointer(addr Address, val rawPointer) {
 	s.writeUint64(addr, uint64(val))
 }
 
@@ -125,7 +125,7 @@ func (s *Segment) lookupSegment(id SegmentID) (*Segment, error) {
 	return s.Message().Segment(id)
 }
 
-func (s *Segment) readPtr(paddr address, depthLimit uint) (ptr Ptr, err error) {
+func (s *Segment) readPtr(paddr Address, depthLimit uint) (ptr Ptr, err error) {
 	s, base, val, err := s.resolveFarPointer(paddr)
 	if err != nil {
 		return Ptr{}, exc.WrapError("read pointer", err)
@@ -171,7 +171,7 @@ func (s *Segment) readPtr(paddr address, depthLimit uint) (ptr Ptr, err error) {
 	}
 }
 
-func (s *Segment) readStructPtr(base address, val rawPointer) (Struct, error) {
+func (s *Segment) readStructPtr(base Address, val rawPointer) (Struct, error) {
 	addr, ok := val.offset().resolve(base)
 	if !ok {
 		return Struct{}, errors.New("struct pointer: invalid address")
@@ -187,7 +187,7 @@ func (s *Segment) readStructPtr(base address, val rawPointer) (Struct, error) {
 	}, nil
 }
 
-func (s *Segment) readListPtr(base address, val rawPointer) (List, error) {
+func (s *Segment) readListPtr(base Address, val rawPointer) (List, error) {
 	addr, ok := val.offset().resolve(base)
 	if !ok {
 		return List{}, errors.New("list pointer: invalid address")
@@ -242,7 +242,7 @@ func (s *Segment) readListPtr(base address, val rawPointer) (List, error) {
 	}, nil
 }
 
-func (s *Segment) resolveFarPointer(paddr address) (dst *Segment, base address, resolved rawPointer, err error) {
+func (s *Segment) resolveFarPointer(paddr Address) (dst *Segment, base Address, resolved rawPointer, err error) {
 	// Encoding details at https://capnproto.org/encoding.html#inter-segment-pointers
 
 	val := s.readRawPointer(paddr)
@@ -298,7 +298,7 @@ func (s *Segment) resolveFarPointer(paddr address) (dst *Segment, base address, 
 	}
 }
 
-func (s *Segment) writePtr(off address, src Ptr, forceCopy bool) error {
+func (s *Segment) writePtr(off Address, src Ptr, forceCopy bool) error {
 	if !src.IsValid() {
 		s.writeRawPointer(off, 0)
 		return nil
@@ -306,7 +306,7 @@ func (s *Segment) writePtr(off address, src Ptr, forceCopy bool) error {
 
 	// Copy src, if needed, and process pointers where placement is
 	// irrelevant (capabilities and zero-sized structs).
-	var srcAddr address
+	var srcAddr Address
 	var srcRaw rawPointer
 	switch src.flags.ptrType() {
 	case structPtrType:
@@ -355,7 +355,7 @@ func (s *Segment) writePtr(off address, src Ptr, forceCopy bool) error {
 			}
 			if dst.flags&isCompositeList != 0 {
 				// Copy tag word
-				newSeg.writeRawPointer(newAddr, l.seg.readRawPointer(l.off-address(wordSize)))
+				newSeg.writeRawPointer(newAddr, l.seg.readRawPointer(l.off-Address(wordSize)))
 				var ok bool
 				dst.off, ok = dst.off.addSize(wordSize)
 				if !ok {
@@ -379,7 +379,7 @@ func (s *Segment) writePtr(off address, src Ptr, forceCopy bool) error {
 		}
 		srcAddr = l.off
 		if l.flags&isCompositeList != 0 {
-			srcAddr -= address(wordSize)
+			srcAddr -= Address(wordSize)
 		}
 		srcRaw = l.raw()
 	case interfacePtrType:

--- a/segment_test.go
+++ b/segment_test.go
@@ -13,7 +13,7 @@ import (
 func TestSegmentInBounds(t *testing.T) {
 	tests := []struct {
 		n    int
-		addr address
+		addr Address
 		ok   bool
 	}{
 		{0, 0, false},
@@ -37,7 +37,7 @@ func TestSegmentInBounds(t *testing.T) {
 func TestSegmentRegionInBounds(t *testing.T) {
 	tests := []struct {
 		n    int
-		addr address
+		addr Address
 		sz   Size
 		ok   bool
 	}{
@@ -71,7 +71,7 @@ func TestSegmentRegionInBounds(t *testing.T) {
 func TestSegmentReadUint8(t *testing.T) {
 	tests := []struct {
 		data   []byte
-		addr   address
+		addr   Address
 		val    uint8
 		panics bool
 	}{
@@ -108,7 +108,7 @@ func TestSegmentReadUint8(t *testing.T) {
 func TestSegmentReadUint16(t *testing.T) {
 	tests := []struct {
 		data   []byte
-		addr   address
+		addr   Address
 		val    uint16
 		panics bool
 	}{
@@ -146,7 +146,7 @@ func TestSegmentReadUint16(t *testing.T) {
 func TestSegmentReadUint32(t *testing.T) {
 	tests := []struct {
 		data   []byte
-		addr   address
+		addr   Address
 		val    uint32
 		panics bool
 	}{
@@ -185,7 +185,7 @@ func TestSegmentReadUint32(t *testing.T) {
 func TestSegmentReadUint64(t *testing.T) {
 	tests := []struct {
 		data   []byte
-		addr   address
+		addr   Address
 		val    uint64
 		panics bool
 	}{
@@ -229,7 +229,7 @@ func TestSegmentReadUint64(t *testing.T) {
 func TestSegmentWriteUint8(t *testing.T) {
 	tests := []struct {
 		data   []byte
-		addr   address
+		addr   Address
 		val    uint8
 		out    []byte
 		panics bool
@@ -303,7 +303,7 @@ func TestSegmentWriteUint8(t *testing.T) {
 func TestSegmentWriteUint16(t *testing.T) {
 	tests := []struct {
 		data   []byte
-		addr   address
+		addr   Address
 		val    uint16
 		out    []byte
 		panics bool
@@ -347,7 +347,7 @@ func TestSegmentWriteUint16(t *testing.T) {
 func TestSegmentWriteUint32(t *testing.T) {
 	tests := []struct {
 		data   []byte
-		addr   address
+		addr   Address
 		val    uint32
 		out    []byte
 		panics bool
@@ -391,7 +391,7 @@ func TestSegmentWriteUint32(t *testing.T) {
 func TestSegmentWriteUint64(t *testing.T) {
 	tests := []struct {
 		data   []byte
-		addr   address
+		addr   Address
 		val    uint64
 		out    []byte
 		panics bool
@@ -620,7 +620,7 @@ func TestWriteFarPointer(t *testing.T) {
 	require.Equal(t, farPointer, root.pointerType())
 	require.Equal(t, SegmentID(1), root.farSegment())
 	padAddr := root.farAddress()
-	require.LessOrEqual(t, padAddr, address(len(seg1.Data())-8))
+	require.LessOrEqual(t, padAddr, Address(len(seg1.Data())-8))
 
 	pad := rawPointer(binary.LittleEndian.Uint64(seg1.Data()[padAddr:]))
 	if pad.pointerType() != structPointer {
@@ -675,7 +675,7 @@ func TestWriteDoubleFarPointer(t *testing.T) {
 		t.Fatalf("msg.Segment(%d): %v", root.farSegment(), err)
 	}
 	padAddr := root.farAddress()
-	if padAddr > address(len(padSeg.Data())-16) {
+	if padAddr > Address(len(padSeg.Data())-16) {
 		t.Fatalf("root points to out of bounds address %v; size of segment is %d", padAddr, len(padSeg.Data()))
 	}
 

--- a/struct.go
+++ b/struct.go
@@ -15,7 +15,7 @@ type Struct StructKind
 // capture any struct type.
 type StructKind = struct {
 	seg        *Segment
-	off        address
+	off        Address
 	size       ObjectSize
 	depthLimit uint
 	flags      structFlags
@@ -174,7 +174,7 @@ func (p Struct) SetData(i uint16, v []byte) error {
 	return p.SetPtr(i, d.ToPtr())
 }
 
-func (p Struct) pointerAddress(i uint16) address {
+func (p Struct) pointerAddress(i uint16) Address {
 	// Struct already had bounds check
 	ptrStart, _ := p.off.addSize(p.size.DataSize)
 	a, _ := ptrStart.element(int32(i), wordSize)
@@ -210,7 +210,7 @@ func (p Struct) SetBit(n BitOffset, v bool) {
 	p.seg.writeUint8(addr, b)
 }
 
-func (p Struct) dataAddress(off DataOffset, sz Size) (addr address, ok bool) {
+func (p Struct) dataAddress(off DataOffset, sz Size) (addr Address, ok bool) {
 	if p.seg == nil || Size(off)+sz > p.size.DataSize {
 		return 0, false
 	}


### PR DESCRIPTION
The `Arena` interface includes an `address` in the signature for the `Allocate` method.
These changes make `Address` public, which allows user programs to provide implementations of `Arena`.