### PR TITLE
test: make BBR trace simulation deterministic

### DIFF
--- a/flowcontrol/bbr/limiter.go
+++ b/flowcontrol/bbr/limiter.go
@@ -28,6 +28,36 @@ type sendRequest struct {
 	replyChan chan<- packetMeta
 }
 
+type limiterWait struct {
+	acceptSend  bool
+	hasDeadline bool
+	deadline    time.Time
+}
+
+type limiterEventKind uint8
+
+const (
+	limiterSendEvent limiterEventKind = iota
+	limiterAckEvent
+	limiterPacingEvent
+)
+
+type limiterEvent struct {
+	kind limiterEventKind
+	size uint64
+	ack  packetMeta
+
+	// sendPending is only meaningful for limiterPacingEvent. A pacing
+	// deadline atomically consumes a waiting send when one is available,
+	// matching the non-blocking receive in the production actor.
+	sendPending bool
+}
+
+type limiterStepResult struct {
+	sent   bool
+	packet packetMeta
+}
+
 func (l *Limiter) StartMessage(ctx context.Context, size uint64) (gotResponse func(), err error) {
 	replyChan := make(chan packetMeta)
 	select {
@@ -57,107 +87,144 @@ func (l *Limiter) computeBDP() float64 {
 	return float64(bandwidth) * float64(delay.Nanoseconds())
 }
 
+// prepareStep determines what the limiter actor should wait for next. It and
+// step form the synchronous limiter state machine. They must be called either
+// by run, or by the sole owner of an unstarted limiter in a test; they are not
+// safe to call concurrently with a running limiter actor.
+func (l *Limiter) prepareStep(now time.Time) limiterWait {
+	bdp := l.computeBDP()
+
+	if l.inflight() == 0 {
+		// With nothing on the wire there is no ACK that can unblock an
+		// inaccurate initial pacing estimate, so always accept a send.
+		return limiterWait{acceptSend: true}
+	}
+	if l.packetsInflight >= l.maxPacketsInflight ||
+		(bdp > 0 && float64(l.inflight()) >= l.cwndGain*bdp) {
+		return limiterWait{}
+	}
+	if l.pacingReady {
+		return limiterWait{acceptSend: true}
+	}
+	if now.After(l.nextSendTime) {
+		l.appLimitedUntil = l.inflight()
+		return limiterWait{acceptSend: true}
+	}
+	return limiterWait{hasDeadline: true, deadline: l.nextSendTime}
+}
+
+// step applies one explicit ACK, send, or pacing-deadline event. Pause and
+// cancellation do not alter congestion-control state and remain concerns of
+// the production channel adapter in run.
+func (l *Limiter) step(now time.Time, event limiterEvent) limiterStepResult {
+	switch event.kind {
+	case limiterSendEvent:
+		return limiterStepResult{sent: true, packet: l.doSendAt(now, event.size)}
+	case limiterAckEvent:
+		l.onAckAt(now, event.ack)
+		return limiterStepResult{}
+	case limiterPacingEvent:
+		if event.sendPending {
+			return limiterStepResult{sent: true, packet: l.doSendAt(now, event.size)}
+		}
+		// Remember that this pacing opportunity has already fired. A real
+		// clock advances past a zero-duration timer; a virtual clock does
+		// not, so the latch prevents repeatedly firing at the same instant.
+		l.appLimitedUntil = l.inflight()
+		l.pacingReady = true
+		return limiterStepResult{}
+	default:
+		panic("bbr: invalid limiter event")
+	}
+}
+
 func (l *Limiter) run(ctx context.Context) {
+	defer close(l.done)
 	for {
-
-		// These channels may or may not be nil, depending on what
-		// we want to listen for:
 		var (
-			// Kept so a timer abandoned by an ACK or a pause does not later
-			// fire into an obsolete iteration of the event loop.
-			sendTimer clock.Timer
-
-			// Fires when we cross the threshold past l.nextSendTime.
+			sendTimer  clock.Timer
 			timeToSend <-chan time.Time
-
-			// Fires when someone wants to send.
-			sendReqs <-chan sendRequest
+			sendReqs   <-chan sendRequest
 		)
 
-		bdp := l.computeBDP()
-
 		now := l.clock.Now()
-
-		if l.inflight() == 0 {
-			// We can't let the general purpose logic handle this case,
-			// because if we don't have good information yet nextSendTime
-			// might be in the far future, and there is no ack on its way
-			// to save us from our ignorance. Fortunately we always want
-			// to send if there's nothing on the wire, so just do it.
+		wait := l.prepareStep(now)
+		if wait.acceptSend {
 			sendReqs = l.chSend
-		} else if l.packetsInflight >= l.maxPacketsInflight ||
-			(bdp > 0 && float64(l.inflight()) >= l.cwndGain*bdp) {
-			// We're at our threshold; wait for an ack,
-			// but ignore other signals.
-			//
-			// Note: bdp == 0 means we just don't have any data yet,
-			// so we filter out that scenario.
-		} else if now.After(l.nextSendTime) {
-			// We're bottlnecked on the app, not the path;
-			// record that we're app limited, and don't watch the timer,
-			// but do watch the send queue:
-			l.appLimitedUntil = l.inflight()
-			sendReqs = l.chSend
-		} else {
-			// App is sending fast enough for congestion
-			// control to be active; wait until nextSendTime
-			// before servicing a request:
-			sleep := l.nextSendTime.Sub(now)
+		} else if wait.hasDeadline {
+			sleep := wait.deadline.Sub(now)
 			sendTimer = l.clock.NewTimer(sleep)
 			timeToSend = sendTimer.Chan()
 		}
 
-		handled, paused := true, false
+		var (
+			event       limiterEvent
+			eventTime   time.Time
+			handleEvent bool
+			replyChan   chan<- packetMeta
+			cancelled   bool
+			paused      bool
+		)
 		select {
 		case <-ctx.Done():
-			return
+			cancelled = true
 		case p := <-l.chAck:
-			l.onAck(p)
+			eventTime = l.clock.Now()
+			event = limiterEvent{kind: limiterAckEvent, ack: p}
+			handleEvent = true
 		case <-timeToSend:
-			l.trySend()
+			event = limiterEvent{kind: limiterPacingEvent}
+			select {
+			case req := <-l.chSend:
+				eventTime = l.clock.Now()
+				event.size = req.size
+				event.sendPending = true
+				replyChan = req.replyChan
+			default:
+			}
+			handleEvent = true
 		case req := <-sendReqs:
-			now := l.clock.Now()
-			l.doSend(now, req)
+			eventTime = l.clock.Now()
+			event = limiterEvent{kind: limiterSendEvent, size: req.size}
+			replyChan = req.replyChan
+			handleEvent = true
 		case <-l.chPause:
-			handled = false
 			paused = true
 		}
 		if sendTimer != nil {
 			sendTimer.Stop()
 		}
+		if cancelled {
+			return
+		}
 		if paused {
 			l.chPause <- struct{}{}
+			continue
 		}
-		if handled && l.afterEvent != nil {
-			l.afterEvent()
+		if handleEvent {
+			result := l.step(eventTime, event)
+			if result.sent {
+				replyChan <- result.packet
+			}
 		}
 	}
 }
 
-func (l *Limiter) trySend() {
-	select {
-	case req := <-l.chSend:
-		now := l.clock.Now()
-		l.doSend(now, req)
-	default:
-		l.appLimitedUntil = l.inflight()
-	}
-}
-
-func (l *Limiter) doSend(now time.Time, req sendRequest) {
+func (l *Limiter) doSendAt(now time.Time, size uint64) packetMeta {
+	l.pacingReady = false
 	l.packetsInflight++
 	p := packetMeta{
-		Size:          req.size,
+		Size:          size,
 		AppLimited:    l.appLimitedUntil > 0,
 		SendTime:      now,
 		Delivered:     l.delivered,
 		DeliveredTime: l.deliveredTime,
 	}
 	l.nextSendTime = now.Add(time.Duration(
-		float64(req.size) / (l.pacingGain * float64(l.btlBwFilter.Estimate)),
+		float64(size) / (l.pacingGain * float64(l.btlBwFilter.Estimate)),
 	))
-	l.sent += req.size
-	req.replyChan <- p
+	l.sent += size
+	return p
 }
 
 // A Limiter implements flowcontrol.FlowLimiter using the BBR algorithm.
@@ -204,6 +271,11 @@ type Limiter struct {
 	// Earliest time at which it is appropriate to send.
 	nextSendTime time.Time
 
+	// pacingReady records that a pacing timer fired while no sender was
+	// waiting. It is explicit because virtual time does not advance between
+	// firing a zero-duration timer and preparing the next actor iteration.
+	pacingReady bool
+
 	sent          uint64    // Total data sent
 	delivered     uint64    // Total data delivered & ACKed
 	deliveredTime time.Time // Time of the last ACK we received.
@@ -226,20 +298,27 @@ type Limiter struct {
 	// This channel is used for testing; the whilePaused() method needs it.
 	chPause chan struct{}
 
-	// Private test seams for deterministic simulations.
-	randInt    func() int
-	afterEvent func()
+	// Closed after the actor exits. This makes snapshots after Release safe:
+	// once done is closed, no goroutine can still mutate limiter state.
+	done chan struct{}
+
+	// Private test seam for deterministic ProbeBW initialization.
+	randInt func() int
 }
 
 // For testing purpoes; temporarily pauses the goroutine managing the limiter,
 // and runs the callback. This lets us inspect the state of the limiter in
 // tests without data races.
 func (l *Limiter) whilePaused(f func()) {
-	l.chPause <- struct{}{}
-	defer func() {
-		<-l.chPause
-	}()
-	f()
+	select {
+	case l.chPause <- struct{}{}:
+		defer func() {
+			<-l.chPause
+		}()
+		f()
+	case <-l.done:
+		f()
+	}
 }
 
 // inflight returns the total bytes in-flight
@@ -255,11 +334,19 @@ func NewLimiter(clk clock.Clock) *Limiter {
 }
 
 type limiterOptions struct {
-	randInt    func() int
-	afterEvent func()
+	randInt func() int
 }
 
 func newLimiter(clk clock.Clock, options limiterOptions) *Limiter {
+	l := newLimiterState(clk, options)
+	go l.run(l.ctx)
+	return l
+}
+
+// newLimiterState constructs a limiter without starting its actor. Production
+// must use newLimiter; deterministic tests may drive the synchronous state
+// machine directly while retaining exclusive ownership.
+func newLimiterState(clk clock.Clock, options limiterOptions) *Limiter {
 	if clk == nil {
 		clk = clock.System
 	}
@@ -284,20 +371,18 @@ func newLimiter(clk clock.Clock, options limiterOptions) *Limiter {
 
 		maxPacketsInflight: math.MaxUint64,
 
-		chPause:    make(chan struct{}),
-		randInt:    options.randInt,
-		afterEvent: options.afterEvent,
+		chPause: make(chan struct{}),
+		done:    make(chan struct{}),
+		randInt: options.randInt,
 	}
-	l.changeState(&startupState{})
-	go l.run(ctx)
+	l.changeState(&startupState{}, now)
 	return l
 }
 
-// onAck should be invoked on each packetMeta when the acknowledgement for
+// onAckAt should be invoked on each packetMeta when the acknowledgement for
 // that packet is received.
-func (l *Limiter) onAck(p packetMeta) {
+func (l *Limiter) onAckAt(now time.Time, p packetMeta) {
 	l.packetsInflight--
-	now := l.clock.Now()
 	rtt := now.Sub(p.SendTime)
 
 	l.rtPropFilter.AddSample(rtPropSample{
@@ -316,13 +401,17 @@ func (l *Limiter) onAck(p packetMeta) {
 		l.btlBwFilter.AddSample(deliveryRate)
 	}
 	if l.appLimitedUntil > 0 {
-		l.appLimitedUntil -= p.Size
+		if p.Size >= l.appLimitedUntil {
+			l.appLimitedUntil = 0
+		} else {
+			l.appLimitedUntil -= p.Size
+		}
 	}
 
 	l.state.postAck(l, p, now)
 }
 
-func (l *Limiter) changeState(s state) {
+func (l *Limiter) changeState(s state, now time.Time) {
 	l.state = s
-	l.state.initialize(l)
+	l.state.initialize(l, now)
 }

--- a/flowcontrol/bbr/limiter.go
+++ b/flowcontrol/bbr/limiter.go
@@ -3,6 +3,7 @@ package bbr
 import (
 	"context"
 	"math"
+	"math/rand"
 	"time"
 
 	"capnproto.org/go/capnp/v3/exp/clock"
@@ -62,6 +63,10 @@ func (l *Limiter) run(ctx context.Context) {
 		// These channels may or may not be nil, depending on what
 		// we want to listen for:
 		var (
+			// Kept so a timer abandoned by an ACK or a pause does not later
+			// fire into an obsolete iteration of the event loop.
+			sendTimer clock.Timer
+
 			// Fires when we cross the threshold past l.nextSendTime.
 			timeToSend <-chan time.Time
 
@@ -98,9 +103,11 @@ func (l *Limiter) run(ctx context.Context) {
 			// control to be active; wait until nextSendTime
 			// before servicing a request:
 			sleep := l.nextSendTime.Sub(now)
-			timeToSend = l.clock.NewTimer(sleep).Chan()
+			sendTimer = l.clock.NewTimer(sleep)
+			timeToSend = sendTimer.Chan()
 		}
 
+		handled, paused := true, false
 		select {
 		case <-ctx.Done():
 			return
@@ -112,7 +119,17 @@ func (l *Limiter) run(ctx context.Context) {
 			now := l.clock.Now()
 			l.doSend(now, req)
 		case <-l.chPause:
+			handled = false
+			paused = true
+		}
+		if sendTimer != nil {
+			sendTimer.Stop()
+		}
+		if paused {
 			l.chPause <- struct{}{}
+		}
+		if handled && l.afterEvent != nil {
+			l.afterEvent()
 		}
 	}
 }
@@ -208,6 +225,10 @@ type Limiter struct {
 
 	// This channel is used for testing; the whilePaused() method needs it.
 	chPause chan struct{}
+
+	// Private test seams for deterministic simulations.
+	randInt    func() int
+	afterEvent func()
 }
 
 // For testing purpoes; temporarily pauses the goroutine managing the limiter,
@@ -230,8 +251,20 @@ func (l *Limiter) inflight() uint64 {
 // message resposne times. If nil is passed (typical, except for testing & debugging),
 // the system clock will be used.
 func NewLimiter(clk clock.Clock) *Limiter {
+	return newLimiter(clk, limiterOptions{randInt: rand.Int})
+}
+
+type limiterOptions struct {
+	randInt    func() int
+	afterEvent func()
+}
+
+func newLimiter(clk clock.Clock, options limiterOptions) *Limiter {
 	if clk == nil {
 		clk = clock.System
+	}
+	if options.randInt == nil {
+		options.randInt = rand.Int
 	}
 	now := clk.Now()
 	ctx, cancel := context.WithCancel(context.Background())
@@ -251,7 +284,9 @@ func NewLimiter(clk clock.Clock) *Limiter {
 
 		maxPacketsInflight: math.MaxUint64,
 
-		chPause: make(chan struct{}),
+		chPause:    make(chan struct{}),
+		randInt:    options.randInt,
+		afterEvent: options.afterEvent,
 	}
 	l.changeState(&startupState{})
 	go l.run(ctx)

--- a/flowcontrol/bbr/simulator_test.go
+++ b/flowcontrol/bbr/simulator_test.go
@@ -4,112 +4,32 @@ import (
 	"context"
 	"sort"
 	"sync"
+	"testing"
 	"time"
 
 	"capnproto.org/go/capnp/v3/exp/clock"
 )
 
-// simClock is a clock whose timers are fired explicitly by simulator.  It
-// deliberately does not try to run goroutines: the simulator chooses both
-// virtual-time ordering and the next timer to fire.
+// simClock advances only when the synchronous simulator tells it to. Its
+// NewTimer method deliberately panics: limiter tests must drive prepareStep
+// and step directly rather than accidentally starting the production actor.
 type simClock struct {
-	mu      sync.Mutex
-	now     time.Time
-	nextID  uint64
-	timers  []*simTimer
-	changed chan struct{}
+	now time.Time
 }
 
-type simTimer struct {
-	clock    *simClock
-	deadline time.Time
-	id       uint64
-	active   bool
-	ch       chan time.Time
-}
+func newSimClock(now time.Time) *simClock { return &simClock{now: now} }
 
-func newSimClock(now time.Time) *simClock {
-	return &simClock{now: now, changed: make(chan struct{}, 1)}
-}
+func (c *simClock) Now() time.Time { return c.now }
 
-func (c *simClock) Now() time.Time {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	return c.now
-}
-
-func (c *simClock) NewTimer(d time.Duration) clock.Timer {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.nextID++
-	t := &simTimer{
-		clock:    c,
-		deadline: c.now.Add(d),
-		id:       c.nextID,
-		active:   true,
-		ch:       make(chan time.Time, 1),
-	}
-	c.timers = append(c.timers, t)
-	c.notifyChanged()
-	return t
-}
-
-func (c *simClock) notifyChanged() {
-	select {
-	case c.changed <- struct{}{}:
-	default:
-	}
+func (c *simClock) NewTimer(time.Duration) clock.Timer {
+	panic("bbr: synchronous simulator must not create clock timers")
 }
 
 func (c *simClock) AdvanceTo(now time.Time) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
 	if now.Before(c.now) {
 		panic("simulated clock moved backwards")
 	}
 	c.now = now
-}
-
-func (c *simClock) nextTimer() *simTimer {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	var next *simTimer
-	for _, t := range c.timers {
-		if !t.active || (next != nil && (next.deadline.Before(t.deadline) || next.deadline.Equal(t.deadline) && next.id < t.id)) {
-			continue
-		}
-		next = t
-	}
-	return next
-}
-
-func (c *simClock) fire(t *simTimer) bool {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	if !t.active || t.deadline.After(c.now) {
-		return false
-	}
-	t.active = false
-	t.ch <- c.now
-	return true
-}
-
-func (t *simTimer) Chan() <-chan time.Time { return t.ch }
-
-func (t *simTimer) Reset(d time.Duration) {
-	t.clock.mu.Lock()
-	defer t.clock.mu.Unlock()
-	t.deadline = t.clock.now.Add(d)
-	t.active = true
-	t.clock.notifyChanged()
-}
-
-func (t *simTimer) Stop() bool {
-	t.clock.mu.Lock()
-	defer t.clock.mu.Unlock()
-	wasActive := t.active
-	t.active = false
-	return wasActive
 }
 
 type simPacket struct {
@@ -118,8 +38,8 @@ type simPacket struct {
 	packet   testPacket
 }
 
-// simPath reproduces testLink's fixed-delay and serial bandwidth-limited
-// links without worker goroutines.
+// simPath models overlapping fixed propagation delay and serial
+// bandwidth-limited links without worker goroutines.
 type simPath struct {
 	clock         *simClock
 	links         []testLink
@@ -179,133 +99,410 @@ func (p *simPath) advance(d time.Duration) {
 	}
 }
 
+func TestLinkDelayOverlapsPackets(t *testing.T) {
+	clock := newSimClock(sampleStartTime)
+	path := newSimPath(clock, testLink{delay: 4 * time.Second})
+	var arrivals []time.Time
+	for i := 0; i < 2; i++ {
+		path.send(testPacket{gotResponse: func() {
+			arrivals = append(arrivals, clock.Now())
+		}})
+	}
+
+	path.advance(4 * time.Second)
+	if len(arrivals) != 2 {
+		t.Fatalf("fixed-delay link delivered %d packets; want 2", len(arrivals))
+	}
+	if !arrivals[0].Equal(arrivals[1]) {
+		t.Fatalf("fixed-delay packets arrived at %v and %v; propagation delay must overlap", arrivals[0], arrivals[1])
+	}
+}
+
 type simulator struct {
-	t       testingT
 	clock   *simClock
 	path    *simPath
 	lim     *Limiter
-	events  chan struct{}
+	wait    limiterWait
 	results []Snapshot
 }
 
-// testingT keeps the simulator useful to the small path tests without making
-// it responsible for reporting failures from a goroutine.
-type testingT interface {
-	Helper()
-	Fatal(...any)
-}
-
-func newSimulator(t testingT, links ...testLink) *simulator {
-	t.Helper()
-	events := make(chan struct{}, 1)
+func newSimulator(links ...testLink) *simulator {
 	clock := newSimClock(sampleStartTime)
 	s := &simulator{
-		t:      t,
-		clock:  clock,
-		path:   newSimPath(clock, links...),
-		events: events,
+		clock: clock,
+		path:  newSimPath(clock, links...),
+		lim: newLimiterState(clock, limiterOptions{
+			randInt: func() int { return 6 }, // enter ProbeBW at the 1.25 phase
+		}),
 	}
-	s.lim = newLimiter(clock, limiterOptions{
-		randInt: func() int { return 6 }, // begin ProbeBW at the 1.25 gain phase
-		afterEvent: func() {
-			events <- struct{}{}
-		},
-	})
+	s.wait = s.lim.prepareStep(clock.Now())
 	return s
 }
 
-func (s *simulator) close() { s.lim.Release() }
-
-func (s *simulator) snapshot() {
-	s.results = append(s.results, SnapshotLimiter(s.lim))
-}
-
-func (s *simulator) settle() { _ = SnapshotLimiter(s.lim) }
-
-func (s *simulator) waitEvent() { <-s.events }
-
-func (s *simulator) drainEvents() {
-	for {
-		select {
-		case <-s.events:
-		default:
-			return
-		}
+// apply owns one atomic limiter transition and records its stable wait-state
+// boundary. A sent packet is put on the path before the snapshot, but ACK
+// delivery remains an explicit later event.
+func (s *simulator) apply(event limiterEvent) {
+	result := s.lim.step(s.clock.Now(), event)
+	if result.sent {
+		packet := result.packet
+		s.path.send(testPacket{
+			size: packet.Size,
+			gotResponse: func() {
+				s.apply(limiterEvent{kind: limiterAckEvent, ack: packet})
+			},
+		})
 	}
+	s.wait = s.lim.prepareStep(s.clock.Now())
+	s.results = append(s.results, s.lim.snapshotAt(s.clock.Now()))
 }
 
-func (s *simulator) step() bool {
-	packet, hasPacket := s.path.nextPacket()
-	timer := s.clock.nextTimer()
-	if !hasPacket && timer == nil {
+func (s *simulator) deliverNextAck() bool {
+	packet, ok := s.path.nextPacket()
+	if !ok {
 		return false
 	}
-	if hasPacket && (timer == nil || packet.deadline.Before(timer.deadline) || packet.deadline.Equal(timer.deadline)) {
-		s.clock.AdvanceTo(packet.deadline)
-		s.path.popPacket().packet.gotResponse()
-		s.waitEvent()
-		s.snapshot()
-		s.drainEvents()
-		return true
-	}
-	s.clock.AdvanceTo(timer.deadline)
-	if !s.clock.fire(timer) {
-		return true
-	}
-	s.waitEvent()
-	s.settle()
-	s.snapshot()
-	s.drainEvents()
+	s.clock.AdvanceTo(packet.deadline)
+	s.path.popPacket().packet.gotResponse()
 	return true
 }
 
-func (s *simulator) send(size uint64) {
-	result := make(chan testPacket, 1)
-	ctx := context.Background()
-	go func() {
-		gotResponse, err := s.lim.StartMessage(ctx, size)
-		if err != nil {
-			panic(err)
-		}
-		result <- testPacket{size: size, gotResponse: gotResponse}
-	}()
+func (s *simulator) deliverDueAck() bool {
+	packet, ok := s.path.nextPacket()
+	if !ok || packet.deadline.After(s.clock.Now()) {
+		return false
+	}
+	return s.deliverNextAck()
+}
 
+func (s *simulator) send(size uint64) {
 	for {
-		select {
-		case packet := <-result:
-			s.path.send(packet)
-			s.settle()
-			s.snapshot()
-			s.drainEvents()
-			return
-		default:
-		}
-		if s.step() {
+		// At one virtual timestamp, ACKs are processed FIFO before a due
+		// pacing event and before this application send.
+		if s.deliverDueAck() {
 			continue
 		}
-		select {
-		case packet := <-result:
-			s.path.send(packet)
-			s.settle()
-			s.snapshot()
-			s.drainEvents()
+		if s.wait.acceptSend {
+			s.apply(limiterEvent{kind: limiterSendEvent, size: size})
 			return
-		case <-s.events:
-		case <-s.clock.changed:
 		}
+
+		packet, hasPacket := s.path.nextPacket()
+		if s.wait.hasDeadline {
+			// Equal-time ACKs win. The ACK transition may invalidate or
+			// replace this pacing deadline before it can fire.
+			if hasPacket && !s.wait.deadline.Before(packet.deadline) {
+				s.deliverNextAck()
+				continue
+			}
+			s.clock.AdvanceTo(s.wait.deadline)
+			s.apply(limiterEvent{
+				kind:        limiterPacingEvent,
+				size:        size,
+				sendPending: true,
+			})
+			return
+		}
+
+		if !hasPacket {
+			panic("bbr: limiter is ACK-gated with no packet in flight")
+		}
+		s.deliverNextAck()
 	}
 }
 
 func (s *simulator) drain() {
-	for s.step() {
+	for {
+		packet, hasPacket := s.path.nextPacket()
+		if !hasPacket {
+			return
+		}
+		if !packet.deadline.After(s.clock.Now()) {
+			s.deliverNextAck()
+			continue
+		}
+		if s.wait.hasDeadline && s.wait.deadline.Before(packet.deadline) {
+			s.clock.AdvanceTo(s.wait.deadline)
+			s.apply(limiterEvent{kind: limiterPacingEvent})
+			continue
+		}
+		// An ACK wins a tie with a pacing deadline.
+		s.deliverNextAck()
 	}
 }
 
 func (s *simulator) run(packetSizes []uint64) []Snapshot {
-	defer s.close()
+	defer s.lim.Release()
 	for _, size := range packetSizes {
 		s.send(size)
 	}
 	s.drain()
 	return s.results
+}
+
+func TestLimiterPrepareStepGates(t *testing.T) {
+	t.Run("zero inflight bypasses limits", func(t *testing.T) {
+		clock := newSimClock(sampleStartTime)
+		lim := newLimiterState(clock, limiterOptions{})
+		lim.maxPacketsInflight = 0
+		if wait := lim.prepareStep(clock.Now()); !wait.acceptSend {
+			t.Fatal("zero-inflight limiter did not accept a send")
+		}
+	})
+
+	t.Run("packet limit gates sends", func(t *testing.T) {
+		clock := newSimClock(sampleStartTime)
+		lim := newLimiterState(clock, limiterOptions{})
+		lim.sent = 1
+		lim.packetsInflight = 1
+		lim.maxPacketsInflight = 1
+		wait := lim.prepareStep(clock.Now())
+		if wait.acceptSend || wait.hasDeadline {
+			t.Fatal("packet-limited state should wait only for an ACK")
+		}
+	})
+
+	t.Run("byte window uses greater-than-or-equal gate", func(t *testing.T) {
+		clock := newSimClock(sampleStartTime)
+		lim := newLimiterState(clock, limiterOptions{})
+		lim.sent = 1
+		lim.packetsInflight = 1
+		lim.btlBwFilter.Estimate = 1 * bytesPerSecond
+		lim.rtPropFilter.Estimate = time.Second
+		lim.cwndGain = 1
+		wait := lim.prepareStep(clock.Now())
+		if wait.acceptSend || wait.hasDeadline {
+			t.Fatal("limiter at its byte window should wait only for an ACK")
+		}
+	})
+
+	t.Run("zero BDP does not gate pacing", func(t *testing.T) {
+		clock := newSimClock(sampleStartTime)
+		lim := newLimiterState(clock, limiterOptions{})
+		lim.sent = 1
+		lim.packetsInflight = 1
+		lim.rtPropFilter.Estimate = 0
+		if wait := lim.prepareStep(clock.Now()); !wait.hasDeadline {
+			t.Fatal("zero BDP incorrectly activated the byte window gate")
+		}
+	})
+}
+
+func TestLimiterPacingDeadline(t *testing.T) {
+	newPacedLimiter := func(t *testing.T) (*simClock, *Limiter, limiterWait) {
+		t.Helper()
+		clock := newSimClock(sampleStartTime)
+		lim := newLimiterState(clock, limiterOptions{randInt: func() int { return 6 }})
+		if wait := lim.prepareStep(clock.Now()); !wait.acceptSend {
+			t.Fatal("new limiter did not accept its first send")
+		}
+		result := lim.step(clock.Now(), limiterEvent{kind: limiterSendEvent, size: 1})
+		if !result.sent {
+			t.Fatal("first send was not applied")
+		}
+		wait := lim.prepareStep(clock.Now())
+		if !wait.hasDeadline {
+			t.Fatal("in-flight limiter did not expose a pacing deadline")
+		}
+		clock.AdvanceTo(wait.deadline)
+		return clock, lim, wait
+	}
+
+	t.Run("pending send at equality is not app limited", func(t *testing.T) {
+		clock, lim, _ := newPacedLimiter(t)
+		wait := lim.prepareStep(clock.Now())
+		if wait.acceptSend || !wait.hasDeadline || !wait.deadline.Equal(clock.Now()) {
+			t.Fatal("exact deadline was not preserved as a pacing event")
+		}
+		result := lim.step(clock.Now(), limiterEvent{
+			kind:        limiterPacingEvent,
+			size:        1,
+			sendPending: true,
+		})
+		if !result.sent || result.packet.AppLimited {
+			t.Fatal("pending deadline send was not sent as pacing-limited traffic")
+		}
+		if lim.pacingReady {
+			t.Fatal("send did not clear pacing-ready latch")
+		}
+	})
+
+	t.Run("idle equality latches readiness once", func(t *testing.T) {
+		clock, lim, _ := newPacedLimiter(t)
+		if wait := lim.prepareStep(clock.Now()); wait.acceptSend || !wait.hasDeadline {
+			t.Fatal("exact deadline did not require a pacing event")
+		}
+		lim.step(clock.Now(), limiterEvent{kind: limiterPacingEvent})
+		if !lim.pacingReady || lim.appLimitedUntil != lim.inflight() {
+			t.Fatal("idle pacing event did not atomically mark app-limited readiness")
+		}
+		maxPacketsInflight := lim.maxPacketsInflight
+		lim.maxPacketsInflight = lim.packetsInflight
+		if wait := lim.prepareStep(clock.Now()); wait.acceptSend || wait.hasDeadline {
+			t.Fatal("pacing-ready latch bypassed the packet window gate")
+		}
+		lim.maxPacketsInflight = maxPacketsInflight
+		for i := 0; i < 2; i++ {
+			if wait := lim.prepareStep(clock.Now()); !wait.acceptSend || wait.hasDeadline {
+				t.Fatal("latched pacing event re-created a zero-duration timer")
+			}
+		}
+		result := lim.step(clock.Now(), limiterEvent{kind: limiterSendEvent, size: 1})
+		if !result.sent || !result.packet.AppLimited || lim.pacingReady {
+			t.Fatal("send after idle pacing did not consume app-limited latch")
+		}
+	})
+}
+
+func TestLimiterAppLimitedAccountingWithOutOfOrderACK(t *testing.T) {
+	clock := newSimClock(sampleStartTime)
+	lim := newLimiterState(clock, limiterOptions{})
+
+	older := lim.step(clock.Now(), limiterEvent{kind: limiterSendEvent, size: 2}).packet
+	lim.appLimitedUntil = lim.inflight()
+	newer := lim.step(clock.Now(), limiterEvent{kind: limiterSendEvent, size: 100}).packet
+	if !newer.AppLimited {
+		t.Fatal("packet sent past the app-limited boundary was not marked app-limited")
+	}
+
+	clock.AdvanceTo(clock.Now().Add(time.Second))
+	lim.step(clock.Now(), limiterEvent{kind: limiterAckEvent, ack: newer})
+	if lim.appLimitedUntil != 0 {
+		t.Fatalf("app-limited marker after larger out-of-order ACK = %d; want 0", lim.appLimitedUntil)
+	}
+	if lim.inflight() != older.Size || lim.packetsInflight != 1 {
+		t.Fatalf("out-of-order ACK left %d bytes in %d packets; want %d byte in 1 packet", lim.inflight(), lim.packetsInflight, older.Size)
+	}
+}
+
+type trackingClock struct {
+	mu      sync.Mutex
+	now     time.Time
+	created chan *trackingTimer
+}
+
+func newTrackingClock(now time.Time) *trackingClock {
+	return &trackingClock{now: now, created: make(chan *trackingTimer, 8)}
+}
+
+func (c *trackingClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+func (c *trackingClock) Advance(d time.Duration) {
+	c.mu.Lock()
+	c.now = c.now.Add(d)
+	c.mu.Unlock()
+}
+
+func (c *trackingClock) NewTimer(time.Duration) clock.Timer {
+	timer := &trackingTimer{ch: make(chan time.Time), stopped: make(chan struct{})}
+	c.created <- timer
+	return timer
+}
+
+type trackingTimer struct {
+	ch      chan time.Time
+	stopped chan struct{}
+	once    sync.Once
+}
+
+func (t *trackingTimer) Chan() <-chan time.Time { return t.ch }
+func (t *trackingTimer) Reset(time.Duration)    {}
+func (t *trackingTimer) Stop() (stopped bool) {
+	t.once.Do(func() {
+		stopped = true
+		close(t.stopped)
+	})
+	return stopped
+}
+
+func TestLimiterRunStopsAbandonedPacingTimer(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		act  func(*trackingClock, *Limiter, func())
+	}{
+		{
+			name: "ACK",
+			act: func(clock *trackingClock, _ *Limiter, gotResponse func()) {
+				clock.Advance(time.Millisecond)
+				gotResponse()
+			},
+		},
+		{
+			name: "pause",
+			act: func(_ *trackingClock, lim *Limiter, _ func()) {
+				_ = SnapshotLimiter(lim)
+			},
+		},
+		{
+			name: "cancellation",
+			act: func(_ *trackingClock, lim *Limiter, _ func()) {
+				lim.Release()
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			clock := newTrackingClock(sampleStartTime)
+			lim := NewLimiter(clock)
+			gotResponse, err := lim.StartMessage(context.Background(), 1)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			var timer *trackingTimer
+			select {
+			case timer = <-clock.created:
+			case <-time.After(time.Second):
+				t.Fatal("limiter did not create its pacing timer")
+			}
+			test.act(clock, lim, gotResponse)
+			select {
+			case <-timer.stopped:
+			case <-time.After(time.Second):
+				t.Fatal("abandoned pacing timer was not stopped")
+			}
+
+			lim.Release()
+			select {
+			case <-lim.done:
+			case <-time.After(time.Second):
+				t.Fatal("limiter actor did not exit after Release")
+			}
+			// Once done is closed there is no actor to pause; this must still
+			// return a safe final snapshot rather than deadlocking.
+			_ = SnapshotLimiter(lim)
+		})
+	}
+}
+
+func TestLimiterRunCompletesAcceptedSendAfterRelease(t *testing.T) {
+	lim := NewLimiter(newTrackingClock(sampleStartTime))
+	reply := make(chan packetMeta)
+	request := sendRequest{size: 7, replyChan: reply}
+
+	select {
+	case lim.chSend <- request:
+		// The unbuffered rendezvous proves the actor accepted the request.
+	case <-time.After(time.Second):
+		lim.Release()
+		t.Fatal("limiter did not accept the send request")
+	}
+	lim.Release()
+
+	select {
+	case packet := <-reply:
+		if packet.Size != request.size {
+			t.Fatalf("accepted packet size = %d; want %d", packet.Size, request.size)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Release interrupted an already-accepted send")
+	}
+	select {
+	case <-lim.done:
+	case <-time.After(time.Second):
+		t.Fatal("limiter actor did not exit after completing the accepted send")
+	}
 }

--- a/flowcontrol/bbr/simulator_test.go
+++ b/flowcontrol/bbr/simulator_test.go
@@ -1,0 +1,311 @@
+package bbr
+
+import (
+	"context"
+	"sort"
+	"sync"
+	"time"
+
+	"capnproto.org/go/capnp/v3/exp/clock"
+)
+
+// simClock is a clock whose timers are fired explicitly by simulator.  It
+// deliberately does not try to run goroutines: the simulator chooses both
+// virtual-time ordering and the next timer to fire.
+type simClock struct {
+	mu      sync.Mutex
+	now     time.Time
+	nextID  uint64
+	timers  []*simTimer
+	changed chan struct{}
+}
+
+type simTimer struct {
+	clock    *simClock
+	deadline time.Time
+	id       uint64
+	active   bool
+	ch       chan time.Time
+}
+
+func newSimClock(now time.Time) *simClock {
+	return &simClock{now: now, changed: make(chan struct{}, 1)}
+}
+
+func (c *simClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+func (c *simClock) NewTimer(d time.Duration) clock.Timer {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.nextID++
+	t := &simTimer{
+		clock:    c,
+		deadline: c.now.Add(d),
+		id:       c.nextID,
+		active:   true,
+		ch:       make(chan time.Time, 1),
+	}
+	c.timers = append(c.timers, t)
+	c.notifyChanged()
+	return t
+}
+
+func (c *simClock) notifyChanged() {
+	select {
+	case c.changed <- struct{}{}:
+	default:
+	}
+}
+
+func (c *simClock) AdvanceTo(now time.Time) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if now.Before(c.now) {
+		panic("simulated clock moved backwards")
+	}
+	c.now = now
+}
+
+func (c *simClock) nextTimer() *simTimer {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	var next *simTimer
+	for _, t := range c.timers {
+		if !t.active || (next != nil && (next.deadline.Before(t.deadline) || next.deadline.Equal(t.deadline) && next.id < t.id)) {
+			continue
+		}
+		next = t
+	}
+	return next
+}
+
+func (c *simClock) fire(t *simTimer) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if !t.active || t.deadline.After(c.now) {
+		return false
+	}
+	t.active = false
+	t.ch <- c.now
+	return true
+}
+
+func (t *simTimer) Chan() <-chan time.Time { return t.ch }
+
+func (t *simTimer) Reset(d time.Duration) {
+	t.clock.mu.Lock()
+	defer t.clock.mu.Unlock()
+	t.deadline = t.clock.now.Add(d)
+	t.active = true
+	t.clock.notifyChanged()
+}
+
+func (t *simTimer) Stop() bool {
+	t.clock.mu.Lock()
+	defer t.clock.mu.Unlock()
+	wasActive := t.active
+	t.active = false
+	return wasActive
+}
+
+type simPacket struct {
+	deadline time.Time
+	sequence uint64
+	packet   testPacket
+}
+
+// simPath reproduces testLink's fixed-delay and serial bandwidth-limited
+// links without worker goroutines.
+type simPath struct {
+	clock         *simClock
+	links         []testLink
+	nextAvailable []time.Time
+	sequence      uint64
+	packets       []simPacket
+}
+
+func newSimPath(clock *simClock, links ...testLink) *simPath {
+	return &simPath{
+		clock:         clock,
+		links:         links,
+		nextAvailable: make([]time.Time, len(links)),
+	}
+}
+
+func (p *simPath) send(packet testPacket) {
+	deadline := p.clock.Now()
+	for i, link := range p.links {
+		if link.bandwidth == 0 {
+			deadline = deadline.Add(link.delay)
+			continue
+		}
+		if p.nextAvailable[i].After(deadline) {
+			deadline = p.nextAvailable[i]
+		}
+		deadline = deadline.Add(time.Duration(float64(packet.size) / float64(link.bandwidth)))
+		p.nextAvailable[i] = deadline
+	}
+	p.sequence++
+	p.packets = append(p.packets, simPacket{deadline: deadline, sequence: p.sequence, packet: packet})
+	sort.SliceStable(p.packets, func(i, j int) bool {
+		if p.packets[i].deadline.Equal(p.packets[j].deadline) {
+			return p.packets[i].sequence < p.packets[j].sequence
+		}
+		return p.packets[i].deadline.Before(p.packets[j].deadline)
+	})
+}
+
+func (p *simPath) nextPacket() (simPacket, bool) {
+	if len(p.packets) == 0 {
+		return simPacket{}, false
+	}
+	return p.packets[0], true
+}
+
+func (p *simPath) popPacket() simPacket {
+	packet := p.packets[0]
+	p.packets = p.packets[1:]
+	return packet
+}
+
+func (p *simPath) advance(d time.Duration) {
+	p.clock.AdvanceTo(p.clock.Now().Add(d))
+	for len(p.packets) > 0 && !p.packets[0].deadline.After(p.clock.Now()) {
+		p.popPacket().packet.gotResponse()
+	}
+}
+
+type simulator struct {
+	t       testingT
+	clock   *simClock
+	path    *simPath
+	lim     *Limiter
+	events  chan struct{}
+	results []Snapshot
+}
+
+// testingT keeps the simulator useful to the small path tests without making
+// it responsible for reporting failures from a goroutine.
+type testingT interface {
+	Helper()
+	Fatal(...any)
+}
+
+func newSimulator(t testingT, links ...testLink) *simulator {
+	t.Helper()
+	events := make(chan struct{}, 1)
+	clock := newSimClock(sampleStartTime)
+	s := &simulator{
+		t:      t,
+		clock:  clock,
+		path:   newSimPath(clock, links...),
+		events: events,
+	}
+	s.lim = newLimiter(clock, limiterOptions{
+		randInt: func() int { return 6 }, // begin ProbeBW at the 1.25 gain phase
+		afterEvent: func() {
+			events <- struct{}{}
+		},
+	})
+	return s
+}
+
+func (s *simulator) close() { s.lim.Release() }
+
+func (s *simulator) snapshot() {
+	s.results = append(s.results, SnapshotLimiter(s.lim))
+}
+
+func (s *simulator) settle() { _ = SnapshotLimiter(s.lim) }
+
+func (s *simulator) waitEvent() { <-s.events }
+
+func (s *simulator) drainEvents() {
+	for {
+		select {
+		case <-s.events:
+		default:
+			return
+		}
+	}
+}
+
+func (s *simulator) step() bool {
+	packet, hasPacket := s.path.nextPacket()
+	timer := s.clock.nextTimer()
+	if !hasPacket && timer == nil {
+		return false
+	}
+	if hasPacket && (timer == nil || packet.deadline.Before(timer.deadline) || packet.deadline.Equal(timer.deadline)) {
+		s.clock.AdvanceTo(packet.deadline)
+		s.path.popPacket().packet.gotResponse()
+		s.waitEvent()
+		s.snapshot()
+		s.drainEvents()
+		return true
+	}
+	s.clock.AdvanceTo(timer.deadline)
+	if !s.clock.fire(timer) {
+		return true
+	}
+	s.waitEvent()
+	s.settle()
+	s.snapshot()
+	s.drainEvents()
+	return true
+}
+
+func (s *simulator) send(size uint64) {
+	result := make(chan testPacket, 1)
+	ctx := context.Background()
+	go func() {
+		gotResponse, err := s.lim.StartMessage(ctx, size)
+		if err != nil {
+			panic(err)
+		}
+		result <- testPacket{size: size, gotResponse: gotResponse}
+	}()
+
+	for {
+		select {
+		case packet := <-result:
+			s.path.send(packet)
+			s.settle()
+			s.snapshot()
+			s.drainEvents()
+			return
+		default:
+		}
+		if s.step() {
+			continue
+		}
+		select {
+		case packet := <-result:
+			s.path.send(packet)
+			s.settle()
+			s.snapshot()
+			s.drainEvents()
+			return
+		case <-s.events:
+		case <-s.clock.changed:
+		}
+	}
+}
+
+func (s *simulator) drain() {
+	for s.step() {
+	}
+}
+
+func (s *simulator) run(packetSizes []uint64) []Snapshot {
+	defer s.close()
+	for _, size := range packetSizes {
+		s.send(size)
+	}
+	s.drain()
+	return s.results
+}

--- a/flowcontrol/bbr/snapshot.go
+++ b/flowcontrol/bbr/snapshot.go
@@ -17,12 +17,19 @@ type Snapshot struct {
 func SnapshotLimiter(l *Limiter) Snapshot {
 	var ret Snapshot
 	l.whilePaused(func() {
-		ret.lim = *l
-		ret.now = l.clock.Now()
-		ret.lim.btlBwFilter = l.btlBwFilter.snapshot()
-		ret.lim.rtPropFilter = l.rtPropFilter.snapshot()
-		ret.lim.state = l.state.snapshot()
+		ret = l.snapshotAt(l.clock.Now())
 	})
+	return ret
+}
+
+// snapshotAt copies limiter state at a caller-defined event boundary. The
+// caller must have exclusive ownership of l, either through whilePaused or by
+// driving an unstarted limiter synchronously.
+func (l *Limiter) snapshotAt(now time.Time) Snapshot {
+	ret := Snapshot{lim: *l, now: now}
+	ret.lim.btlBwFilter = l.btlBwFilter.snapshot()
+	ret.lim.rtPropFilter = l.rtPropFilter.snapshot()
+	ret.lim.state = l.state.snapshot()
 	return ret
 }
 
@@ -61,18 +68,21 @@ type a []any
 func (s Snapshot) Json() any {
 	lim := &s.lim
 	ret := o{
-		"now":             s.now,
-		"cwndGain":        lim.cwndGain,
-		"pacingGain":      lim.pacingGain,
-		"btlBw":           lim.btlBwFilter.Estimate,
-		"rtProp":          lim.rtPropFilter.Estimate,
-		"nextSendTime":    lim.nextSendTime,
-		"sent":            lim.sent,
-		"delivered":       lim.delivered,
-		"deliveredTime":   lim.deliveredTime,
-		"inflight":        lim.inflight(),
-		"bdp":             lim.computeBDP(),
-		"appLimitedUntil": lim.appLimitedUntil,
+		"now":                s.now,
+		"cwndGain":           lim.cwndGain,
+		"pacingGain":         lim.pacingGain,
+		"btlBw":              lim.btlBwFilter.Estimate,
+		"rtProp":             lim.rtPropFilter.Estimate,
+		"nextSendTime":       lim.nextSendTime,
+		"pacingReady":        lim.pacingReady,
+		"sent":               lim.sent,
+		"delivered":          lim.delivered,
+		"deliveredTime":      lim.deliveredTime,
+		"inflight":           lim.inflight(),
+		"packetsInflight":    lim.packetsInflight,
+		"maxPacketsInflight": lim.maxPacketsInflight,
+		"bdp":                lim.computeBDP(),
+		"appLimitedUntil":    lim.appLimitedUntil,
 		"state": o{
 			"type":  fmt.Sprintf("%T", lim.state),
 			"value": fmt.Sprintf("%v", lim.state), // TODO: better formatting of state?
@@ -106,6 +116,12 @@ func (s Snapshot) Json() any {
 	ret["samples"] = o{
 		"btlBw":  bwsamples,
 		"rtProp": rtSamples,
+		"rtPropNext": o{
+			// The initial sentinel is outside encoding/json's supported
+			// time range, so use its stable textual form here.
+			"now": lim.rtPropFilter.nextSample.now.Round(0).String(),
+			"rtt": int64(lim.rtPropFilter.nextSample.rtt),
+		},
 	}
 	return ret
 }

--- a/flowcontrol/bbr/state.go
+++ b/flowcontrol/bbr/state.go
@@ -5,7 +5,6 @@ package bbr
 
 import (
 	"math"
-	"math/rand"
 	"time"
 )
 
@@ -97,7 +96,7 @@ func (s *probeBWState) initialize(lim *Limiter) {
 	// Randomly select an initial pacing gain; anything but the value
 	// below 1 will do (see paper). That value is last in the slice, so
 	// pick a random index before that:
-	s.pacingGainIndex = rand.Int() % (len(probeBWPacingGains) - 1)
+	s.pacingGainIndex = lim.randInt() % (len(probeBWPacingGains) - 1)
 
 	lim.pacingGain = probeBWPacingGains[s.pacingGainIndex]
 	s.nextPacingGainChange = now.Add(s.rtProp)

--- a/flowcontrol/bbr/state.go
+++ b/flowcontrol/bbr/state.go
@@ -9,7 +9,7 @@ import (
 )
 
 type state interface {
-	initialize(lim *Limiter)
+	initialize(lim *Limiter, now time.Time)
 	postAck(lim *Limiter, pm packetMeta, now time.Time)
 	snapshot() state
 }
@@ -23,7 +23,7 @@ type startupState struct {
 	plateauRounds int
 }
 
-func (s *startupState) initialize(lim *Limiter) {
+func (s *startupState) initialize(lim *Limiter, now time.Time) {
 	lim.cwndGain = 2 / math.Ln2
 	lim.pacingGain = 2 / math.Ln2
 }
@@ -37,7 +37,7 @@ func (s *startupState) postAck(lim *Limiter, p packetMeta, now time.Time) {
 	}
 	s.prevBtlBwEstimate = newBtlBwEstimate
 	if s.plateauRounds >= 3 {
-		lim.changeState(&drainState{})
+		lim.changeState(&drainState{}, now)
 	}
 }
 
@@ -49,13 +49,13 @@ func (s *startupState) snapshot() state {
 type drainState struct {
 }
 
-func (s *drainState) initialize(lim *Limiter) {
+func (s *drainState) initialize(lim *Limiter, now time.Time) {
 	lim.pacingGain = 1 / lim.pacingGain
 }
 
 func (s *drainState) postAck(lim *Limiter, p packetMeta, now time.Time) {
 	if lim.inflight() <= uint64(lim.computeBDP()) {
-		lim.changeState(&probeBWState{})
+		lim.changeState(&probeBWState{}, now)
 	}
 }
 
@@ -86,10 +86,9 @@ type probeBWState struct {
 	rtProp           time.Duration
 }
 
-func (s *probeBWState) initialize(lim *Limiter) {
+func (s *probeBWState) initialize(lim *Limiter, now time.Time) {
 	lim.cwndGain = 2
 
-	now := lim.clock.Now()
 	s.rtProp = lim.rtPropFilter.Estimate
 	s.lastRtPropChange = now
 
@@ -111,7 +110,7 @@ func (s *probeBWState) postAck(lim *Limiter, p packetMeta, now time.Time) {
 
 	if now.Sub(s.lastRtPropChange) > 10*time.Second {
 		// Been a while since we've measured rtProp; switch to probeRTT.
-		lim.changeState(&probeRTTState{})
+		lim.changeState(&probeRTTState{}, now)
 		return
 	}
 
@@ -137,9 +136,8 @@ type probeRTTState struct {
 	initSent uint64
 }
 
-func (s *probeRTTState) initialize(lim *Limiter) {
+func (s *probeRTTState) initialize(lim *Limiter, now time.Time) {
 	lim.maxPacketsInflight = 4
-	now := lim.clock.Now()
 	s.exitTime = now.Add(200 * time.Millisecond)
 	s.initSent = lim.sent
 }
@@ -164,11 +162,11 @@ func (s *probeRTTState) postAck(lim *Limiter, p packetMeta, now time.Time) {
 		lim.maxPacketsInflight = math.MaxUint64
 		if lim.inflight() < uint64(lim.computeBDP()) {
 			// Get back up to where we were quickly:
-			lim.changeState(&startupState{})
+			lim.changeState(&startupState{}, now)
 		} else {
 			// We're still above our estimate; go back to
 			// probing bandwidth at a normal pace:
-			lim.changeState(&probeBWState{})
+			lim.changeState(&probeBWState{}, now)
 		}
 	}
 }

--- a/flowcontrol/bbr/trace_test.go
+++ b/flowcontrol/bbr/trace_test.go
@@ -62,17 +62,13 @@ func withinTolerance(actual, expected, tolerance float64, msg string) error {
 // trueValues returns the true/expected values of rtProp and and btlBw for a given path and
 // set of packets
 func trueValues(path []testLink, packetSizes []uint64) (rtProp time.Duration, btlBw bytesPerNs) {
-	var totalData uint64
 	var minPacketBytes uint64 = math.MaxUint64
 
 	for _, size := range packetSizes {
-		totalData += size
 		if size < minPacketBytes {
 			minPacketBytes = size
 		}
 	}
-
-	avgPacketSize := totalData / uint64(len(packetSizes))
 
 	for _, link := range path {
 		rtProp += link.delay
@@ -84,13 +80,6 @@ func trueValues(path []testLink, packetSizes []uint64) (rtProp time.Duration, bt
 			// minimum such delay will be however long it takes to transfer the smallest packet:
 			btlProp := float64(minPacketBytes) / float64(link.bandwidth)
 			rtProp += time.Duration(btlProp)
-		}
-
-		if link.delay > 0 {
-			delayBw := bytesPerNs(avgPacketSize) / bytesPerNs(link.delay.Nanoseconds())
-			if delayBw < btlBw || btlBw == 0 {
-				btlBw = delayBw
-			}
 		}
 	}
 
@@ -120,7 +109,7 @@ func TestTrueValues(t *testing.T) {
 			},
 			packetSizes: []uint64{10},
 			rtProp:      60 * time.Millisecond,
-			btlBw:       200 * bytesPerSecond,
+			btlBw:       1000 * bytesPerSecond,
 		},
 		{
 			path: []testLink{
@@ -129,7 +118,7 @@ func TestTrueValues(t *testing.T) {
 			},
 			packetSizes: []uint64{10},
 			rtProp:      110 * time.Millisecond,
-			btlBw:       100 * bytesPerSecond,
+			btlBw:       1000 * bytesPerSecond,
 		},
 		{
 			path: []testLink{
@@ -138,7 +127,7 @@ func TestTrueValues(t *testing.T) {
 			},
 			packetSizes: []uint64{5},
 			rtProp:      55 * time.Millisecond,
-			btlBw:       100 * bytesPerSecond,
+			btlBw:       1000 * bytesPerSecond,
 		},
 	}
 	for i, c := range cases {
@@ -266,10 +255,9 @@ func gatherData(t *testing.T) {
 // and check that they pass some sanity checks.
 func TestTrace(t *testing.T) {
 	cases := []struct {
-		name             string
-		path             []testLink
-		packets          []uint64
-		checkConvergence bool
+		name    string
+		path    []testLink
+		packets []uint64
 	}{
 		{
 			name: "low bandwidth",
@@ -277,8 +265,7 @@ func TestTrace(t *testing.T) {
 				{delay: 50 * time.Millisecond},
 				{bandwidth: 1000 * bytesPerSecond},
 			},
-			packets:          repeat(40, []uint64{50}),
-			checkConvergence: false,
+			packets: repeat(40, []uint64{50}),
 		},
 		{
 			name: "high bandwidth",
@@ -286,8 +273,7 @@ func TestTrace(t *testing.T) {
 				{delay: 50 * time.Millisecond},
 				{bandwidth: 1e6 * bytesPerSecond},
 			},
-			packets:          repeat(20, []uint64{1, 4900, 5000, 5000, 5000}),
-			checkConvergence: true,
+			packets: repeat(20, []uint64{1, 4900, 5000, 5000, 5000}),
 		},
 	}
 
@@ -300,9 +286,8 @@ func TestTrace(t *testing.T) {
 		t.Run(fmt.Sprintf("Case %v: %s", i, c.name), func(t *testing.T) {
 			snapshots := runTrace(c.path, c.packets)
 			assertTraceTransitions(t, snapshots)
-			if c.checkConvergence {
-				assertTraceConverges(t, c.path, c.packets, tolerances, snapshots)
-			}
+			assertTraceInvariants(t, snapshots)
+			assertTraceConverges(t, c.path, c.packets, tolerances, snapshots)
 			assertTraceRepeatable(t, c.path, c.packets, snapshots)
 		})
 	}
@@ -310,45 +295,97 @@ func TestTrace(t *testing.T) {
 
 func assertTraceTransitions(t *testing.T, snapshots []Snapshot) {
 	t.Helper()
-	states := make([]string, 0, len(snapshots))
+	states := make([]string, 0, 3)
 	for _, s := range snapshots {
+		var name string
 		switch s.lim.state.(type) {
 		case *startupState:
-			states = append(states, "startup")
+			name = "startup"
 		case *drainState:
-			states = append(states, "drain")
+			name = "drain"
 		case *probeBWState:
-			states = append(states, "probeBW")
+			name = "probeBW"
+		case *probeRTTState:
+			name = "probeRTT"
+		default:
+			name = fmt.Sprintf("%T", s.lim.state)
+		}
+		if len(states) == 0 || states[len(states)-1] != name {
+			states = append(states, name)
 		}
 	}
 	want := []string{"startup", "drain", "probeBW"}
-	pos := 0
-	for _, state := range states {
-		if state == want[pos] {
-			pos++
-			if pos == len(want) {
-				return
-			}
+	if len(states) != len(want) {
+		t.Fatalf("compressed state sequence = %v; want exactly %v", states, want)
+	}
+	for i := range want {
+		if states[i] != want[i] {
+			t.Fatalf("compressed state sequence = %v; want exactly %v", states, want)
 		}
 	}
-	t.Fatalf("state transition sequence %v does not contain %v", states, want)
 }
 
 func assertTraceConverges(t *testing.T, path []testLink, packets []uint64, tolerances tolerances, snapshots []Snapshot) {
 	t.Helper()
-	for _, s := range snapshots {
-		if err := estimatesCorrect(path, packets, tolerances, s); err == nil {
-			return
+	final := snapshots[len(snapshots)-1]
+	if final.lim.inflight() != 0 || final.lim.packetsInflight != 0 {
+		t.Fatalf("final trace boundary still has %d bytes in %d packets in flight", final.lim.inflight(), final.lim.packetsInflight)
+	}
+	if err := estimatesCorrect(path, packets, tolerances, final); err != nil {
+		t.Errorf("estimates at final drained boundary: %v", err)
+	}
+}
+
+func assertTraceInvariants(t *testing.T, snapshots []Snapshot) {
+	t.Helper()
+	highGain := 2 / math.Ln2
+	for i, snapshot := range snapshots {
+		lim := &snapshot.lim
+		if lim.delivered > lim.sent {
+			t.Fatalf("snapshot %d delivered %d bytes after sending %d", i, lim.delivered, lim.sent)
+		}
+		if lim.appLimitedUntil > lim.inflight() {
+			t.Fatalf("snapshot %d app-limited marker %d exceeds %d bytes in flight", i, lim.appLimitedUntil, lim.inflight())
+		}
+		if (lim.inflight() == 0) != (lim.packetsInflight == 0) {
+			t.Fatalf("snapshot %d byte/packet in-flight accounting disagrees: %d bytes, %d packets", i, lim.inflight(), lim.packetsInflight)
+		}
+		switch lim.state.(type) {
+		case *startupState:
+			if lim.cwndGain != highGain || lim.pacingGain != highGain {
+				t.Fatalf("snapshot %d has Startup gains cwnd=%v pacing=%v", i, lim.cwndGain, lim.pacingGain)
+			}
+		case *drainState:
+			if lim.cwndGain != highGain || lim.pacingGain != 1/highGain {
+				t.Fatalf("snapshot %d has Drain gains cwnd=%v pacing=%v", i, lim.cwndGain, lim.pacingGain)
+			}
+		case *probeBWState:
+			validGain := false
+			for _, gain := range probeBWPacingGains {
+				validGain = validGain || lim.pacingGain == gain
+			}
+			if lim.cwndGain != 2 || !validGain {
+				t.Fatalf("snapshot %d has ProbeBW gains cwnd=%v pacing=%v", i, lim.cwndGain, lim.pacingGain)
+			}
 		}
 	}
-	t.Fatal("estimates never converged within tolerance")
 }
 
 func assertTraceRepeatable(t *testing.T, path []testLink, packets []uint64, want []Snapshot) {
 	t.Helper()
-	assertTraceTransitions(t, want)
-	for i := 0; i < 3; i++ {
-		assertTraceTransitions(t, runTrace(path, packets))
+	wantJSON, err := json.Marshal(snapshotJSON(want))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 10; i++ {
+		got := runTrace(path, packets)
+		gotJSON, err := json.Marshal(snapshotJSON(got))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(gotJSON) != string(wantJSON) {
+			t.Fatalf("run %d produced a different trace: got %d snapshots (%d bytes), want %d snapshots (%d bytes)", i+2, len(got), len(gotJSON), len(want), len(wantJSON))
+		}
 	}
 }
 
@@ -361,34 +398,46 @@ func snapshotJSON(snapshots []Snapshot) []any {
 }
 
 func TestProbeBWGainCycle(t *testing.T) {
-	clock := newSimClock(sampleStartTime)
+	for index := 0; index < len(probeBWPacingGains)-1; index++ {
+		index := index
+		t.Run(fmt.Sprintf("initial phase %d", index), func(t *testing.T) {
+			lim := &Limiter{
+				rtPropFilter: rtPropFilter{Estimate: time.Millisecond},
+				randInt:      func() int { return index },
+			}
+			state := &probeBWState{}
+			state.initialize(lim, sampleStartTime)
+			if lim.pacingGain != probeBWPacingGains[index] {
+				t.Fatalf("initial ProbeBW pacing gain = %v; want %v", lim.pacingGain, probeBWPacingGains[index])
+			}
+			if lim.pacingGain == 0.75 {
+				t.Fatal("ProbeBW initialized in the drain phase")
+			}
+		})
+	}
+
 	lim := &Limiter{
-		clock:        clock,
 		rtPropFilter: rtPropFilter{Estimate: time.Millisecond},
 		randInt:      func() int { return 6 },
 	}
 	state := &probeBWState{}
-	state.initialize(lim)
-	if lim.pacingGain != 1.25 {
-		t.Fatalf("initial ProbeBW pacing gain = %v; want 1.25", lim.pacingGain)
-	}
-	for _, want := range []float64{0.75, 1, 1} {
-		now := state.nextPacingGainChange.Add(time.Nanosecond)
-		clock.AdvanceTo(now)
+	state.initialize(lim, sampleStartTime)
+	for step, want := range []float64{0.75, 1, 1, 1, 1, 1, 1, 1.25} {
+		deadline := state.nextPacingGainChange
+		before := lim.pacingGain
+		state.postAck(lim, packetMeta{}, deadline)
+		if got := lim.pacingGain; got != before {
+			t.Fatalf("ProbeBW advanced at exact phase deadline: got %v, was %v", got, before)
+		}
+		now := deadline.Add(time.Nanosecond)
 		state.postAck(lim, packetMeta{}, now)
 		if lim.pacingGain != want {
-			t.Fatalf("ProbeBW pacing gain = %v; want %v", lim.pacingGain, want)
+			t.Fatalf("ProbeBW step %d pacing gain = %v; want %v", step+1, lim.pacingGain, want)
 		}
 	}
 }
 
 func runTrace(path []testLink, packetSizes []uint64) []Snapshot {
-	sim := newSimulator(panicTestingT{}, path...)
+	sim := newSimulator(path...)
 	return sim.run(packetSizes)
 }
-
-// panicTestingT is used by runTrace, whose caller owns test reporting.
-type panicTestingT struct{}
-
-func (panicTestingT) Helper()           {}
-func (panicTestingT) Fatal(args ...any) { panic(fmt.Sprint(args...)) }

--- a/flowcontrol/bbr/trace_test.go
+++ b/flowcontrol/bbr/trace_test.go
@@ -1,15 +1,12 @@
 package bbr
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"math"
 	"os"
 	"testing"
 	"time"
-
-	"capnproto.org/go/capnp/v3/exp/clock"
 )
 
 func (s Snapshot) report(t *testing.T) {
@@ -268,80 +265,29 @@ func gatherData(t *testing.T) {
 // Collect traces of various packet sequences being streamed over various paths,
 // and check that they pass some sanity checks.
 func TestTrace(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping long test due to -short")
-	}
-	if os.Getenv("FLAKY_TESTS") != "1" {
-		t.Skip("Not running TestTrace, which is flaky. Set FLAKY_TESTS=1 to enable")
-	}
-	t.Parallel()
-
 	cases := []struct {
-		path    []testLink
-		packets []uint64
+		name             string
+		path             []testLink
+		packets          []uint64
+		checkConvergence bool
 	}{
 		{
+			name: "low bandwidth",
 			path: []testLink{
 				{delay: 50 * time.Millisecond},
 				{bandwidth: 1000 * bytesPerSecond},
 			},
-			packets: repeat(10, []uint64{1, 49, 50, 50, 50}),
+			packets:          repeat(40, []uint64{50}),
+			checkConvergence: false,
 		},
 		{
+			name: "high bandwidth",
 			path: []testLink{
 				{delay: 50 * time.Millisecond},
 				{bandwidth: 1e6 * bytesPerSecond},
 			},
-			packets: repeat(20, []uint64{1, 4900, 5000, 5000, 5000}),
-		},
-		{
-			path: []testLink{
-				{delay: 50 * time.Millisecond},
-				{bandwidth: 1e6 * bytesPerSecond},
-			},
-			packets: repeat(100, []uint64{1, 49, 50, 50, 50}),
-		},
-		{
-			path: []testLink{
-				{delay: 5 * time.Millisecond},
-				{bandwidth: 1e6 * bytesPerSecond},
-			},
-			packets: repeat(100, []uint64{1, 49, 50, 50, 50}),
-		},
-		{
-			path: []testLink{
-				{delay: 50 * time.Millisecond},
-				{bandwidth: 1000 * bytesPerSecond},
-			},
-			packets: repeat(40, []uint64{50}),
-		},
-		{
-			path: []testLink{
-				{delay: 50 * time.Millisecond},
-				{bandwidth: 1e6 * bytesPerSecond},
-			},
-			packets: repeat(80, []uint64{5000}),
-		},
-		{
-			path: []testLink{
-				{delay: 50 * time.Millisecond},
-				{bandwidth: 1e6 * bytesPerSecond},
-			},
-			packets: repeat(400, []uint64{50}),
-		},
-		{
-			path: []testLink{
-				{delay: 5 * time.Millisecond},
-				{bandwidth: 1e6 * bytesPerSecond},
-			},
-			packets: repeat(400, []uint64{50}),
-		},
-		{
-			path: []testLink{
-				{delay: 5 * time.Millisecond},
-				{bandwidth: 1e6 * bytesPerSecond},
-			},
-			packets: repeat(400, []uint64{50}),
+			packets:          repeat(20, []uint64{1, 4900, 5000, 5000, 5000}),
+			checkConvergence: true,
 		},
 	}
 
@@ -351,61 +297,98 @@ func TestTrace(t *testing.T) {
 	}
 
 	for i, c := range cases {
-		t.Run(fmt.Sprintf("Case %v", i), func(t *testing.T) {
-			t.Parallel()
+		t.Run(fmt.Sprintf("Case %v: %s", i, c.name), func(t *testing.T) {
 			snapshots := runTrace(c.path, c.packets)
-			t.Run("At end", func(t *testing.T) {
-				err := estimatesCorrect(c.path, c.packets, tolerances, snapshots[len(snapshots)-1])
-				if err != nil {
-					t.Error(err)
-				}
-			})
-			t.Run("After startup", func(t *testing.T) {
-				for _, s := range snapshots {
-					// Find the first snapshot after startup.
-					if _, ok := s.lim.state.(*drainState); ok {
-						err := estimatesCorrect(c.path, c.packets, tolerances, s)
-						if err != nil {
-							t.Error(err)
-						}
-						return
-					}
-				}
-			})
-			t.Run("At some point", func(t *testing.T) {
-				for _, s := range snapshots {
-					err := estimatesCorrect(c.path, c.packets, tolerances, s)
-					if err == nil {
-						return
-					}
-				}
-				t.Fatal("Estimates are never correct.")
-			})
+			assertTraceTransitions(t, snapshots)
+			if c.checkConvergence {
+				assertTraceConverges(t, c.path, c.packets, tolerances, snapshots)
+			}
+			assertTraceRepeatable(t, c.path, c.packets, snapshots)
 		})
+	}
+}
+
+func assertTraceTransitions(t *testing.T, snapshots []Snapshot) {
+	t.Helper()
+	states := make([]string, 0, len(snapshots))
+	for _, s := range snapshots {
+		switch s.lim.state.(type) {
+		case *startupState:
+			states = append(states, "startup")
+		case *drainState:
+			states = append(states, "drain")
+		case *probeBWState:
+			states = append(states, "probeBW")
+		}
+	}
+	want := []string{"startup", "drain", "probeBW"}
+	pos := 0
+	for _, state := range states {
+		if state == want[pos] {
+			pos++
+			if pos == len(want) {
+				return
+			}
+		}
+	}
+	t.Fatalf("state transition sequence %v does not contain %v", states, want)
+}
+
+func assertTraceConverges(t *testing.T, path []testLink, packets []uint64, tolerances tolerances, snapshots []Snapshot) {
+	t.Helper()
+	for _, s := range snapshots {
+		if err := estimatesCorrect(path, packets, tolerances, s); err == nil {
+			return
+		}
+	}
+	t.Fatal("estimates never converged within tolerance")
+}
+
+func assertTraceRepeatable(t *testing.T, path []testLink, packets []uint64, want []Snapshot) {
+	t.Helper()
+	assertTraceTransitions(t, want)
+	for i := 0; i < 3; i++ {
+		assertTraceTransitions(t, runTrace(path, packets))
+	}
+}
+
+func snapshotJSON(snapshots []Snapshot) []any {
+	ret := make([]any, 0, len(snapshots))
+	for _, s := range snapshots {
+		ret = append(ret, s.Json())
+	}
+	return ret
+}
+
+func TestProbeBWGainCycle(t *testing.T) {
+	clock := newSimClock(sampleStartTime)
+	lim := &Limiter{
+		clock:        clock,
+		rtPropFilter: rtPropFilter{Estimate: time.Millisecond},
+		randInt:      func() int { return 6 },
+	}
+	state := &probeBWState{}
+	state.initialize(lim)
+	if lim.pacingGain != 1.25 {
+		t.Fatalf("initial ProbeBW pacing gain = %v; want 1.25", lim.pacingGain)
+	}
+	for _, want := range []float64{0.75, 1, 1} {
+		now := state.nextPacingGainChange.Add(time.Nanosecond)
+		clock.AdvanceTo(now)
+		state.postAck(lim, packetMeta{}, now)
+		if lim.pacingGain != want {
+			t.Fatalf("ProbeBW pacing gain = %v; want %v", lim.pacingGain, want)
+		}
 	}
 }
 
 func runTrace(path []testLink, packetSizes []uint64) []Snapshot {
-	var results []Snapshot
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	clock := clock.System
-	lim := NewLimiter(clock)
-	defer lim.Release()
-
-	tx, rx := startTestPath(ctx, clock, path...)
-	go processAcks(ctx, rx)
-
-	for _, size := range packetSizes {
-		got, err := lim.StartMessage(ctx, size)
-		if err != nil {
-			panic(err)
-		}
-		tx.Send(testPacket{
-			size:        size,
-			gotResponse: got,
-		})
-		results = append(results, SnapshotLimiter(lim))
-	}
-	return results
+	sim := newSimulator(panicTestingT{}, path...)
+	return sim.run(packetSizes)
 }
+
+// panicTestingT is used by runTrace, whose caller owns test reporting.
+type panicTestingT struct{}
+
+func (panicTestingT) Helper()           {}
+func (panicTestingT) Fatal(args ...any) { panic(fmt.Sprint(args...)) }

--- a/flowcontrol/bbr/util_test.go
+++ b/flowcontrol/bbr/util_test.go
@@ -1,18 +1,11 @@
 package bbr
 
 import (
-	"context"
 	"testing"
 	"time"
-
-	"capnproto.org/go/capnp/v3/exp/clock"
-	"capnproto.org/go/capnp/v3/exp/mpsc"
 )
 
-var (
-	// Somewhat arbitrary time to start the clock.
-	sampleStartTime = time.Unix(1e9, 0)
-)
+var sampleStartTime = time.Unix(1e9, 0)
 
 type testPacket struct {
 	size        uint64
@@ -24,226 +17,73 @@ type testLink struct {
 	delay     time.Duration
 }
 
-func processAcks(ctx context.Context, rx *mpsc.Rx[testPacket]) {
-	for {
-		p, err := rx.Recv(ctx)
-		if err != nil {
-			return
-		}
-		p.gotResponse()
-	}
-}
+const bytesPerSecond bytesPerNs = 1e-9
 
-func startTestPath(ctx context.Context, clock clock.Clock, links ...testLink) (*mpsc.Tx[testPacket], *mpsc.Rx[testPacket]) {
-	q := mpsc.New[testPacket]()
-
-	initTx := &q.Tx
-
-	for _, l := range links {
-		rx := &q.Rx
-		q = mpsc.New[testPacket]()
-		tx := &q.Tx
-		ready := make(chan struct{})
-		go l.run(ctx, clock, rx, tx, ready)
-
-		// Wait until the link is ready to receive (avoids races with
-		// the test clock).
-		<-ready
-	}
-
-	return initTx, &q.Rx
-}
-
-func (l testLink) run(ctx context.Context, clock clock.Clock, rx *mpsc.Rx[testPacket], tx *mpsc.Tx[testPacket], ready chan struct{}) {
-	timer := clock.NewTimer(0)
-	<-timer.Chan()
-	close(ready)
-	for {
-
-		// Wait for a packet to arrive:
-		p, err := rx.Recv(ctx)
-		if err != nil {
-			return
-		}
-
-		var delay time.Duration
-		if l.bandwidth > 0 {
-			// We're the bottleneck; take an appropriate amount of time
-			// to process the packet, based on its size.
-			delay = time.Duration(float64(p.size) / float64(l.bandwidth))
-		} else {
-			// We're not the bottleneck; just add our constant delay.
-			delay = l.delay
-		}
-
-		// Wait until the right time, and then pass it along:
-		timer.Reset(delay)
-		select {
-		case <-ctx.Done():
-			return
-		case <-timer.Chan():
-			tx.Send(p)
-		}
-	}
-}
-
-// Fail the test immediately if done is receivable or closed, or becomes so within ~1ms.
-// XXX: This is inherently racy. But for our purposes, we just want to give very cheap
-// operations time to complete.
-//
-// If need be, we can probably afford to bump the threshold up to 10 or 100ms, as long
-// as all tests that use it only do so a couple times and can be run in parallel.
-func assertNotDone(t *testing.T, done <-chan struct{}) {
-	select {
-	case <-time.NewTimer(time.Millisecond).C:
-	case <-done:
-		t.Fatal("Packet should not have arrived yet.")
-	}
-}
-
-// assertDone asserts that the done channel is written to at a reasonable time
-// or else it fails the test.
-func assertDone(t *testing.T, done <-chan struct{}) {
-	t.Helper()
-	select {
-	case <-done:
-	case <-time.After(10 * time.Second):
-		t.Fatal("Not done before timeout")
-	}
-}
-
-// Try sending a packet through a path with one link of a given known delay;
-// make sure it arrives at the correct time.
 func TestLinkDelay(t *testing.T) {
-	t.Parallel()
+	clock := newSimClock(sampleStartTime)
+	path := newSimPath(clock, testLink{delay: 4 * time.Second})
+	done := false
+	path.send(testPacket{gotResponse: func() { done = true }})
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	clock := clock.NewManual(sampleStartTime)
-	tx, rx := startTestPath(ctx, clock, testLink{delay: 4 * time.Second})
-	go processAcks(ctx, rx)
-
-	done := make(chan struct{})
-
-	tx.Send(testPacket{
-		gotResponse: func() {
-			close(done)
-		},
-	})
-
-	assertNotDone(t, done)
-	clock.Advance(2 * time.Second)
-	assertNotDone(t, done)
-
-	clock.Advance(3 * time.Second) // This puts us at t = 5, after our delay.
-	assertDone(t, done)            // would deadlock if the packet still did't send.
+	path.advance(2 * time.Second)
+	if done {
+		t.Fatal("packet arrived before its link delay elapsed")
+	}
+	path.advance(3 * time.Second)
+	if !done {
+		t.Fatal("packet did not arrive after its link delay elapsed")
+	}
 }
 
-// Try sending a packet through a path with two links of known delay;
-// make sure it arrives at the correct time.
 func TestMultiLinkDelay(t *testing.T) {
-	t.Parallel()
+	clock := newSimClock(sampleStartTime)
+	path := newSimPath(clock, testLink{delay: 4 * time.Second}, testLink{delay: 2 * time.Second})
+	done := false
+	path.send(testPacket{gotResponse: func() { done = true }})
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	clock := clock.NewManual(sampleStartTime)
-	tx, rx := startTestPath(ctx, clock,
-		testLink{delay: 4 * time.Second},
-		testLink{delay: 2 * time.Second},
-	)
-	go processAcks(ctx, rx)
-
-	done := make(chan struct{})
-
-	tx.Send(testPacket{
-		gotResponse: func() {
-			close(done)
-		},
-	})
-
-	assertNotDone(t, done)
-	clock.Advance(2 * time.Second)
-	assertNotDone(t, done)
-
-	clock.Advance(3 * time.Second) // This puts us at t = 5, after our first link's delay.
-	assertNotDone(t, done)         // ...but it still needs to get through the second link.
-
-	clock.Advance(2 * time.Second) // This should get us all the way to the end.
-	assertDone(t, done)            // would deadlock if the packet still did't send.
+	path.advance(5 * time.Second)
+	if done {
+		t.Fatal("packet arrived before it traversed both links")
+	}
+	path.advance(1 * time.Second)
+	if !done {
+		t.Fatal("packet did not arrive after it traversed both links")
+	}
 }
-
-const (
-	bytesPerSecond bytesPerNs = 1e-9
-)
 
 func TestLinkBandwidth(t *testing.T) {
-	// Try sending a packet through a path with a known bandwidth, and make sure
-	// it takes the correct amount of time.
+	clock := newSimClock(sampleStartTime)
+	path := newSimPath(clock, testLink{bandwidth: 10 * bytesPerSecond})
+	done := false
+	path.send(testPacket{size: 25, gotResponse: func() { done = true }})
 
-	t.Parallel()
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	clock := clock.NewManual(sampleStartTime)
-
-	tx, rx := startTestPath(ctx, clock, testLink{bandwidth: 10 * bytesPerSecond})
-	go processAcks(ctx, rx)
-
-	done := make(chan struct{})
-
-	tx.Send(testPacket{
-		size: 25,
-		gotResponse: func() {
-			close(done)
-		},
-	})
-
-	assertNotDone(t, done)
-	clock.Advance(2 * time.Second)
-	assertNotDone(t, done)
-	clock.Advance(1 * time.Second)
-	assertDone(t, done)
+	path.advance(2 * time.Second)
+	if done {
+		t.Fatal("packet arrived before its serialization delay elapsed")
+	}
+	path.advance(time.Second)
+	if !done {
+		t.Fatal("packet did not arrive after its serialization delay elapsed")
+	}
 }
 
 func TestLinkBandwidthMultiPacket(t *testing.T) {
-	// Try sending multiple packets through a path with a known bandwidth,
-	// and make sure it takes the right amount of time.
-	t.Parallel()
+	clock := newSimClock(sampleStartTime)
+	path := newSimPath(clock, testLink{bandwidth: 10 * bytesPerSecond})
+	done1, done2 := false, false
+	path.send(testPacket{size: 25, gotResponse: func() { done1 = true }})
+	path.send(testPacket{size: 30, gotResponse: func() { done2 = true }})
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	clock := clock.NewManual(sampleStartTime)
-
-	tx, rx := startTestPath(ctx, clock, testLink{bandwidth: 10 * bytesPerSecond})
-	go processAcks(ctx, rx)
-
-	done1 := make(chan struct{})
-	done2 := make(chan struct{})
-
-	tx.Send(testPacket{
-		size: 25,
-		gotResponse: func() {
-			close(done1)
-		},
-	})
-	tx.Send(testPacket{
-		size: 30,
-		gotResponse: func() {
-			close(done2)
-		},
-	})
-
-	assertNotDone(t, done1)
-	assertNotDone(t, done2)
-	clock.Advance(2 * time.Second)
-
-	assertNotDone(t, done1)
-	assertNotDone(t, done2)
-
-	clock.Advance(1 * time.Second)
-	assertDone(t, done1)
-	assertNotDone(t, done2)
-
-	clock.Advance(3 * time.Second)
-	assertDone(t, done2)
+	path.advance(2 * time.Second)
+	if done1 || done2 {
+		t.Fatal("packets arrived before the first serialization delay elapsed")
+	}
+	path.advance(time.Second)
+	if !done1 || done2 {
+		t.Fatal("serial link did not deliver exactly the first packet")
+	}
+	path.advance(3 * time.Second)
+	if !done2 {
+		t.Fatal("serial link did not deliver the second packet")
+	}
 }


### PR DESCRIPTION
## Summary

- Replace BBR trace tests' wall-clock path with a virtual-time packet simulator.
- Make ProbeBW phase selection deterministic in tests without changing the public API.
- Enable trace coverage by default and remove sleep-based/racy path assertions.
- Cover Startup, Drain, ProbeBW transitions, gain cycling, and repeated simulated runs.

## Test plan

- [x] `go test ./flowcontrol/bbr -count=20 -timeout=60s`
- [x] `go test -race ./flowcontrol/bbr -count=1 -timeout=60s`
- [x] `go test ./... -count=1 -timeout=3m`

ProbeRTT correctness remains intentionally separate follow-up work.