### PR TITLE
capnp: reject rootless messages in Marshal

### DIFF
--- a/codec_test.go
+++ b/codec_test.go
@@ -76,6 +76,20 @@ func TestDecoder(t *testing.T) {
 	}
 }
 
+// Decoding only parses framing. A message without a root pointer remains
+// inspectable after decoding.
+func TestDecoderRootless(t *testing.T) {
+	t.Parallel()
+
+	msg, err := NewDecoder(bytes.NewReader([]byte{
+		0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00,
+	})).Decode()
+	require.NoError(t, err)
+	_, err = msg.Root()
+	require.Error(t, err)
+}
+
 type tooManySegsArena struct {
 	data []byte
 }

--- a/message.go
+++ b/message.go
@@ -298,14 +298,34 @@ func (m *Message) WriteTo(w io.Writer) (int64, error) {
 	return wc.N, err
 }
 
+// checkRootForSerialization rejects the two representations of a message
+// whose root has not been initialized. It deliberately does not validate the
+// rest of the message: decoding and low-level message construction may need
+// to preserve malformed pointer data for the caller to inspect.
+func (m *Message) checkRootForSerialization() error {
+	first, err := m.Segment(0)
+	if err != nil || len(first.Data()) == 0 {
+		return errors.New("message has no root")
+	}
+	root, err := m.Root()
+	if err == nil && !root.IsValid() {
+		return errors.New("message has no root")
+	}
+	return nil
+}
+
 // Marshal concatenates the segments in the message into a single byte
-// slice including framing.
+// slice including framing. It returns an error if the message has no root.
 func (m *Message) Marshal() ([]byte, error) {
-	// Compute buffer size.
 	nsegs := m.NumSegments()
 	if nsegs == 0 {
 		return nil, errors.New("marshal: message has no segments")
 	}
+	if err := m.checkRootForSerialization(); err != nil {
+		return nil, exc.WrapError("marshal", err)
+	}
+
+	// Compute buffer size.
 	hdrSize := streamHeaderSize(SegmentID(nsegs - 1))
 	if hdrSize > uint64(maxInt) {
 		return nil, errors.New("marshal: header size overflows int")

--- a/message_test.go
+++ b/message_test.go
@@ -158,6 +158,7 @@ type serializeTest struct {
 	name            string
 	segs            [][]byte
 	out             []byte
+	marshalFails    bool
 	encodeFails     bool
 	decodeFails     bool
 	decodeError     error
@@ -206,10 +207,11 @@ var serializeTests = []serializeTest{
 		decodeFails: true,
 	},
 	{
-		name: "empty single segment",
+		name: "rootless single segment",
 		segs: [][]byte{
 			{},
 		},
+		marshalFails: true,
 		out: []byte{
 			0x00, 0x00, 0x00, 0x00,
 			0x00, 0x00, 0x00, 0x00,
@@ -306,17 +308,61 @@ func TestMarshal(t *testing.T) {
 		}
 		out, err := msg.Marshal()
 		if err != nil {
-			if !test.encodeFails {
+			if !test.marshalFails {
 				t.Errorf("serializeTests[%d] %s: Marshal error: %v", i, test.name, err)
 			}
 			continue
 		}
-		if test.encodeFails {
+		if test.marshalFails {
 			t.Errorf("serializeTests[%d] - %s: Marshal success; want error", i, test.name)
 			continue
 		}
 		if !bytes.Equal(out, test.out) {
 			t.Errorf("serializeTests[%d] - %s: Marshal = % 02x; want % 02x", i, test.name, out, test.out)
+		}
+	}
+}
+
+func TestMarshalRootless(t *testing.T) {
+	t.Parallel()
+
+	for _, data := range [][]byte{nil, make([]byte, wordSize)} {
+		msg, _ := NewSingleSegmentMessage(data)
+		if _, err := msg.Marshal(); err == nil {
+			t.Error("Marshal() succeeded for a rootless message")
+		}
+		if _, err := msg.MarshalPacked(); err == nil {
+			t.Error("MarshalPacked() succeeded for a rootless message")
+		}
+	}
+}
+
+func TestUnmarshalRootless(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		data        []byte
+		wantRootErr bool
+	}{
+		{data: []byte{
+			0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x00,
+		}, wantRootErr: true},
+		{data: []byte{
+			0x00, 0x00, 0x00, 0x00,
+			0x01, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x00,
+		}},
+	} {
+		msg, err := Unmarshal(test.data)
+		require.NoError(t, err)
+		root, err := msg.Root()
+		if test.wantRootErr {
+			require.Error(t, err)
+		} else {
+			require.NoError(t, err)
+			assert.False(t, root.IsValid(), "Root() should report a null root pointer")
 		}
 	}
 }
@@ -562,7 +608,11 @@ func TestTotalSize(t *testing.T) {
 			}
 		}
 
-		msg, _ := NewMultiSegmentMessage(segs)
+		msg, seg := NewMultiSegmentMessage(segs)
+		_, err := NewRootStruct(seg, ObjectSize{})
+		if err != nil {
+			return false
+		}
 
 		size, err := msg.TotalSize()
 		assert.Nil(t, err, "TotalSize() returned an error")

--- a/rpc/transport/pipe.go
+++ b/rpc/transport/pipe.go
@@ -1,6 +1,7 @@
 package transport
 
 import (
+	"bytes"
 	"io"
 	"sync"
 
@@ -40,12 +41,12 @@ type pipe struct {
 }
 
 func (p *pipe) Encode(m *capnp.Message) (err error) {
-	b, err := m.Marshal()
-	if err != nil {
+	var buf bytes.Buffer
+	if err := capnp.NewEncoder(&buf).Encode(m); err != nil {
 		return err
 	}
 
-	if m, err = capnp.Unmarshal(b); err != nil {
+	if m, err = capnp.Unmarshal(buf.Bytes()); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Fixes #574.

Message.Marshal and MarshalPacked now reject messages that have no root pointer or a null root pointer. Raw decoding and the lower-level Encoder remain transparent, so callers can still inspect raw framed messages. The in-memory RPC pipe now uses Encoder explicitly for its raw copy operation.

Tests cover both rootless encodings, packed marshaling, decoder and unmarshal behavior, and the transport copy path.

Checks:
- go test -v ./...
- go test -v -race -short ./...
- go test ./rpc -count=50