### PR TITLE
rpc: preserve wrapped exception types

### DIFF
--- a/exc/types.go
+++ b/exc/types.go
@@ -58,11 +58,11 @@ func (typ Type) GoString() string {
 	}
 }
 
-// TypeOf returns err's type if err was created by this package or
-// Failed if it was not.
+// TypeOf returns err's exception type if its error chain contains an exception
+// created by this package, or Failed if it does not.
 func TypeOf(err error) Type {
-	ce, ok := err.(*Exception)
-	if !ok {
+	var ce *Exception
+	if !errors.As(err, &ce) {
 		return Failed
 	}
 	return ce.Type

--- a/exc/types_test.go
+++ b/exc/types_test.go
@@ -22,6 +22,7 @@ func TestTypeOf(t *testing.T) {
 		{exc.New(exc.Overloaded, "capnp", "overloaded error"), exc.Overloaded},
 		{exc.New(exc.Disconnected, "capnp", "disconnected error"), exc.Disconnected},
 		{exc.New(exc.Unimplemented, "capnp", "unimplemented error"), exc.Unimplemented},
+		{fmt.Errorf("wrapped: %w", exc.New(exc.Unimplemented, "capnp", "unimplemented error")), exc.Unimplemented},
 	}
 	for _, test := range tests {
 		assert.Equal(t, test.want, exc.TypeOf(test.err))

--- a/rpc/level0_test.go
+++ b/rpc/level0_test.go
@@ -1102,7 +1102,7 @@ func TestRecvBootstrapCallException(t *testing.T) {
 	t.Parallel()
 
 	srv := newServer(func(ctx context.Context, call *server.Call) error {
-		return errors.New("everything went wrong")
+		return fmt.Errorf("handler failed: %w", exc.New(exc.Unimplemented, "test", "everything went wrong"))
 	}, nil)
 	left, right := transport.NewPipe(1)
 	p1, p2 := rpc.NewTransport(left), rpc.NewTransport(right)
@@ -1202,10 +1202,10 @@ func TestRecvBootstrapCallException(t *testing.T) {
 		if rmsg.Return.Which != rpccp.Return_Which_exception {
 			t.Fatalf("return which = %v; want results", rmsg.Return.Which)
 		}
-		if rmsg.Return.Exception.Type != rpccp.Exception_Type_failed {
-			t.Errorf("return.exception.type = %v; want failed", rmsg.Return.Exception.Type)
+		if rmsg.Return.Exception.Type != rpccp.Exception_Type_unimplemented {
+			t.Errorf("return.exception.type = %v; want unimplemented", rmsg.Return.Exception.Type)
 		}
-		const want = "everything went wrong"
+		const want = "handler failed: test: everything went wrong"
 		if !strings.Contains(rmsg.Return.Exception.Reason, want) {
 			t.Errorf("return.exception.reason = %q; want to contain %q", rmsg.Return.Exception.Reason, want)
 		}


### PR DESCRIPTION
Preserves a typed Cap’n Proto exception when application code wraps it with Go error wrapping.

exc.TypeOf now searches the error chain, and a level-0 RPC regression verifies that a wrapped unimplemented exception keeps its wire type and reason.

Fixes #602.