### PR TITLE
perf(pogs): cache schema metadata and struct mappings

### DIFF
--- a/internal/nodemap/nodemap.go
+++ b/internal/nodemap/nodemap.go
@@ -2,6 +2,8 @@
 package nodemap
 
 import (
+	"sync"
+
 	"capnproto.org/go/capnp/v3"
 	"capnproto.org/go/capnp/v3/internal/schema"
 	"capnproto.org/go/capnp/v3/schemas"
@@ -11,6 +13,16 @@ import (
 // The zero value is an index of the default registry.
 type Map struct {
 	reg   *schemas.Registry
+	index *nodeIndex
+}
+
+// defaultIndex is shared by all zero-value Maps.  Generated schemas are
+// immutable after registration, so nodes are safe to share once an entire
+// decoded request has been published under the lock.
+var defaultIndex = new(nodeIndex)
+
+type nodeIndex struct {
+	mu    sync.RWMutex
 	nodes map[uint64]schema.Node
 }
 
@@ -21,18 +33,32 @@ func (m *Map) registry() *schemas.Registry {
 	return schemas.DefaultRegistry
 }
 
-// UseRegistry assigns 'reg' to 'm' and initializes the nodes map.
+// UseRegistry assigns reg to m and initializes an index for it.  The default
+// registry uses the process-wide shared index; custom registries remain local
+// to the Map.
 func (m *Map) UseRegistry(reg *schemas.Registry) {
 	m.reg = reg
-	m.nodes = make(map[uint64]schema.Node)
+	m.index = new(nodeIndex)
 }
 
 // Find returns the node for the given ID.
 func (m *Map) Find(id uint64) (schema.Node, error) {
-	if n := m.nodes[id]; n.IsValid() {
+	reg := m.registry()
+	index := m.index
+	if reg == schemas.DefaultRegistry {
+		index = defaultIndex
+	}
+	return index.find(reg, id)
+}
+
+func (index *nodeIndex) find(reg *schemas.Registry, id uint64) (schema.Node, error) {
+	index.mu.RLock()
+	n := index.nodes[id]
+	index.mu.RUnlock()
+	if n.IsValid() {
 		return n, nil
 	}
-	data, err := m.registry().Find(id)
+	data, err := reg.Find(id)
 	if err != nil {
 		return schema.Node{}, err
 	}
@@ -48,12 +74,26 @@ func (m *Map) Find(id uint64) (schema.Node, error) {
 	if err != nil {
 		return schema.Node{}, err
 	}
-	if m.nodes == nil {
-		m.nodes = make(map[uint64]schema.Node)
-	}
+	decoded := make(map[uint64]schema.Node, nodes.Len())
 	for i := 0; i < nodes.Len(); i++ {
 		n := nodes.At(i)
-		m.nodes[n.Id()] = n
+		decoded[n.Id()] = n
 	}
-	return m.nodes[id], nil
+	// Cached nodes retain msg for the lifetime of the index.  Schema data is
+	// trusted, immutable metadata, so a finite cumulative traversal budget
+	// would eventually make an otherwise valid cache entry unreadable.
+	msg.ResetReadLimit(^uint64(0))
+
+	index.mu.Lock()
+	if index.nodes == nil {
+		index.nodes = make(map[uint64]schema.Node)
+	}
+	for nodeID, n := range decoded {
+		if !index.nodes[nodeID].IsValid() {
+			index.nodes[nodeID] = n
+		}
+	}
+	n = index.nodes[id]
+	index.mu.Unlock()
+	return n, nil
 }

--- a/internal/nodemap/nodemap.go
+++ b/internal/nodemap/nodemap.go
@@ -16,10 +16,26 @@ type Map struct {
 	index *nodeIndex
 }
 
-// defaultIndex is shared by all zero-value Maps.  Generated schemas are
-// immutable after registration, so nodes are safe to share once an entire
-// decoded request has been published under the lock.
-var defaultIndex = new(nodeIndex)
+// defaultIndex is shared by all zero-value Maps.  It associates the index with
+// the current default registry so replacing schemas.DefaultRegistry cannot
+// expose nodes decoded from the previous registry.
+var defaultIndex defaultNodeIndex
+
+type defaultNodeIndex struct {
+	mu    sync.Mutex
+	reg   *schemas.Registry
+	index *nodeIndex
+}
+
+func (d *defaultNodeIndex) forRegistry(reg *schemas.Registry) *nodeIndex {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.reg != reg || d.index == nil {
+		d.reg = reg
+		d.index = new(nodeIndex)
+	}
+	return d.index
+}
 
 type nodeIndex struct {
 	mu    sync.RWMutex
@@ -46,7 +62,7 @@ func (m *Map) Find(id uint64) (schema.Node, error) {
 	reg := m.registry()
 	index := m.index
 	if reg == schemas.DefaultRegistry {
-		index = defaultIndex
+		index = defaultIndex.forRegistry(reg)
 	}
 	return index.find(reg, id)
 }

--- a/internal/nodemap/nodemap_test.go
+++ b/internal/nodemap/nodemap_test.go
@@ -61,12 +61,9 @@ func nodeName(t *testing.T, n schema.Node) string {
 func useFreshDefaultRegistry(t *testing.T) {
 	t.Helper()
 	oldRegistry := schemas.DefaultRegistry
-	oldIndex := defaultIndex
 	schemas.DefaultRegistry = new(schemas.Registry)
-	defaultIndex = new(nodeIndex)
 	t.Cleanup(func() {
 		schemas.DefaultRegistry = oldRegistry
-		defaultIndex = oldIndex
 	})
 }
 
@@ -104,6 +101,37 @@ func TestDefaultIndexFindsLaterRegistration(t *testing.T) {
 	}
 	if got := nodeName(t, n); got != "later" {
 		t.Fatalf("display name = %q; want later", got)
+	}
+}
+
+func TestDefaultIndexTracksRegistryReplacement(t *testing.T) {
+	const id = 0x9c5c2bf81252e180
+	first := new(schemas.Registry)
+	second := new(schemas.Registry)
+	registerSchema(t, first, map[uint64]string{id: "first registry"})
+	registerSchema(t, second, map[uint64]string{id: "second registry"})
+
+	oldRegistry := schemas.DefaultRegistry
+	t.Cleanup(func() { schemas.DefaultRegistry = oldRegistry })
+	schemas.DefaultRegistry = first
+
+	var firstMap Map
+	n, err := firstMap.Find(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := nodeName(t, n); got != "first registry" {
+		t.Fatalf("first registry returned %q", got)
+	}
+
+	schemas.DefaultRegistry = second
+	var secondMap Map
+	n, err = secondMap.Find(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := nodeName(t, n); got != "second registry" {
+		t.Fatalf("replacement registry returned %q; want second registry", got)
 	}
 }
 

--- a/internal/nodemap/nodemap_test.go
+++ b/internal/nodemap/nodemap_test.go
@@ -1,0 +1,195 @@
+package nodemap
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+
+	"capnproto.org/go/capnp/v3"
+	"capnproto.org/go/capnp/v3/internal/schema"
+	"capnproto.org/go/capnp/v3/schemas"
+)
+
+func makeSchema(t *testing.T, nodes map[uint64]string) []byte {
+	t.Helper()
+	msg, seg := capnp.NewSingleSegmentMessage(nil)
+	req, err := schema.NewRootCodeGeneratorRequest(seg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	list, err := req.NewNodes(int32(len(nodes)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	i := 0
+	for id, name := range nodes {
+		n := list.At(i)
+		n.SetId(id)
+		if err := n.SetDisplayName(name); err != nil {
+			t.Fatal(err)
+		}
+		i++
+	}
+	data, err := msg.Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return data
+}
+
+func registerSchema(t *testing.T, reg *schemas.Registry, nodes map[uint64]string) {
+	t.Helper()
+	ids := make([]uint64, 0, len(nodes))
+	for id := range nodes {
+		ids = append(ids, id)
+	}
+	if err := reg.Register(&schemas.Schema{Bytes: makeSchema(t, nodes), Nodes: ids}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func nodeName(t *testing.T, n schema.Node) string {
+	t.Helper()
+	name, err := n.DisplayName()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return name
+}
+
+func useFreshDefaultRegistry(t *testing.T) {
+	t.Helper()
+	oldRegistry := schemas.DefaultRegistry
+	oldIndex := defaultIndex
+	schemas.DefaultRegistry = new(schemas.Registry)
+	defaultIndex = new(nodeIndex)
+	t.Cleanup(func() {
+		schemas.DefaultRegistry = oldRegistry
+		defaultIndex = oldIndex
+	})
+}
+
+func TestDefaultIndexFindsLaterRegistration(t *testing.T) {
+	useFreshDefaultRegistry(t)
+	const firstID = 0x9c5c2bf81252e101
+	const laterID = 0x9c5c2bf81252e102
+	const siblingID = 0x9c5c2bf81252e103
+	registerSchema(t, schemas.DefaultRegistry, map[uint64]string{
+		firstID:   "first",
+		siblingID: "sibling",
+	})
+
+	var first Map
+	firstNode, err := first.Find(firstID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var sibling Map
+	siblingNode, err := sibling.Find(siblingID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if firstNode.Message() != siblingNode.Message() {
+		t.Fatal("default Maps did not share the decoded schema request")
+	}
+
+	// Populating the shared index must not snapshot the registry.  A schema
+	// registered before its first lookup is still found on a later miss.
+	registerSchema(t, schemas.DefaultRegistry, map[uint64]string{laterID: "later"})
+	var later Map
+	n, err := later.Find(laterID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := nodeName(t, n); got != "later" {
+		t.Fatalf("display name = %q; want later", got)
+	}
+}
+
+func TestCustomRegistriesAreIsolated(t *testing.T) {
+	const id = 0x9c5c2bf81252e201
+	reg1, reg2 := new(schemas.Registry), new(schemas.Registry)
+	registerSchema(t, reg1, map[uint64]string{id: "registry one"})
+	registerSchema(t, reg2, map[uint64]string{id: "registry two"})
+
+	var m1, m2 Map
+	m1.UseRegistry(reg1)
+	m2.UseRegistry(reg2)
+	n1, err := m1.Find(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	n2, err := m2.Find(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := nodeName(t, n1); got != "registry one" {
+		t.Fatalf("first registry returned %q", got)
+	}
+	if got := nodeName(t, n2); got != "registry two" {
+		t.Fatalf("second registry returned %q", got)
+	}
+}
+
+func TestConcurrentDefaultFirstUse(t *testing.T) {
+	useFreshDefaultRegistry(t)
+	const baseID = 0x9c5c2bf81252e300
+	nodes := make(map[uint64]string)
+	for i := uint64(0); i < 4; i++ {
+		nodes[baseID+i] = fmt.Sprintf("node %d", i)
+	}
+	registerSchema(t, schemas.DefaultRegistry, nodes)
+
+	const goroutines = 32
+	start := make(chan struct{})
+	errs := make(chan error, goroutines)
+	var wg sync.WaitGroup
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			var m Map
+			id := baseID + uint64(i%len(nodes))
+			n, err := m.Find(id)
+			if err == nil && !n.IsValid() {
+				err = fmt.Errorf("node %#x is invalid", id)
+			}
+			errs <- err
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Error(err)
+		}
+	}
+}
+
+func TestCachedNodeDoesNotExhaustTraversalLimit(t *testing.T) {
+	useFreshDefaultRegistry(t)
+	const id = 0x9c5c2bf81252e400
+	name := strings.Repeat("x", 1<<20)
+	registerSchema(t, schemas.DefaultRegistry, map[uint64]string{id: name})
+
+	var m Map
+	n, err := m.Find(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The default message traversal limit is 64 MiB.  Reading this field 80
+	// times would exhaust a cached message unless publication makes its
+	// trusted schema metadata effectively non-exhausting.
+	for i := 0; i < 80; i++ {
+		got, err := n.DisplayName()
+		if err != nil {
+			t.Fatalf("DisplayName iteration %d: %v", i, err)
+		}
+		if len(got) != len(name) {
+			t.Fatalf("DisplayName iteration %d length = %d; want %d", i, len(got), len(name))
+		}
+	}
+}

--- a/pogs/fields.go
+++ b/pogs/fields.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"sync"
 
 	"capnproto.org/go/capnp/v3/internal/schema"
 )
@@ -93,7 +94,31 @@ type structProps struct {
 	fixedWhich uint16
 }
 
+type structPropsKey struct {
+	typeID uint64
+	t      reflect.Type
+}
+
+type structPropsResult struct {
+	props structProps
+	err   error
+}
+
+var structPropsCache sync.Map
+
 func mapStruct(t reflect.Type, n schema.Node) (structProps, error) {
+	key := structPropsKey{typeID: n.Id(), t: t}
+	if cached, ok := structPropsCache.Load(key); ok {
+		result := cached.(structPropsResult)
+		return result.props, result.err
+	}
+	props, err := buildStructProps(t, n)
+	actual, _ := structPropsCache.LoadOrStore(key, structPropsResult{props: props, err: err})
+	result := actual.(structPropsResult)
+	return result.props, result.err
+}
+
+func buildStructProps(t reflect.Type, n schema.Node) (structProps, error) {
 	fields, err := n.StructNode().Fields()
 	if err != nil {
 		return structProps{}, err

--- a/pogs/pogs_test.go
+++ b/pogs/pogs_test.go
@@ -4,11 +4,15 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"reflect"
 	"strings"
+	"sync"
 	"testing"
 
 	"capnproto.org/go/capnp/v3"
 	air "capnproto.org/go/capnp/v3/internal/aircraftlib"
+	"capnproto.org/go/capnp/v3/internal/nodemap"
+	"capnproto.org/go/capnp/v3/internal/schema"
 	"github.com/kylelemons/godebug/pretty"
 )
 
@@ -1172,6 +1176,96 @@ func zfill(c air.Z, g *Z) error {
 var zpretty = &pretty.Config{
 	Compact:        true,
 	SkipZeroFields: true,
+}
+
+type invalidCachedMapping struct {
+	NotInSchema int
+}
+
+func benchmarkANode(t *testing.T) schema.Node {
+	t.Helper()
+	var nodes nodemap.Map
+	n, err := nodes.Find(air.BenchmarkA_TypeID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return n
+}
+
+func TestMapStructCachesResult(t *testing.T) {
+	n := benchmarkANode(t)
+	typ := reflect.TypeOf(A{})
+	first, err := mapStruct(typ, n)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := mapStruct(typ, n)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(first.fields) == 0 || &first.fields[0] != &second.fields[0] {
+		t.Fatal("mapStruct did not return the cached field mapping")
+	}
+}
+
+func TestMapStructCachesError(t *testing.T) {
+	n := benchmarkANode(t)
+	typ := reflect.TypeOf(invalidCachedMapping{})
+	_, first := mapStruct(typ, n)
+	_, second := mapStruct(typ, n)
+	if first == nil {
+		t.Fatal("mapStruct unexpectedly succeeded")
+	}
+	if first != second {
+		t.Fatalf("mapStruct errors are not cached: first %p, second %p", first, second)
+	}
+}
+
+func TestMapStructConcurrentFirstUse(t *testing.T) {
+	type concurrentMapping struct {
+		Name     string
+		BirthDay int64
+		Phone    string
+		Siblings int32
+		Spouse   bool
+		Money    float64
+	}
+
+	n := benchmarkANode(t)
+	typ := reflect.TypeOf(concurrentMapping{})
+	const goroutines = 32
+	start := make(chan struct{})
+	results := make(chan *fieldLoc, goroutines)
+	errs := make(chan error, goroutines)
+	var wg sync.WaitGroup
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			props, err := mapStruct(typ, n)
+			if err != nil {
+				errs <- err
+				return
+			}
+			results <- &props.fields[0]
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(results)
+	close(errs)
+	for err := range errs {
+		t.Error(err)
+	}
+	var first *fieldLoc
+	for result := range results {
+		if first == nil {
+			first = result
+		} else if first != result {
+			t.Error("concurrent mapStruct call returned a separately built mapping")
+		}
+	}
 }
 
 func sliceeq(na, nb int, f func(i int) bool) bool {


### PR DESCRIPTION
Closes #625

## Summary

- Add a concurrency-safe, lazily populated node index shared by users of `schemas.DefaultRegistry`.
- Keep custom schema registries isolated with per-`nodemap.Map` indexes.
- Cache successful POGS struct mappings and validation errors by schema type ID and Go type.
- Treat cached schema messages as trusted immutable metadata so their traversal budget cannot be exhausted by repeated use.

## Performance

Compared with the issue baseline of roughly 13.8 KB/op and 26-30 allocations:

| Benchmark | Time | Bytes/op | Allocs/op |
|---|---:|---:|---:|
| Extract | 948-1005 ns/op | 336 B/op | 7 |
| Insert | 956-975 ns/op | 240 B/op | 3 |

This reduces allocated bytes by more than 97%.

## Test plan

- [x] `go test ./...`
- [x] `go test -race ./internal/nodemap ./pogs ./encoding/text ./schemas`
- [x] Concurrent cache-publication coverage
- [x] Traversal-budget longevity regression coverage
- [x] Existing POGS benchmarks with `-benchmem -count=3`
