### PR TITLE
capnp: restore Promise pipeline admission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Go Cap'n Proto Release Notes
 
+## Unreleased
+
+- Clarify that a `PipelineCaller` or `Resolver` used by `capnp.NewPromise`
+  must not synchronously resolve, or wait for resolution of, that same
+  `Promise`. Promise resolution waits for already-admitted pipelined calls to
+  yield before publishing the result.
+
 ## 2.17.0
 
 - Add `capnp.Canonicalize` function that implements the

--- a/answer.go
+++ b/answer.go
@@ -48,6 +48,11 @@ type promiseState struct {
 	// the promise leaves the unresolved state.
 	caller PipelineCaller
 
+	// ongoingCalls counts calls admitted to caller that have not yet yielded.
+	ongoingCalls int
+	// callsStopped is installed during pending resolution when ongoingCalls > 0.
+	callsStopped chan struct{}
+
 	// clients is a table of promised clients created to proxy the eventual
 	// result's clients.  Even after resolution, this table may still have
 	// entries until the clients are released. Cannot be read or written
@@ -67,7 +72,11 @@ type clientAndPromise struct {
 
 // NewPromise creates a new unresolved promise.  The PipelineCaller will
 // be used to make pipelined calls before the promise resolves. If resolver
-// is not nil,  calls to Fulfill will be forwarded to it.
+// is not nil, calls to Fulfill and Reject will be forwarded to it.
+//
+// PipelineCaller and Resolver implementations must not synchronously resolve
+// this Promise, or wait for this Promise to resolve, from a callback made by
+// the Promise itself. Doing so creates a dependency cycle.
 func NewPromise(m Method, pc PipelineCaller, resolver Resolver[Ptr]) *Promise {
 	if pc == nil {
 		panic("NewPromise(nil)")
@@ -147,6 +156,7 @@ func (p *Promise) Resolve(r Ptr, e error) {
 	// It's ok to extract p.clients and use it while not holding the lock:
 	// it may not be accessed in the pending resolution state, so we have
 	// exclusive access to the variable anyway.
+	var callsStopped <-chan struct{}
 	clients := mutex.With1(&p.state, func(p *promiseState) map[clientPath]*clientAndPromise {
 		if e != nil {
 			p.requireUnresolved("Reject")
@@ -154,6 +164,10 @@ func (p *Promise) Resolve(r Ptr, e error) {
 			p.requireUnresolved("Fulfill")
 		}
 		p.caller = nil
+		if p.ongoingCalls > 0 {
+			p.callsStopped = make(chan struct{})
+			callsStopped = p.callsStopped
+		}
 		return p.clients
 	})
 
@@ -172,6 +186,9 @@ func (p *Promise) Resolve(r Ptr, e error) {
 		t := path.transform()
 		cp.promise.fulfill(dq, res.client(t))
 		cp.promise = nil
+	}
+	if callsStopped != nil {
+		<-callsStopped
 	}
 
 	p.state.With(func(p *promiseState) {
@@ -322,7 +339,9 @@ func (ans *Answer) PipelineSend(ctx context.Context, transform []PipelineOp, s S
 	switch {
 	case l.Value().isUnresolved():
 		caller := l.Value().caller
+		l.Value().ongoingCalls++
 		l.Unlock()
+		defer p.pipelineCallDone()
 		return caller.PipelineSend(ctx, transform, s)
 	case l.Value().isPendingResolution():
 		// Block new calls until resolved.
@@ -350,7 +369,9 @@ func (ans *Answer) PipelineRecv(ctx context.Context, transform []PipelineOp, r R
 	switch {
 	case l.Value().isUnresolved():
 		caller := l.Value().caller
+		l.Value().ongoingCalls++
 		l.Unlock()
+		defer p.pipelineCallDone()
 		return caller.PipelineRecv(ctx, transform, r)
 	case l.Value().isPendingResolution():
 		// Block new calls until resolved.
@@ -370,6 +391,16 @@ func (ans *Answer) PipelineRecv(ctx context.Context, transform []PipelineOp, r R
 	default:
 		panic("unreachable")
 	}
+}
+
+func (p *Promise) pipelineCallDone() {
+	p.state.With(func(s *promiseState) {
+		s.ongoingCalls--
+		if s.ongoingCalls == 0 && s.callsStopped != nil {
+			close(s.callsStopped)
+			s.callsStopped = nil
+		}
+	})
 }
 
 // A Future accesses a portion of an Answer.  It is safe to use from

--- a/answer_admission_test.go
+++ b/answer_admission_test.go
@@ -1,0 +1,190 @@
+package capnp
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+)
+
+type blockingPipelineCaller struct {
+	admitted      chan struct{}
+	release       <-chan struct{}
+	panicOnReturn bool
+}
+
+func (c *blockingPipelineCaller) wait() {
+	c.admitted <- struct{}{}
+	<-c.release
+	if c.panicOnReturn {
+		panic("pipeline caller panic")
+	}
+}
+
+func (c *blockingPipelineCaller) PipelineSend(context.Context, []PipelineOp, Send) (*Answer, ReleaseFunc) {
+	c.wait()
+	return ErrorAnswer(Method{}, errors.New("test call")), func() {}
+}
+
+func (c *blockingPipelineCaller) PipelineRecv(context.Context, []PipelineOp, Recv) PipelineCaller {
+	c.wait()
+	return nil
+}
+
+type signalingPtrResolver struct {
+	called  chan struct{}
+	release <-chan struct{}
+}
+
+func (r signalingPtrResolver) signal() {
+	close(r.called)
+	if r.release != nil {
+		<-r.release
+	}
+}
+
+func (r signalingPtrResolver) Fulfill(Ptr)  { r.signal() }
+func (r signalingPtrResolver) Reject(error) { r.signal() }
+
+func TestPromiseResolutionDrainsAdmittedCalls(t *testing.T) {
+	for _, recv := range []bool{false, true} {
+		name := "send"
+		if recv {
+			name = "recv"
+		}
+		t.Run(name, func(t *testing.T) {
+			const callCount = 64
+			admitted := make(chan struct{}, callCount)
+			release := make(chan struct{})
+			resolverCalled := make(chan struct{})
+			resolverRelease := make(chan struct{})
+			p := NewPromise(Method{}, &blockingPipelineCaller{
+				admitted: admitted,
+				release:  release,
+			}, signalingPtrResolver{called: resolverCalled, release: resolverRelease})
+
+			// Materialize a promised client so the test also verifies that
+			// promised clients resolve before admission drain blocks Resolve.
+			promisedClient := p.Answer().Field(0, nil).Client()
+			clientResolved := make(chan struct{})
+			go func() {
+				_ = promisedClient.Resolve(context.Background())
+				close(clientResolved)
+			}()
+
+			var calls sync.WaitGroup
+			calls.Add(callCount)
+			for i := 0; i < callCount; i++ {
+				go func() {
+					defer calls.Done()
+					if recv {
+						p.Answer().PipelineRecv(context.Background(), nil, Recv{})
+						return
+					}
+					_, release := p.Answer().PipelineSend(context.Background(), nil, Send{Method: Method{}})
+					release()
+				}()
+			}
+			for i := 0; i < callCount; i++ {
+				<-admitted
+			}
+
+			msg, seg := NewSingleSegmentMessage(nil)
+			defer msg.Release()
+			result, err := NewStruct(seg, ObjectSize{PointerCount: 1})
+			if err != nil {
+				t.Fatal(err)
+			}
+			client := ErrorClient(errors.New("resolved client"))
+			if err := result.SetPtr(0, NewInterface(seg, msg.CapTable().Add(client)).ToPtr()); err != nil {
+				t.Fatal(err)
+			}
+
+			resolveReturned := make(chan struct{})
+			go func() {
+				p.Resolve(result.ToPtr(), nil)
+				close(resolveReturned)
+			}()
+
+			<-resolverCalled
+			select {
+			case <-clientResolved:
+				t.Fatal("promised client resolved before Resolver returned")
+			default:
+			}
+			close(resolverRelease)
+			<-clientResolved
+			select {
+			case <-p.Answer().Done():
+				t.Fatal("result published before admitted calls yielded")
+			default:
+			}
+			select {
+			case <-resolveReturned:
+				t.Fatal("Resolve returned before admitted calls yielded")
+			default:
+			}
+			lateCtx, cancelLateCall := context.WithCancel(context.Background())
+			lateCallReturned := make(chan error, 1)
+			go func() {
+				ans, release := p.Answer().PipelineSend(lateCtx, nil, Send{Method: Method{}})
+				_, err := ans.Struct()
+				release()
+				lateCallReturned <- err
+			}()
+			cancelLateCall()
+			if err := <-lateCallReturned; !errors.Is(err, context.Canceled) {
+				t.Fatalf("call arriving during admission drain returned %v; want context.Canceled", err)
+			}
+			select {
+			case <-admitted:
+				t.Fatal("call admitted to old PipelineCaller after resolution began")
+			default:
+			}
+
+			close(release)
+			calls.Wait()
+			<-resolveReturned
+			<-p.Answer().Done()
+			ans, releaseCall := p.Answer().PipelineSend(context.Background(), nil, Send{Method: Method{}})
+			_, _ = ans.Struct()
+			releaseCall()
+			select {
+			case <-admitted:
+				t.Fatal("call admitted to old PipelineCaller after result publication")
+			default:
+			}
+			p.ReleaseClients()
+		})
+	}
+}
+
+func TestPromiseAdmissionReleasedWhenPipelineCallerPanics(t *testing.T) {
+	admitted := make(chan struct{}, 1)
+	release := make(chan struct{})
+	resolverCalled := make(chan struct{})
+	p := NewPromise(Method{}, &blockingPipelineCaller{
+		admitted:      admitted,
+		release:       release,
+		panicOnReturn: true,
+	}, signalingPtrResolver{called: resolverCalled})
+
+	panicked := make(chan struct{})
+	go func() {
+		defer close(panicked)
+		defer func() { _ = recover() }()
+		p.Answer().PipelineSend(context.Background(), nil, Send{Method: Method{}})
+	}()
+	<-admitted
+
+	resolveReturned := make(chan struct{})
+	go func() {
+		p.Resolve(Ptr{}, nil)
+		close(resolveReturned)
+	}()
+	<-resolverCalled
+	close(release)
+	<-panicked
+	<-resolveReturned
+	p.ReleaseClients()
+}

--- a/rpc/answer.go
+++ b/rpc/answer.go
@@ -220,12 +220,47 @@ func (ans *ansReturner) Return() {
 	dq := &deferred.Queue{}
 	defer dq.Run()
 	pcallsWait := func() {}
+	var owner *ansent
+	var promise *capnp.Promise
+	var promiseResult capnp.Ptr
+	var promiseErr error
 
 	var err error
 	ans.c.withLocked(func(c *lockedConn) {
 		ent, _ := c.lk.answers.Find(ans.id)
+		owner = ent
 		pcallsWait = ent.pcalls.Wait
 
+		// Claim completion before resolving the promise. Promise resolution can
+		// wait for admitted pipeline calls, so it must not run under Conn.lk.
+		// A concurrent Finish may mark this answer, but cannot destroy it until
+		// returnSent is set in the second critical section below.
+		ent.pcall = nil
+		ent.flags |= resultsReady
+		if ent.promise != nil && (ent.err != nil || ent.sendMsg != nil) {
+			promise = ent.promise
+			ent.promise = nil
+			switch {
+			case ent.err != nil:
+				promiseErr = ent.err
+			case ent.flags.Contains(finishReceived):
+				promiseErr = rpcerr.Failed(errors.New("received finish before return"))
+			default:
+				promiseResult, promiseErr = ent.returner.results.Content()
+			}
+		}
+	})
+
+	if promise != nil {
+		promise.Resolve(promiseResult, promiseErr)
+		promise.ReleaseClients()
+	}
+
+	ans.c.withLocked(func(c *lockedConn) {
+		ent, ok := c.lk.answers.Find(ans.id)
+		if !ok || ent != owner {
+			panic("rpc: answer completion lost ownership")
+		}
 		if ent.err == nil {
 			err = ent.completeSendReturn(dq)
 		} else {

--- a/rpc/answer_lock_test.go
+++ b/rpc/answer_lock_test.go
@@ -1,0 +1,229 @@
+package rpc
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"capnproto.org/go/capnp/v3"
+	transportpkg "capnproto.org/go/capnp/v3/rpc/transport"
+)
+
+type blockingServerPipelineCaller struct {
+	admitted chan struct{}
+	release  <-chan struct{}
+}
+
+func (c *blockingServerPipelineCaller) PipelineSend(context.Context, []capnp.PipelineOp, capnp.Send) (*capnp.Answer, capnp.ReleaseFunc) {
+	close(c.admitted)
+	<-c.release
+	return capnp.ErrorAnswer(capnp.Method{}, errors.New("test call")), func() {}
+}
+
+func (c *blockingServerPipelineCaller) PipelineRecv(context.Context, []capnp.PipelineOp, capnp.Recv) capnp.PipelineCaller {
+	close(c.admitted)
+	<-c.release
+	return nil
+}
+
+type signalingRPCPtrResolver struct{ result chan<- error }
+
+func (r signalingRPCPtrResolver) Fulfill(capnp.Ptr) { r.result <- nil }
+func (r signalingRPCPtrResolver) Reject(err error)  { r.result <- err }
+
+type blockedServerAnswer struct {
+	conn           *Conn
+	peer           Transport
+	ans            *ansent
+	release        chan struct{}
+	callReturned   chan struct{}
+	resolverResult chan error
+	finishObserved chan struct{}
+}
+
+func newBlockedServerAnswer(t *testing.T) *blockedServerAnswer {
+	t.Helper()
+	left, right := transportpkg.NewPipe(4)
+	f := &blockedServerAnswer{
+		conn:           NewConn(NewTransport(left), nil),
+		peer:           NewTransport(right),
+		release:        make(chan struct{}),
+		callReturned:   make(chan struct{}),
+		resolverResult: make(chan error, 1),
+		finishObserved: make(chan struct{}),
+	}
+	t.Cleanup(func() {
+		_ = f.conn.Close()
+		_ = f.peer.Close()
+	})
+
+	admitted := make(chan struct{})
+	caller := &blockingServerPipelineCaller{admitted: admitted, release: f.release}
+	f.conn.withLocked(func(c *lockedConn) {
+		ret, send, releaser, err := f.conn.newReturn()
+		if err != nil {
+			t.Fatal(err)
+		}
+		f.ans = &ansent{
+			returner: ansReturner{c: f.conn, id: 0, ret: ret, msgReleaser: releaser},
+			pcall:    caller,
+			sendMsg:  send,
+			cancel:   func() { close(f.finishObserved) },
+		}
+		f.ans.promise = capnp.NewPromise(capnp.Method{}, caller, signalingRPCPtrResolver{result: f.resolverResult})
+		if !c.lk.answers.Create(0, f.ans) {
+			t.Fatal("answer ID already present")
+		}
+		f.conn.tasks.Add(1)
+	})
+	go func() {
+		defer close(f.callReturned)
+		_, _ = f.ans.promise.Answer().PipelineSend(context.Background(), nil, capnp.Send{Method: capnp.Method{}})
+	}()
+	<-admitted
+	return f
+}
+
+func (f *blockedServerAnswer) startReturn(returnErr error) <-chan struct{} {
+	f.ans.returner.PrepareReturn(returnErr)
+	completed := make(chan struct{})
+	go func() {
+		f.ans.returner.Return()
+		close(completed)
+	}()
+	return completed
+}
+
+func sendFinish(t *testing.T, peer Transport) {
+	t.Helper()
+	out, err := peer.NewMessage()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer out.Release()
+	finish, err := out.Message().NewFinish()
+	if err != nil {
+		t.Fatal(err)
+	}
+	finish.SetQuestionId(0)
+	if err := out.Send(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestServerAnswerResolvesPromiseOutsideConnLock(t *testing.T) {
+	t.Run("fulfill", func(t *testing.T) {
+		testServerAnswerResolvesPromiseOutsideConnLock(t, nil)
+	})
+	t.Run("reject", func(t *testing.T) {
+		testServerAnswerResolvesPromiseOutsideConnLock(t, errors.New("return failed"))
+	})
+}
+
+func testServerAnswerResolvesPromiseOutsideConnLock(t *testing.T, returnErr error) {
+	f := newBlockedServerAnswer(t)
+	returnCompleted := f.startReturn(returnErr)
+	resolvedErr := <-f.resolverResult
+	if returnErr == nil && resolvedErr != nil {
+		t.Fatalf("Promise resolver rejected successful Return: %v", resolvedErr)
+	}
+	if returnErr != nil && !errors.Is(resolvedErr, returnErr) {
+		t.Fatalf("Promise resolver error = %v; want %v", resolvedErr, returnErr)
+	}
+
+	lockObserved := make(chan struct{})
+	go func() {
+		f.conn.withLocked(func(c *lockedConn) {
+			got, ok := c.lk.answers.Find(0)
+			if !ok || got != f.ans || !got.flags.Contains(resultsReady) || got.promise != nil {
+				t.Error("answer did not retain completion ownership while resolving its promise")
+			}
+		})
+		close(lockObserved)
+	}()
+	select {
+	case <-lockObserved:
+	case <-time.After(time.Second):
+		t.Fatal("Conn.lk held while Promise resolution drained admitted calls")
+	}
+	select {
+	case <-returnCompleted:
+		t.Fatal("Return completed before admitted pipeline call yielded")
+	default:
+	}
+
+	close(f.release)
+	<-f.callReturned
+	<-returnCompleted
+}
+
+func TestServerAnswerFinishDuringPromiseDrain(t *testing.T) {
+	for _, timing := range []string{"before claim", "after claim"} {
+		t.Run(timing, func(t *testing.T) {
+			f := newBlockedServerAnswer(t)
+			if timing == "before claim" {
+				sendFinish(t, f.peer)
+				<-f.finishObserved
+			}
+
+			returnCompleted := f.startReturn(nil)
+			resolvedErr := <-f.resolverResult
+			if timing == "before claim" {
+				if resolvedErr == nil {
+					t.Fatal("Promise fulfilled after Finish won race; want rejection")
+				}
+			} else {
+				if resolvedErr != nil {
+					t.Fatalf("Promise rejected after Return claimed completion: %v", resolvedErr)
+				}
+				sendFinish(t, f.peer)
+				<-f.finishObserved
+			}
+
+			f.conn.withLocked(func(c *lockedConn) {
+				got, ok := c.lk.answers.Find(0)
+				if !ok || got != f.ans || got.flags.Contains(returnSent) || !got.flags.Contains(finishReceived) {
+					t.Error("Finish destroyed or corrupted answer before Return completed")
+				}
+			})
+			close(f.release)
+			<-f.callReturned
+			<-returnCompleted
+			f.conn.withLocked(func(c *lockedConn) {
+				if _, ok := c.lk.answers.Find(0); ok {
+					t.Error("answer retained after Return and Finish completed")
+				}
+			})
+		})
+	}
+}
+
+func TestServerAnswerShutdownWaitsForPromiseDrain(t *testing.T) {
+	f := newBlockedServerAnswer(t)
+	returnCompleted := f.startReturn(nil)
+	if err := <-f.resolverResult; err != nil {
+		t.Fatalf("Promise resolver error = %v; want nil", err)
+	}
+
+	closeReturned := make(chan error, 1)
+	go func() { closeReturned <- f.conn.Close() }()
+	<-f.conn.bgctx.Done()
+	select {
+	case <-returnCompleted:
+		t.Fatal("Return completed before admitted pipeline call yielded")
+	default:
+	}
+	select {
+	case err := <-closeReturned:
+		t.Fatalf("Close returned before Return released completion ownership: %v", err)
+	default:
+	}
+
+	close(f.release)
+	<-f.callReturned
+	<-returnCompleted
+	if err := <-closeReturned; err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
## Summary

- restore documented admitted-call accounting in `capnp.Promise`
- resolve in the order resolver, promised clients, admission drain, then result publication
- move server-answer Promise resolution outside `Conn.lk` with explicit completion ownership
- retain the existing 250 ms Finish workaround for the lifecycle PR
- clarify in the release notes that a caller or resolver must not synchronously resolve or wait on its own Promise

This is PR 2 of 3 for #626 and is stacked on #630.

Stack: #630 → **this PR** → #632

## Test coverage

- full `go test ./...`
- full `go test -race ./...`
- 100-count targeted admission, ordering, rejection, Finish-race, and shutdown tests

## Review

Independent concurrency-focused review found no remaining issues after strengthening resolver-ordering and real Finish-race coverage.

## Compatibility

No public API, schema, or wire-format changes.
