### PR TITLE
rpc: classify outbound send failures

### DIFF
--- a/rpc/answer.go
+++ b/rpc/answer.go
@@ -138,11 +138,12 @@ func (c *Conn) newReturn() (_ rpccp.Return, sendMsg func(), _ *rc.Releaser, _ er
 
 	return ret, func() {
 		c.lk.sendTx.Send(asyncSend{
+			ctx:     c.bgctx,
 			send:    outMsg.Send,
 			release: releaser.Decr,
-			onSent: func(err error) {
-				if err != nil {
-					c.er.ReportError(exc.WrapError("send return", err))
+			onSent: func(outcome sendOutcome) {
+				if outcome.err != nil && !outcome.fatal {
+					c.er.ReportError(exc.WrapError("send return", outcome.err))
 				}
 			},
 		})

--- a/rpc/import.go
+++ b/rpc/import.go
@@ -189,7 +189,7 @@ func (ic *importClient) Shutdown() {
 			}
 			return err
 		}, func(err error) {
-			if err != nil {
+			if err != nil && !isFatalSendError(err) {
 				ic.c.er.ReportError(rpcerr.Annotate(err, "send release"))
 			}
 		})

--- a/rpc/question.go
+++ b/rpc/question.go
@@ -116,7 +116,7 @@ func (q *question) handleCancel(ctx context.Context) {
 		}, func(err error) {
 			if err == nil {
 				syncutil.With(&q.c.lk, func() { q.flags |= finishSent })
-			} else if q.c.bgctx.Err() == nil {
+			} else if q.c.bgctx.Err() == nil && !isFatalSendError(err) {
 				q.c.er.ReportError(rpcerr.Annotate(err, "send finish"))
 			}
 			close(q.finishMsgSend)

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -542,7 +542,9 @@ func (c *Conn) send(ctx context.Context) func() error {
 				return err
 			}
 
-			async.Send()
+			if err := async.Send(); err != nil {
+				return err
+			}
 		}
 	})
 }
@@ -781,7 +783,7 @@ func (c *Conn) handleCall(ctx context.Context, in transport.IncomingMessage) err
 
 				return nil
 			}, func(err error) {
-				if err != nil {
+				if err != nil && !isFatalSendError(err) {
 					c.er.ReportError(rpcerr.Annotate(err, "incoming call: send unimplemented"))
 				}
 			})
