### PR TITLE
rpc: make stream decode limits configurable

### DIFF
--- a/rpc/transport.go
+++ b/rpc/transport.go
@@ -11,15 +11,28 @@ import (
 type Codec = transport.Codec
 type Transport = transport.Transport
 type NewTransportFunc func(io.ReadWriteCloser) Transport
+type StreamTransportOptions = transport.StreamTransportOptions
 
 // NewStreamTransport is an alias for as transport.NewStream
 func NewStreamTransport(rwc io.ReadWriteCloser) Transport {
 	return transport.NewStream(rwc)
 }
 
+// NewStreamTransportWithOptions creates a stream transport with the given
+// options.
+func NewStreamTransportWithOptions(rwc io.ReadWriteCloser, opts StreamTransportOptions) Transport {
+	return transport.NewStreamWithOptions(rwc, opts)
+}
+
 // NewPackedStreamTransport is an alias for as transport.NewPackedStream
 func NewPackedStreamTransport(rwc io.ReadWriteCloser) Transport {
 	return transport.NewPackedStream(rwc)
+}
+
+// NewPackedStreamTransportWithOptions creates a packed stream transport with
+// the given options.
+func NewPackedStreamTransportWithOptions(rwc io.ReadWriteCloser, opts StreamTransportOptions) Transport {
+	return transport.NewPackedStreamWithOptions(rwc, opts)
 }
 
 // NewTransport is an alias for as transport.New

--- a/rpc/transport/transport.go
+++ b/rpc/transport/transport.go
@@ -91,6 +91,13 @@ type Codec interface {
 	Close() error
 }
 
+// StreamTransportOptions configures a stream transport.
+type StreamTransportOptions struct {
+	// MaxMessageSize is the maximum number of bytes accepted in an incoming
+	// message. If zero, the decoder's default limit is used.
+	MaxMessageSize uint64
+}
+
 // A transport serializes and deserializes Cap'n Proto using a Codec.
 // It adds no buffering beyond what is provided by the underlying
 // byte transfer mechanism.
@@ -109,7 +116,12 @@ func New(c Codec) Transport { return &transport{c: c} }
 // rwc's Close method must interrupt any outstanding IO, and it must be safe
 // to call rwc.Read and rwc.Write concurrently.
 func NewStream(rwc io.ReadWriteCloser) Transport {
-	return New(newStreamCodec(rwc, basicEncoding{}))
+	return NewStreamWithOptions(rwc, StreamTransportOptions{})
+}
+
+// NewStreamWithOptions creates a stream transport with the given options.
+func NewStreamWithOptions(rwc io.ReadWriteCloser, opts StreamTransportOptions) Transport {
+	return New(newStreamCodec(rwc, basicEncoding{}, opts))
 }
 
 // NewPackedStream creates a new transport that uses a packed
@@ -117,7 +129,13 @@ func NewStream(rwc io.ReadWriteCloser) Transport {
 //
 // See:  NewStream.
 func NewPackedStream(rwc io.ReadWriteCloser) Transport {
-	return New(newStreamCodec(rwc, packedEncoding{}))
+	return NewPackedStreamWithOptions(rwc, StreamTransportOptions{})
+}
+
+// NewPackedStreamWithOptions creates a packed stream transport with the
+// given options.
+func NewPackedStreamWithOptions(rwc io.ReadWriteCloser, opts StreamTransportOptions) Transport {
+	return New(newStreamCodec(rwc, packedEncoding{}, opts))
 }
 
 // NewMessage allocates a new message to be sent.
@@ -183,9 +201,11 @@ type streamCodec struct {
 	io.Closer
 }
 
-func newStreamCodec(rwc io.ReadWriteCloser, f streamEncoding) *streamCodec {
+func newStreamCodec(rwc io.ReadWriteCloser, f streamEncoding, opts StreamTransportOptions) *streamCodec {
+	decoder := f.NewDecoder(rwc)
+	decoder.MaxMessageSize = opts.MaxMessageSize
 	return &streamCodec{
-		Decoder: f.NewDecoder(rwc),
+		Decoder: decoder,
 		Encoder: f.NewEncoder(rwc),
 		Closer:  rwc,
 	}

--- a/rpc/transport/transport_test.go
+++ b/rpc/transport/transport_test.go
@@ -183,6 +183,123 @@ func TestTCPStreamTransport(t *testing.T) {
 	})
 }
 
+func TestStreamTransportOptions(t *testing.T) {
+	tests := []struct {
+		name    string
+		new     func(io.ReadWriteCloser, StreamTransportOptions) Transport
+		maxSize uint64
+	}{
+		{
+			name:    "UnpackedDefault",
+			new:     NewStreamWithOptions,
+			maxSize: 0,
+		},
+		{
+			name:    "UnpackedConfigured",
+			new:     NewStreamWithOptions,
+			maxSize: 128,
+		},
+		{
+			name:    "PackedDefault",
+			new:     NewPackedStreamWithOptions,
+			maxSize: 0,
+		},
+		{
+			name:    "PackedConfigured",
+			new:     NewPackedStreamWithOptions,
+			maxSize: 128,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			left, right := net.Pipe()
+			t.Cleanup(func() {
+				left.Close()
+				right.Close()
+			})
+
+			got := test.new(left, StreamTransportOptions{MaxMessageSize: test.maxSize})
+			codec := got.(*transport).c.(*streamCodec)
+			if codec.MaxMessageSize != test.maxSize {
+				t.Errorf("MaxMessageSize = %d; want %d", codec.MaxMessageSize, test.maxSize)
+			}
+		})
+	}
+}
+
+func TestStreamTransportOptions_MessageLimit(t *testing.T) {
+	tests := []struct {
+		name    string
+		new     func(io.ReadWriteCloser, StreamTransportOptions) Transport
+		encoder func(io.Writer) *capnp.Encoder
+		maxSize uint64
+		wantErr bool
+	}{
+		{
+			name:    "UnpackedAccept",
+			new:     NewStreamWithOptions,
+			encoder: capnp.NewEncoder,
+			maxSize: 32,
+		},
+		{
+			name:    "UnpackedReject",
+			new:     NewStreamWithOptions,
+			encoder: capnp.NewEncoder,
+			maxSize: 8,
+			wantErr: true,
+		},
+		{
+			name:    "PackedAccept",
+			new:     NewPackedStreamWithOptions,
+			encoder: capnp.NewPackedEncoder,
+			maxSize: 32,
+		},
+		{
+			name:    "PackedReject",
+			new:     NewPackedStreamWithOptions,
+			encoder: capnp.NewPackedEncoder,
+			maxSize: 8,
+			wantErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			left, right := net.Pipe()
+			t.Cleanup(func() {
+				left.Close()
+				right.Close()
+			})
+
+			msg, seg, err := capnp.NewMessage(capnp.SingleSegment(nil))
+			require.NoError(t, err)
+			_, err = capnp.NewRootStruct(seg, capnp.ObjectSize{DataSize: 8})
+			require.NoError(t, err)
+
+			writeErr := make(chan error, 1)
+			go func() {
+				writeErr <- test.encoder(right).Encode(msg)
+			}()
+
+			transport := test.new(left, StreamTransportOptions{MaxMessageSize: test.maxSize})
+			incoming, err := transport.RecvMessage()
+			if test.wantErr {
+				assert.Error(t, err)
+				require.NoError(t, left.Close())
+			} else {
+				require.NoError(t, err)
+				incoming.Release()
+			}
+			if test.wantErr {
+				assert.Error(t, <-writeErr)
+			} else {
+				require.NoError(t, <-writeErr)
+			}
+		})
+	}
+}
+
 func testTCPStreamTransport(t *testing.T, newTransport func(io.ReadWriteCloser) Transport) {
 	type listenCall struct {
 		c   *net.TCPConn


### PR DESCRIPTION
Adds `StreamTransportOptions{MaxMessageSize}` and option-aware normal and packed stream transport constructors. Existing constructors retain the 64 MiB default. Includes normal/packed acceptance and pre-allocation rejection coverage.

Fixes #609.