### PR TITLE
fix: enforce test tool bandwidth limit

### DIFF
--- a/flowcontrol/internal/test-tool/main.go
+++ b/flowcontrol/internal/test-tool/main.go
@@ -169,6 +169,10 @@ func (writerImpl) Write(ctx context.Context, p Writer_write) error {
 	if err != nil {
 		return err
 	}
-	time.Sleep(time.Duration(float64(len(data)) / (float64(*bandwidth) * float64(time.Second))))
+	time.Sleep(transferDelay(len(data), *bandwidth))
 	return nil
+}
+
+func transferDelay(size int, bytesPerSecond uint64) time.Duration {
+	return time.Duration(float64(size) / float64(bytesPerSecond) * float64(time.Second))
 }

--- a/flowcontrol/internal/test-tool/main_test.go
+++ b/flowcontrol/internal/test-tool/main_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func TestTransferDelay(t *testing.T) {
+	tests := []struct {
+		name           string
+		size           int
+		bytesPerSecond uint64
+		want           time.Duration
+	}{
+		{
+			name:           "one MiB per second",
+			size:           8192,
+			bytesPerSecond: 1_000_000,
+			want:           8_192 * time.Microsecond,
+		},
+		{
+			name:           "one GiB per second",
+			size:           8192,
+			bytesPerSecond: 1_000_000_000,
+			want:           8_192 * time.Nanosecond,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := transferDelay(test.size, test.bytesPerSecond); got != test.want {
+				t.Errorf("transferDelay(%d, %d) = %v; want %v", test.size, test.bytesPerSecond, got, test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- correct the test tool’s bytes-per-second to duration conversion
- add a regression test for representative transfer delays

The prior conversion truncated the configured delay to zero, so experiments did not enforce their requested server bandwidth.

## Verification

- `go test ./... -count=1 -timeout=3m`
- `go test -race ./flowcontrol/internal/test-tool ./flowcontrol/bbr -count=1`

## Manual BBR validation

With the corrected tool, BBR tracked configured 250 KB/s, 1 MB/s, and 10 MB/s caps within a few percent.