@@ -1223,7 +1225,7 @@ func (c *Conn) handleReturn(ctx context.Context, in transport.IncomingMessage) e
 				// TODO(soon): make embargo resolve to error client.
 				for _, s := range pr.disembargoes {
 					c.sendMessage(ctx, s.buildDisembargo, func(err error) {
-						if err != nil {
+						if err != nil && !isFatalSendError(err) {
 							err = exc.WrapError("incoming return: send disembargo", err)
 							c.er.ReportError(err)
 						}
@@ -1244,8 +1246,10 @@ func (c *Conn) handleReturn(ctx context.Context, in transport.IncomingMessage) e
 					defer close(q.finishMsgSend)
 
 					if err != nil {
-						err = exc.WrapError("incoming return: send finish: build message", err)
-						c.er.ReportError(err)
+						if !isFatalSendError(err) {
+							err = exc.WrapError("incoming return: send finish: build message", err)
+							c.er.ReportError(err)
+						}
 					} else {
 						q.flags |= finishSent
 						c.lk.questions.release(qid)
@@ -1740,7 +1744,7 @@ func (c *Conn) handleDisembargo(ctx context.Context, in transport.IncomingMessag
 				defer in.Release()
 				defer snapshot.Release()
 
-				if err != nil {
+				if err != nil && !isFatalSendError(err) {
 					c.er.ReportError(rpcerr.Annotate(err, "incoming disembargo: send receiver loopback"))
 				}
 			})
@@ -1762,7 +1766,7 @@ func (c *Conn) handleDisembargo(ctx context.Context, in transport.IncomingMessag
 				return
 			}, func(err error) {
 				defer in.Release()
-				if err != nil {
+				if err != nil && !isFatalSendError(err) {
 					c.er.ReportError(rpcerr.Annotate(err, "incoming disembargo: send unimplemented"))
 				}
 			})
@@ -1880,7 +1884,7 @@ func (c *Conn) handleResolve(ctx context.Context, in transport.IncomingMessage) 
 					},
 				}
 				c.sendMessage(ctx, disembargo.buildDisembargo, func(err error) {
-					if err != nil {
+					if err != nil && !isFatalSendError(err) {
 						c.er.ReportError(
 							exc.WrapError(
 								"incoming resolve: send disembargo",
@@ -1950,35 +1954,51 @@ func (c *lockedConn) startTask() (ok bool) {
 // onSent will be called without holding c.lk.  Callers of
 // sendMessage MAY wish to reacquire the c.lk within the onSent.
 func (c *lockedConn) sendMessage(ctx context.Context, build func(rpccp.Message) error, onSent func(error)) {
-	outMsg, err := c.transport.NewMessage()
-	send := outMsg.Send
-	release := outMsg.Release
-
-	// If errors happen when allocating or building the message, set up dummy send/release
-	// functions so the error handling logic in onSent() runs as normal:
-	if err != nil {
-		release = func() {}
-		send = func() error {
-			return rpcerr.WrapFailed("create message", err)
-		}
-	} else if err = build(outMsg.Message()); err != nil {
-		send = func() error {
-			return rpcerr.WrapFailed("build message", err)
+	var callback func(sendOutcome)
+	if onSent != nil {
+		callback = func(outcome sendOutcome) {
+			err := outcome.err
+			if outcome.fatal && err != nil {
+				err = fatalSendError{err}
+			}
+			onSent(err)
 		}
 	}
+	c.sendMessageOutcome(ctx, build, false, callback)
+}
 
-	oldSend := send
-	send = func() error {
-		if ctx.Err() != nil {
-			return ctx.Err()
-		}
-		return oldSend()
+// sendMessageOutcome is the classified form of sendMessage.  It distinguishes
+// failures that happened before calling OutgoingMessage.Send from failures
+// whose delivery is ambiguous.  fatalIfUnsent is for protocol messages, such
+// as Finish, whose failure prevents the connection from making safe progress.
+func (c *lockedConn) sendMessageOutcome(
+	ctx context.Context,
+	build func(rpccp.Message) error,
+	fatalIfUnsent bool,
+	onSent func(sendOutcome),
+) {
+	outMsg, err := c.transport.NewMessage()
+	var send func() error
+	var release capnp.ReleaseFunc
+	var preSendErr error
+	if err != nil {
+		release = func() {}
+		preSendErr = rpcerr.WrapFailed("create message", err)
+	} else if err = build(outMsg.Message()); err != nil {
+		release = outMsg.Release
+		preSendErr = rpcerr.WrapFailed("build message", err)
+	} else {
+		send = outMsg.Send
+		release = outMsg.Release
 	}
 
 	c.lk.sendTx.Send(asyncSend{
-		release: release,
-		send:    send,
-		onSent:  onSent,
+		ctx:           ctx,
+		preSendErr:    preSendErr,
+		fatalIfUnsent: fatalIfUnsent,
+		release:       release,
+		send:          send,
+		onSent:        onSent,
 	})
 }
 
@@ -2007,27 +2027,75 @@ type incomingMessage struct {
 }
 
 type asyncSend struct {
-	send    func() error
-	onSent  func(error)
-	release capnp.ReleaseFunc
+	ctx           context.Context
+	preSendErr    error
+	fatalIfUnsent bool
+	send          func() error
+	onSent        func(sendOutcome)
+	release       capnp.ReleaseFunc
+}
+
+type sendDisposition uint8
+
+const (
+	sendSucceeded sendDisposition = iota
+	sendDefinitelyUnsent
+	sendDeliveryAmbiguous
+	sendAbortedByShutdown
+)
+
+type sendOutcome struct {
+	disposition sendDisposition
+	err         error
+	fatal       bool
+}
+
+type fatalSendError struct{ error }
+
+func isFatalSendError(err error) bool {
+	var fatal fatalSendError
+	return errors.As(err, &fatal)
 }
 
 func (as asyncSend) Abort(err error) {
 	defer as.release()
 
 	if as.onSent != nil {
-		as.onSent(rpcerr.Disconnected(err))
+		as.onSent(sendOutcome{
+			disposition: sendAbortedByShutdown,
+			err:         rpcerr.Disconnected(err),
+		})
 	}
 }
 
-func (as asyncSend) Send() {
+func (as asyncSend) Send() error {
 	defer as.release()
 
-	if err := as.send(); as.onSent != nil {
-		if err != nil {
-			err = rpcerr.WrapFailed("send message", err)
+	outcome := sendOutcome{disposition: sendSucceeded}
+	switch {
+	case as.preSendErr != nil:
+		outcome.disposition = sendDefinitelyUnsent
+		outcome.err = as.preSendErr
+		outcome.fatal = as.fatalIfUnsent
+	case as.ctx.Err() != nil:
+		outcome.disposition = sendDefinitelyUnsent
+		outcome.err = as.ctx.Err()
+		outcome.fatal = as.fatalIfUnsent
+	default:
+		if err := as.send(); err != nil {
+			outcome.disposition = sendDeliveryAmbiguous
+			outcome.err = err
+			outcome.fatal = true
 		}
-
-		as.onSent(err)
 	}
+	if outcome.err != nil {
+		outcome.err = rpcerr.WrapFailed("send message", outcome.err)
+	}
+	if as.onSent != nil {
+		as.onSent(outcome)
+	}
+	if outcome.fatal {
+		return outcome.err
+	}
+	return nil
 }

--- a/rpc/send_outcome_test.go
+++ b/rpc/send_outcome_test.go
@@ -1,0 +1,292 @@
+package rpc
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	capnp "capnproto.org/go/capnp/v3"
+	"capnproto.org/go/capnp/v3/exp/spsc"
+	"capnproto.org/go/capnp/v3/rpc/transport"
+	rpccp "capnproto.org/go/capnp/v3/std/capnp/rpc"
+)
+
+type newMessageErrorTransport struct{ err error }
+
+func (t newMessageErrorTransport) NewMessage() (transport.OutgoingMessage, error) {
+	return nil, t.err
+}
+
+func (newMessageErrorTransport) RecvMessage() (transport.IncomingMessage, error) {
+	return nil, errors.New("unused")
+}
+
+func (newMessageErrorTransport) Close() error { return nil }
+
+func TestSendMessageNewMessageError(t *testing.T) {
+	wantErr := errors.New("allocate")
+	queue := spsc.New[asyncSend]()
+	c := &Conn{transport: newMessageErrorTransport{err: wantErr}}
+	c.lk.sendTx = &queue.Tx
+
+	var got sendOutcome
+	(*lockedConn)(c).sendMessageOutcome(
+		context.Background(),
+		func(rpccp.Message) error {
+			t.Fatal("build called after NewMessage failed")
+			return nil
+		},
+		false,
+		func(outcome sendOutcome) { got = outcome },
+	)
+
+	pending, ok := queue.Rx.TryRecv()
+	if !ok {
+		t.Fatal("message was not queued")
+	}
+	if err := pending.Send(); err != nil {
+		t.Fatalf("Send() error = %v; want non-fatal allocation failure", err)
+	}
+	if got.disposition != sendDefinitelyUnsent || got.fatal {
+		t.Fatalf("outcome = %+v; want definitely-unsent non-fatal", got)
+	}
+	if !errors.Is(got.err, wantErr) {
+		t.Fatalf("outcome error = %v; want wrapped %v", got.err, wantErr)
+	}
+}
+
+func TestAsyncSendOutcomes(t *testing.T) {
+	canceled, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	tests := []struct {
+		name      string
+		as        asyncSend
+		want      sendDisposition
+		wantFatal bool
+		abort     bool
+	}{
+		{
+			name: "success",
+			as:   asyncSend{ctx: context.Background(), send: func() error { return nil }},
+			want: sendSucceeded,
+		},
+		{
+			name: "definitely unsent",
+			as:   asyncSend{ctx: context.Background(), preSendErr: errors.New("build")},
+			want: sendDefinitelyUnsent,
+		},
+		{
+			name:      "required message definitely unsent",
+			as:        asyncSend{ctx: context.Background(), preSendErr: errors.New("build"), fatalIfUnsent: true},
+			want:      sendDefinitelyUnsent,
+			wantFatal: true,
+		},
+		{
+			name: "canceled before send",
+			as:   asyncSend{ctx: canceled, send: func() error { t.Fatal("send called with canceled context"); return nil }},
+			want: sendDefinitelyUnsent,
+		},
+		{
+			name:      "required message canceled before send",
+			as:        asyncSend{ctx: canceled, fatalIfUnsent: true, send: func() error { t.Fatal("send called with canceled context"); return nil }},
+			want:      sendDefinitelyUnsent,
+			wantFatal: true,
+		},
+		{
+			name:      "delivery ambiguous",
+			as:        asyncSend{ctx: context.Background(), send: func() error { return errors.New("write") }},
+			want:      sendDeliveryAmbiguous,
+			wantFatal: true,
+		},
+		{
+			name:  "shutdown abort",
+			as:    asyncSend{ctx: context.Background()},
+			want:  sendAbortedByShutdown,
+			abort: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			releases := 0
+			test.as.release = func() { releases++ }
+			var got sendOutcome
+			test.as.onSent = func(outcome sendOutcome) { got = outcome }
+
+			var err error
+			if test.abort {
+				test.as.Abort(errors.New("closed"))
+			} else {
+				err = test.as.Send()
+			}
+			if got.disposition != test.want || got.fatal != test.wantFatal {
+				t.Fatalf("outcome = %+v; want disposition %v, fatal %t", got, test.want, test.wantFatal)
+			}
+			if (err != nil) != test.wantFatal {
+				t.Fatalf("Send() error = %v; want fatal %t", err, test.wantFatal)
+			}
+			if releases != 1 {
+				t.Fatalf("release count = %d; want 1", releases)
+			}
+		})
+	}
+}
+
+type failingSendTransport struct {
+	mu           sync.Mutex
+	firstSend    chan struct{}
+	closed       chan struct{}
+	closeOnce    sync.Once
+	newMessages  int
+	closeCount   int
+	writeErr     error
+	firstRelease chan struct{}
+}
+
+func newFailingSendTransport(writeErr error) *failingSendTransport {
+	return &failingSendTransport{
+		firstSend:    make(chan struct{}),
+		closed:       make(chan struct{}),
+		writeErr:     writeErr,
+		firstRelease: make(chan struct{}),
+	}
+}
+
+func (t *failingSendTransport) NewMessage() (transport.OutgoingMessage, error) {
+	_, seg := capnp.NewMultiSegmentMessage(nil)
+	m, err := rpccp.NewRootMessage(seg)
+	if err != nil {
+		return nil, err
+	}
+
+	t.mu.Lock()
+	t.newMessages++
+	messageNumber := t.newMessages
+	t.mu.Unlock()
+
+	return &failingOutgoingMessage{
+		message: m,
+		send: func() error {
+			if messageNumber == 1 {
+				<-t.firstSend
+				return t.writeErr
+			}
+			return nil
+		},
+		onRelease: func() {
+			if messageNumber == 1 {
+				close(t.firstRelease)
+			}
+		},
+	}, nil
+}
+
+func (t *failingSendTransport) RecvMessage() (transport.IncomingMessage, error) {
+	<-t.closed
+	return nil, errors.New("transport closed")
+}
+
+func (t *failingSendTransport) Close() error {
+	t.closeOnce.Do(func() {
+		t.mu.Lock()
+		t.closeCount++
+		t.mu.Unlock()
+		close(t.closed)
+	})
+	return nil
+}
+
+type failingOutgoingMessage struct {
+	message   rpccp.Message
+	send      func() error
+	onRelease func()
+	once      sync.Once
+}
+
+func (m *failingOutgoingMessage) Message() rpccp.Message { return m.message }
+func (m *failingOutgoingMessage) Send() error            { return m.send() }
+func (m *failingOutgoingMessage) Release() {
+	m.once.Do(func() {
+		m.message.Message().Release()
+		if m.onRelease != nil {
+			m.onRelease()
+		}
+	})
+}
+
+type recordingLogger struct {
+	mu     sync.Mutex
+	errors []string
+}
+
+func (*recordingLogger) Debug(string, ...any) {}
+func (*recordingLogger) Info(string, ...any)  {}
+func (*recordingLogger) Warn(string, ...any)  {}
+func (l *recordingLogger) Error(message string, _ ...any) {
+	l.mu.Lock()
+	l.errors = append(l.errors, message)
+	l.mu.Unlock()
+}
+
+func TestSendFailureShutsDownAndDrainsQueue(t *testing.T) {
+	writeErr := errors.New("write failed")
+	tr := newFailingSendTransport(writeErr)
+	logger := new(recordingLogger)
+	c := NewConn(tr, &Options{Logger: logger})
+
+	var mu sync.Mutex
+	var outcomes [2][]sendOutcome
+	c.withLocked(func(c *lockedConn) {
+		for i := range outcomes {
+			i := i
+			c.sendMessageOutcome(context.Background(), func(m rpccp.Message) error {
+				_, err := m.NewUnimplemented()
+				return err
+			}, false, func(outcome sendOutcome) {
+				mu.Lock()
+				outcomes[i] = append(outcomes[i], outcome)
+				mu.Unlock()
+			})
+		}
+	})
+	close(tr.firstSend)
+
+	select {
+	case <-c.Done():
+	case <-time.After(2 * time.Second):
+		t.Fatal("connection did not shut down after fatal send failure")
+	}
+	select {
+	case <-tr.firstRelease:
+	default:
+		t.Fatal("failed outgoing message was not released")
+	}
+
+	mu.Lock()
+	gotOutcomes := outcomes
+	mu.Unlock()
+	if len(gotOutcomes[0]) != 1 || gotOutcomes[0][0].disposition != sendDeliveryAmbiguous || !gotOutcomes[0][0].fatal {
+		t.Fatalf("first outcomes = %+v; want one fatal delivery-ambiguous outcome", gotOutcomes[0])
+	}
+	if len(gotOutcomes[1]) != 1 || gotOutcomes[1][0].disposition != sendAbortedByShutdown || gotOutcomes[1][0].fatal {
+		t.Fatalf("queued outcomes = %+v; want one non-fatal shutdown-aborted outcome", gotOutcomes[1])
+	}
+
+	tr.mu.Lock()
+	closeCount := tr.closeCount
+	tr.mu.Unlock()
+	if closeCount != 1 {
+		t.Fatalf("transport close count = %d; want 1", closeCount)
+	}
+
+	logger.mu.Lock()
+	loggedErrors := append([]string(nil), logger.errors...)
+	logger.mu.Unlock()
+	if len(loggedErrors) != 1 || !strings.Contains(loggedErrors[0], writeErr.Error()) {
+		t.Fatalf("logged errors = %q; want one error containing %q", loggedErrors, writeErr)
+	}
+}


### PR DESCRIPTION
## Summary

- classify outbound RPC sends as successful, definitely unsent, delivery ambiguous, or aborted by shutdown
- report fatal send failures through the sender loop and existing connection supervisor
- avoid dereferencing a nil message when `NewMessage` returns `(nil, err)`
- preserve existing Promise behavior and Finish timing in this preparatory change

This is PR 1 of 3 for #626.

Stack: **this PR** → #631 → #632

## Test coverage

- full `go test ./...`
- full `go test -race ./...`
- 100-count targeted send-failure tests
- transport-level regression coverage for sender supervision, shutdown, queue draining, callback cardinality, and error classification

## Review

Independent concurrency-focused review found no remaining issues.

## Compatibility

No public API, schema, or wire-format changes.
