### PR TITLE
capnp: reject unpipelineable queued calls safely

### DIFF
--- a/answer_test.go
+++ b/answer_test.go
@@ -53,6 +53,40 @@ func TestPromiseReject(t *testing.T) {
 	})
 }
 
+func TestAnswerQueueFulfillLeafWithoutPipelineCaller(t *testing.T) {
+	aq := NewAnswerQueue(dummyMethod)
+	ret1 := new(dummyReturner)
+	pcall := aq.PipelineRecv(context.Background(), nil, Recv{
+		Method:      dummyMethod,
+		Returner:    ret1,
+		ReleaseArgs: func() {},
+	})
+	ret2 := new(dummyReturner)
+	pcall.PipelineRecv(context.Background(), nil, Recv{
+		Method:      dummyMethod,
+		Returner:    ret2,
+		ReleaseArgs: func() {},
+	})
+
+	msg, seg := NewSingleSegmentMessage(nil)
+	defer msg.Release()
+	capID := msg.CapTable().Add(ErrorClient(errors.New("test error")))
+	aq.Fulfill(NewInterface(seg, capID).ToPtr())
+
+	if !ret1.returned {
+		t.Fatal("first queued call was not returned")
+	}
+	if ret1.err == nil {
+		t.Fatal("first queued call was not rejected")
+	}
+	if !ret2.returned {
+		t.Fatal("dependent queued call was not returned")
+	}
+	if ret2.err == nil {
+		t.Fatal("dependent queued call was not rejected")
+	}
+}
+
 func TestPromiseFulfill(t *testing.T) {
 	t.Parallel()
 

--- a/answerqueue.go
+++ b/answerqueue.go
@@ -101,8 +101,17 @@ func (aq *AnswerQueue) Fulfill(ptr Ptr) {
 		pcall := recv(ent.ctx, ent.path, ent.Recv)
 		// The basis for our result will always be our index in the queue + 1
 		// since 0 is used for the initial fulfilled result.
-		aq.bases[i+1].recv = pcall.PipelineRecv
+		if pcall == nil {
+			aq.bases[i+1].recv = rejectPipelineCall
+		} else {
+			aq.bases[i+1].recv = pcall.PipelineRecv
+		}
 	}
+}
+
+func rejectPipelineCall(_ context.Context, _ []PipelineOp, r Recv) PipelineCaller {
+	r.Reject(errors.New("capnp: pipeline call has no pipeline caller"))
+	return nil
 }
 
 // Reject empties the queue, returning errors on all the method calls.


### PR DESCRIPTION
Prevents `AnswerQueue.Fulfill` from dereferencing a nil `PipelineCaller` when a queued call completes synchronously or is rejected. Dependent queued pipeline calls now receive a structured rejection instead of panicking.

Adds a regression test covering both leaf and dependent queued calls.