### PR TITLE
capnp: make zero ClientSnapshot release a no-op

### DIFF
--- a/capability.go
+++ b/capability.go
@@ -692,6 +692,10 @@ func (cs ClientSnapshot) AddRef() ClientSnapshot {
 
 // Release the reference to the hook.
 func (cs *ClientSnapshot) Release() {
+	if cs.hook == nil {
+		return
+	}
+
 	cs.hook.Release()
 }
 

--- a/capability.go
+++ b/capability.go
@@ -690,7 +690,7 @@ func (cs ClientSnapshot) AddRef() ClientSnapshot {
 	return cs
 }
 
-// Release the reference to the hook.
+// Release the reference to the hook. Release on a zero ClientSnapshot is a no-op.
 func (cs *ClientSnapshot) Release() {
 	if cs.hook == nil {
 		return

--- a/capability_test.go
+++ b/capability_test.go
@@ -119,6 +119,12 @@ func TestReleasedClient(t *testing.T) {
 		t.Error("second Release made more calls to ClientHook.Shutdown")
 	}
 }
+
+func TestZeroClientSnapshotRelease(t *testing.T) {
+	var snapshot ClientSnapshot
+	snapshot.Release()
+}
+
 func TestResolve(t *testing.T) {
 	test := func(t *testing.T, name string, f func(t *testing.T, p1, p2 Client, r1, r2 Resolver[Client])) {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
Makes `ClientSnapshot.Release` a no-op for a zero-value snapshot and adds regression coverage for that contract. This is defensive cleanup hardening; the promised-answer protocol-boundary fix remains separate in #613.

Supersedes #610.