### PR TITLE
capnp: support external arena implementations

### DIFF
--- a/arena_external_test.go
+++ b/arena_external_test.go
@@ -1,0 +1,83 @@
+package capnp_test
+
+import (
+	"testing"
+
+	"capnproto.org/go/capnp/v3"
+)
+
+type externalArena struct {
+	segs []*capnp.Segment
+}
+
+func (a *externalArena) NumSegments() int64 {
+	return int64(len(a.segs))
+}
+
+func (a *externalArena) Segment(id capnp.SegmentID) *capnp.Segment {
+	if int(id) >= len(a.segs) {
+		return nil
+	}
+	return a.segs[id]
+}
+
+func (a *externalArena) Allocate(minsz capnp.Size, msg *capnp.Message, preferred *capnp.Segment) (*capnp.Segment, capnp.Address, error) {
+	if preferred != nil && cap(preferred.Data())-len(preferred.Data()) >= int(minsz) {
+		addr := capnp.Address(len(preferred.Data()))
+		preferred.SetData(preferred.Data()[:len(preferred.Data())+int(minsz)])
+		preferred.BindTo(msg)
+		return preferred, addr, nil
+	}
+
+	capacity := int(minsz) + 8
+	if capacity < 16 {
+		capacity = 16
+	}
+	seg := capnp.NewSegment(capnp.SegmentID(len(a.segs)), make([]byte, int(minsz), capacity))
+	seg.BindTo(msg)
+	a.segs = append(a.segs, seg)
+	return seg, 0, nil
+}
+
+func (*externalArena) Release() {}
+
+func TestExternalArena(t *testing.T) {
+	arena := new(externalArena)
+	msg, seg, err := capnp.NewMessage(arena)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	root, err := capnp.NewRootStruct(seg, capnp.ObjectSize{PointerCount: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	child, err := capnp.NewStruct(root.Segment(), capnp.ObjectSize{DataSize: 8})
+	if err != nil {
+		t.Fatal(err)
+	}
+	child.SetUint64(0, 42)
+	if err := root.SetPtr(0, child.ToPtr()); err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := msg.Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	decoded, err := capnp.Unmarshal(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ptr, err := decoded.Root()
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := ptr.Struct().Ptr(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Struct().Uint64(0) != 42 {
+		t.Errorf("decoded child data = %d; want 42", got.Struct().Uint64(0))
+	}
+}

--- a/rpc/flow_test.go
+++ b/rpc/flow_test.go
@@ -78,7 +78,9 @@ func (l *observingLimiter) signalChanged() {
 // flow of messages. The server holds accepted calls until the test releases it,
 // which fills the client's limiter without depending on scheduler timing.
 func TestFixedFlowLimit(t *testing.T) {
-	t.Parallel()
+	// This test deliberately saturates an RPC connection and uses a short
+	// deadline to detect a blocked client. Keep it serial so unrelated parallel
+	// RPC tests cannot consume that deadline.
 
 	limit := int64(1 << 20)
 

--- a/segment.go
+++ b/segment.go
@@ -23,6 +23,14 @@ type Segment struct {
 	data []byte
 }
 
+// NewSegment creates a segment with the given ID and data.
+//
+// It is intended for use by Arena implementations. The ID of a segment must
+// not change after it has been added to an arena.
+func NewSegment(id SegmentID, data []byte) *Segment {
+	return &Segment{id: id, data: data}
+}
+
 // Message returns the message that contains s.
 func (s *Segment) Message() *Message {
 	return s.msg
@@ -42,6 +50,15 @@ func (s *Segment) ID() SegmentID {
 // Data returns the raw byte slice for the segment.
 func (s *Segment) Data() []byte {
 	return s.data
+}
+
+// SetData replaces the data in s.
+//
+// This is intended for use by Arena implementations when growing a segment.
+// If an arena returns an existing segment from Allocate, it must preserve the
+// existing data when replacing the segment's data.
+func (s *Segment) SetData(data []byte) {
+	s.data = data
 }
 
 func (s *Segment) inBounds(addr Address) bool {


### PR DESCRIPTION
## Summary

Expose the missing `Segment` operations needed to implement `capnp.Arena` outside this package:

- `capnp.NewSegment` constructs a segment with a stable ID and caller-owned data.
- `(*capnp.Segment).SetData` lets an arena replace or reslice segment storage while growing it.

`Arena` has long been a public interface, and `Address` is now public for its `Allocate` signature. Before this change, external implementations still could not create a usable `Segment` or update its backing slice because both fields were package-private. They could only wrap the built-in arenas.

The new API is intentionally narrow: IDs are assigned at construction and remain immutable; custom arenas may only replace the segment data and are responsible for preserving it when reusing a segment.

## Tests

Adds a black-box `capnp_test` Arena implementation that:

1. creates segment 0 externally;
2. grows it with `SetData`;
3. allocates a second segment;
4. writes a cross-segment pointer; and
5. marshals and decodes the message successfully.

`go test ./...`