### PR TITLE
rpc: reject invalid promised answer targets

### DIFF
--- a/rpc/level0_test.go
+++ b/rpc/level0_test.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"os"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -1246,6 +1247,22 @@ func TestRecvBootstrapCallException(t *testing.T) {
 // requirement.
 func TestRecvBootstrapPipelineCall(t *testing.T) {
 	t.Parallel()
+	testRecvBootstrapPipelineCall(t)
+}
+
+func TestRecvBootstrapPipelineCallStress(t *testing.T) {
+	if os.Getenv("CAPNP_RPC_STRESS") != "1" {
+		t.Skip("set CAPNP_RPC_STRESS=1 to run promised-answer lifecycle stress test")
+	}
+
+	for i := 0; i < 100; i++ {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			testRecvBootstrapPipelineCall(t)
+		})
+	}
+}
+
+func testRecvBootstrapPipelineCall(t *testing.T) {
 
 	srvShutdown := make(chan struct{})
 	srv := newServer(

--- a/rpc/level0_test.go
+++ b/rpc/level0_test.go
@@ -1250,6 +1250,40 @@ func TestRecvBootstrapPipelineCall(t *testing.T) {
 	testRecvBootstrapPipelineCall(t)
 }
 
+func TestRecvPromisedAnswerMissingCapability(t *testing.T) {
+	t.Parallel()
+	srv := newServer(func(_ context.Context, call *server.Call) error {
+		results, err := call.AllocResults(capnp.ObjectSize{PointerCount: 1})
+		if err != nil {
+			return err
+		}
+		results.SetPtr(0, capnp.NewInterface(results.Segment(), 1).ToPtr())
+		return nil
+	}, nil)
+	left, right := transport.NewPipe(1)
+	conn := rpc.NewConn(rpc.NewTransport(left), &rpc.Options{BootstrapClient: srv, Logger: testErrorReporter{tb: t}})
+	p := rpc.NewTransport(right)
+	defer finishTest(t, conn, p)
+	ctx := context.Background()
+	const boot, source, bad, good = 1, 2, 3, 4
+	require.NoError(t, sendMessage(ctx, p, &rpcMessage{Which: rpccp.Message_Which_bootstrap, Bootstrap: &rpcBootstrap{QuestionID: boot}}))
+	_, err := recvBootstrapReturn(ctx, p, boot)
+	require.NoError(t, err)
+	send := func(qid uint32, target rpcMessageTarget) *rpcMessage {
+		require.NoError(t, sendMessage(ctx, p, &rpcMessage{Which: rpccp.Message_Which_call, Call: &rpcCall{QuestionID: qid, Target: target, InterfaceID: interfaceID, MethodID: methodID}}))
+		m, release, err := recvMessage(ctx, p)
+		require.NoError(t, err)
+		defer release()
+		return m
+	}
+	first := send(source, rpcMessageTarget{Which: rpccp.MessageTarget_Which_promisedAnswer, PromisedAnswer: &rpcPromisedAnswer{QuestionID: boot}})
+	require.Equal(t, rpccp.Return_Which_results, first.Return.Which)
+	badReturn := send(bad, rpcMessageTarget{Which: rpccp.MessageTarget_Which_promisedAnswer, PromisedAnswer: &rpcPromisedAnswer{QuestionID: source, Transform: []rpcPromisedAnswerOp{{Which: rpccp.PromisedAnswer_Op_Which_getPointerField, GetPointerField: 0}}}})
+	require.Equal(t, rpccp.Return_Which_exception, badReturn.Return.Which)
+	valid := send(good, rpcMessageTarget{Which: rpccp.MessageTarget_Which_promisedAnswer, PromisedAnswer: &rpcPromisedAnswer{QuestionID: boot}})
+	require.Equal(t, rpccp.Return_Which_results, valid.Return.Which)
+}
+
 func TestRecvBootstrapPipelineCallStress(t *testing.T) {
 	if os.Getenv("CAPNP_RPC_STRESS") != "1" {
 		t.Skip("set CAPNP_RPC_STRESS=1 to run promised-answer lifecycle stress test")

--- a/rpc/promised_target_test.go
+++ b/rpc/promised_target_test.go
@@ -1,0 +1,50 @@
+package rpc
+
+import (
+	"errors"
+	"testing"
+
+	"capnproto.org/go/capnp/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPromisedAnswerTarget(t *testing.T) {
+	t.Parallel()
+
+	msg, seg, err := capnp.NewMessage(capnp.SingleSegment(nil))
+	require.NoError(t, err)
+	defer msg.Release()
+
+	t.Run("MissingCapability", func(t *testing.T) {
+		target, err := promisedAnswerTarget(capnp.NewInterface(seg, 1).ToPtr(), nil)
+		assert.Error(t, err)
+		assert.False(t, target.IsValid())
+	})
+
+	t.Run("InvalidCapability", func(t *testing.T) {
+		target, err := promisedAnswerTarget(capnp.NewInterface(seg, 0).ToPtr(), []capnp.ClientSnapshot{{}})
+		assert.Error(t, err)
+		assert.False(t, target.IsValid())
+	})
+
+	t.Run("NonCapability", func(t *testing.T) {
+		st, err := capnp.NewStruct(seg, capnp.ObjectSize{})
+		require.NoError(t, err)
+		target, err := promisedAnswerTarget(st.ToPtr(), nil)
+		require.NoError(t, err)
+		defer target.Release()
+		assert.True(t, target.IsValid())
+	})
+
+	t.Run("Capability", func(t *testing.T) {
+		client := capnp.ErrorClient(errors.New("test"))
+		defer client.Release()
+		snapshot := client.Snapshot()
+		defer snapshot.Release()
+		target, err := promisedAnswerTarget(capnp.NewInterface(seg, 0).ToPtr(), []capnp.ClientSnapshot{snapshot})
+		require.NoError(t, err)
+		defer target.Release()
+		assert.True(t, target.IsValid())
+	})
+}

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -927,16 +927,11 @@ func (c *Conn) handleCall(ctx context.Context, in transport.IncomingMessage) err
 					dq.Defer(in.Release)
 					return nil
 				}
-				iface := sub.Interface()
-				var tgt capnp.ClientSnapshot
-				if sub.IsValid() && !iface.IsValid() {
-					tgt = capnp.ErrorClient(rpcerr.Failed(ErrNotACapability)).Snapshot()
-				} else {
-					capID := iface.Capability()
-					capTable := tgtAns.returner.resultsCapTable
-					if int(capID) < len(capTable) {
-						tgt = capTable[capID].AddRef()
-					}
+				tgt, err := promisedAnswerTarget(sub, tgtAns.returner.resultsCapTable)
+				if err != nil {
+					ans.sendException(dq, err)
+					dq.Defer(in.Release)
+					return nil
 				}
 
 				c.tasks.Add(1) // will be finished by answer.Return
@@ -967,6 +962,26 @@ func (c *Conn) handleCall(ctx context.Context, in transport.IncomingMessage) err
 			panic("unreachable")
 		}
 	})
+}
+
+// promisedAnswerTarget resolves an interface pointer from a promised answer's
+// results. The returned snapshot owns a reference and must be released by the
+// caller. A non-capability result is represented by an error client; a missing
+// capability-table entry is an invalid incoming call.
+func promisedAnswerTarget(sub capnp.Ptr, capTable []capnp.ClientSnapshot) (capnp.ClientSnapshot, error) {
+	iface := sub.Interface()
+	if !sub.IsValid() || !iface.IsValid() {
+		return capnp.ErrorClient(rpcerr.Failed(ErrNotACapability)).Snapshot(), nil
+	}
+
+	capID := iface.Capability()
+	if int(capID) >= len(capTable) || !capTable[capID].IsValid() {
+		return capnp.ClientSnapshot{}, rpcerr.Failed(errors.New(
+			"incoming call: promised answer capability index " + str.Utod(capID) +
+				" is not present in results capability table",
+		))
+	}
+	return capTable[capID].AddRef(), nil
 }
 
 // A promisedPipelineCaller is a PipelineCaller that stands in for another


### PR DESCRIPTION
Rejects missing or invalid transformed capability-table targets at the promised-answer protocol boundary, returning an RPC failure before callback/task scheduling. Includes deterministic target coverage and an opt-in lifecycle stress harness (`CAPNP_RPC_STRESS=1`).

Fixes #572.