### PR TITLE
rpc: make question completion deterministic

### DIFF
--- a/rpc/question.go
+++ b/rpc/question.go
@@ -18,41 +18,53 @@ type question struct {
 	p       *capnp.Promise
 	release capnp.ReleaseFunc // written before resolving p
 
-	// Protected by c.mu:
-
-	flags         questionFlags
-	finishMsgSend chan struct{}        // closed after attempting to send the Finish message
-	called        [][]capnp.PipelineOp // paths to called clients
+	// Protected by c.lk:
+	owner          questionTerminalOwner
+	callSend       questionCallSendState
+	callSendDone   chan struct{}
+	callSendErr    error
+	drainComplete  bool
+	drainDone      chan struct{}
+	returnReceived bool
+	noFinishNeeded bool
+	finish         questionFinishState
+	called         [][]capnp.PipelineOp // paths to called clients
 }
 
-// questionFlags is a bitmask of which events have occurred in a question's
-// lifetime.
-type questionFlags uint8
+type questionTerminalOwner uint8
 
 const (
-	// finished is set when the question's Context has been canceled or
-	// its Return message has been received.  The codepath that sets this
-	// flag is responsible for sending the Finish message.
-	finished questionFlags = 1 << iota
-
-	// finishSent indicates whether the Finish message was sent
-	// successfully.  It is only valid to query after finishMsgSend is
-	// closed.
-	finishSent
+	questionOwnerNone questionTerminalOwner = iota
+	questionOwnerReturn
+	questionOwnerCancel
+	questionOwnerSendFailure
 )
 
-// flags.Contains(flag) Returns true iff flags contains flag, which must
-// be a single flag.
-func (flags questionFlags) Contains(flag questionFlags) bool {
-	return flags&flag != 0
-}
+type questionFinishState uint8
+
+const (
+	questionFinishNotQueued questionFinishState = iota
+	questionFinishQueued
+	questionFinishSent
+	questionFinishFailed
+	questionFinishSuppressed
+)
+
+type questionCallSendState uint8
+
+const (
+	questionCallSendPending questionCallSendState = iota
+	questionCallSendSucceeded
+	questionCallSendFailed
+)
 
 // newQuestion adds a new question to c's table.
 func (c *lockedConn) newQuestion(method capnp.Method) *question {
 	q := &question{
-		c:             (*Conn)(c),
-		release:       func() {},
-		finishMsgSend: make(chan struct{}),
+		c:            (*Conn)(c),
+		release:      func() {},
+		callSendDone: make(chan struct{}),
+		drainDone:    make(chan struct{}),
 	}
 	q.id = c.lk.questions.Add(q)
 	q.p = capnp.NewPromise(method, q, nil) // TODO(someday): customize error message for bootstrap
@@ -97,36 +109,155 @@ func (q *question) handleCancel(ctx context.Context) {
 		return
 	}
 
+	claimed := false
 	q.c.withLocked(func(c *lockedConn) {
-		// Promise already fulfilled?
-		if q.flags.Contains(finished) {
+		if q.owner == questionOwnerNone {
+			q.owner = questionOwnerCancel
+			q.release = func() {}
+			claimed = true
+		}
+	})
+	if !claimed {
+		return
+	}
+
+	// Reject drains every pipeline call that selected q before cancellation
+	// claimed terminal ownership. No Finish may be queued before it returns.
+	q.p.Reject(rejectErr)
+	q.c.withLocked(func(c *lockedConn) {
+		q.drainComplete = true
+		q.queueFinish(c, true)
+		q.signalDrainDone()
+	})
+}
+
+func (q *question) signalDrainDone() {
+	if q.drainDone != nil {
+		close(q.drainDone)
+	}
+}
+
+// handleCallSend completes the initial Call send. The caller MUST NOT hold
+// q.c.lk; it is invoked by the sender loop.
+func (q *question) handleCallSend(ctx context.Context, outcome sendOutcome, annotation string) {
+	var callErr error
+	if outcome.err != nil {
+		callErr = rpcerr.Annotate(outcome.err, annotation)
+	} else if outcome.disposition != sendSucceeded {
+		callErr = ExcClosed
+	}
+	q.c.withLocked(func(c *lockedConn) {
+		if q.callSend != questionCallSendPending {
 			return
 		}
-		q.flags |= finished
-		q.release = func() {}
+		if outcome.disposition == sendSucceeded {
+			q.callSend = questionCallSendSucceeded
+		} else {
+			q.callSend = questionCallSendFailed
+			q.callSendErr = callErr
+		}
+		close(q.callSendDone)
+	})
 
-		c.sendMessage(c.bgctx, func(m rpccp.Message) error {
-			fin, err := m.NewFinish()
-			if err != nil {
-				return err
+	switch outcome.disposition {
+	case sendSucceeded:
+		startCancel := false
+		q.c.withLocked(func(c *lockedConn) {
+			if q.owner == questionOwnerNone {
+				startCancel = c.startTask()
 			}
+		})
+		if startCancel {
+			go func() {
+				defer q.c.tasks.Done()
+				q.handleCancel(ctx)
+			}()
+		}
+
+	case sendDefinitelyUnsent:
+		reject := false
+		q.c.withLocked(func(c *lockedConn) {
+			if current, ok := c.lk.questions.Find(q.id); ok && current == q && q.owner == questionOwnerNone {
+				q.owner = questionOwnerSendFailure
+				reject = true
+			}
+		})
+		if reject {
+			// callSendDone wakes admitted old-route calls. They must yield
+			// without enqueueing before rejection completes and the ID is freed.
+			q.p.Reject(callErr)
+			q.c.withLocked(func(c *lockedConn) {
+				if current, ok := c.lk.questions.Find(q.id); ok && current == q {
+					c.lk.questions.Remove(q.id)
+				}
+			})
+		}
+
+	case sendDeliveryAmbiguous:
+		reject := false
+		q.c.withLocked(func(c *lockedConn) {
+			if current, ok := c.lk.questions.Find(q.id); ok && current == q && q.owner == questionOwnerNone {
+				q.owner = questionOwnerSendFailure
+				reject = true
+			}
+		})
+		if reject {
+			q.p.Reject(callErr)
+		}
+
+	case sendAbortedByShutdown:
+		// callSendDone was closed above so admitted pipeline calls can yield;
+		// shutdown owns Promise rejection and table cleanup.
+	}
+}
+
+// queueFinish queues the question's single terminal Finish after Promise
+// admission has drained. The caller MUST hold q.c.lk.
+func (q *question) queueFinish(c *lockedConn, releaseResultCaps bool) {
+	if !q.drainComplete || q.finish != questionFinishNotQueued {
+		return
+	}
+	if c.lk.closing {
+		q.finish = questionFinishFailed
+		return
+	}
+	q.finish = questionFinishQueued
+	c.sendMessageOutcome(c.bgctx, func(m rpccp.Message) error {
+		fin, err := m.NewFinish()
+		if err == nil {
 			fin.SetQuestionId(uint32(q.id))
-			fin.SetReleaseResultCaps(true)
-			return nil
-		}, func(err error) {
-			if err == nil {
-				syncutil.With(&q.c.lk, func() { q.flags |= finishSent })
-			} else if q.c.bgctx.Err() == nil && !isFatalSendError(err) {
-				q.c.er.ReportError(rpcerr.Annotate(err, "send finish"))
+			fin.SetReleaseResultCaps(releaseResultCaps)
+		}
+		return err
+	}, true, func(outcome sendOutcome) {
+		q.c.withLocked(func(c *lockedConn) {
+			if q.finish != questionFinishQueued {
+				return
 			}
-			close(q.finishMsgSend)
-			q.p.Reject(rejectErr)
+			if outcome.disposition == sendSucceeded {
+				q.finish = questionFinishSent
+				if q.returnReceived {
+					c.lk.questions.release(q.id)
+				}
+			} else {
+				q.finish = questionFinishFailed
+			}
 		})
 	})
 }
 
 func (q *question) PipelineSend(ctx context.Context, transform []capnp.PipelineOp, s capnp.Send) (*capnp.Answer, capnp.ReleaseFunc) {
+	select {
+	case <-q.callSendDone:
+	case <-ctx.Done():
+		return capnp.ErrorAnswer(s.Method, ctx.Err()), func() {}
+	case <-q.c.bgctx.Done():
+		return capnp.ErrorAnswer(s.Method, ExcClosed), func() {}
+	}
 	return withLockedConn2(q.c, func(c *lockedConn) (*capnp.Answer, capnp.ReleaseFunc) {
+		if q.callSend != questionCallSendSucceeded {
+			return capnp.ErrorAnswer(s.Method, q.callSendErr), func() {}
+		}
 		// Mark this transform as having been used for a call ASAP.
 		// q's Return could be received while q2 is being sent.
 		// Don't bother cleaning it up if the call fails because:
@@ -167,21 +298,9 @@ func (c *lockedConn) startCall(ctx context.Context, s capnp.Send, preflight func
 	}
 
 	q := c.newQuestion(s.Method)
-	c.sendMessage(ctx, func(m rpccp.Message) error {
+	c.sendMessageOutcome(ctx, func(m rpccp.Message) error {
 		return c.newCallMessage(m, q.id, s, populateTarget)
-	}, func(err error) {
-		if err != nil {
-			syncutil.With(&q.c.lk, func() { q.c.lk.questions.Remove(q.id) })
-			q.p.Reject(rpcerr.WrapFailed("send message", err))
-			return
-		}
-
-		q.c.tasks.Add(1)
-		go func() {
-			defer q.c.tasks.Done()
-			q.handleCancel(ctx)
-		}()
-	})
+	}, false, func(outcome sendOutcome) { q.handleCallSend(ctx, outcome, "send message") })
 
 	ans := q.p.Answer()
 	return ans, func() {

--- a/rpc/question_lifecycle_test.go
+++ b/rpc/question_lifecycle_test.go
@@ -1,0 +1,696 @@
+package rpc
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"capnproto.org/go/capnp/v3"
+	"capnproto.org/go/capnp/v3/exp/spsc"
+	transportpkg "capnproto.org/go/capnp/v3/rpc/transport"
+	rpccp "capnproto.org/go/capnp/v3/std/capnp/rpc"
+)
+
+type gatedQuestionCaller struct {
+	inner    *question
+	admitted chan struct{}
+	release  <-chan struct{}
+}
+
+func (g *gatedQuestionCaller) PipelineSend(ctx context.Context, transform []capnp.PipelineOp, s capnp.Send) (*capnp.Answer, capnp.ReleaseFunc) {
+	g.admitted <- struct{}{}
+	<-g.release
+	return g.inner.PipelineSend(ctx, transform, s)
+}
+
+func (g *gatedQuestionCaller) PipelineRecv(ctx context.Context, transform []capnp.PipelineOp, r capnp.Recv) capnp.PipelineCaller {
+	g.admitted <- struct{}{}
+	<-g.release
+	return g.inner.PipelineRecv(ctx, transform, r)
+}
+
+type lifecycleResolver struct{ result chan<- error }
+
+func (r lifecycleResolver) Fulfill(capnp.Ptr) { r.result <- nil }
+func (r lifecycleResolver) Reject(err error)  { r.result <- err }
+
+type questionLifecycleFixture struct {
+	conn           *Conn
+	peer           Transport
+	q              *question
+	ans            *capnp.Answer
+	admitted       chan struct{}
+	gate           chan struct{}
+	gateOnce       sync.Once
+	resolverResult chan error
+}
+
+type countingIncomingMessage struct {
+	message  rpccp.Message
+	releases int32
+	once     sync.Once
+}
+
+func (m *countingIncomingMessage) Message() rpccp.Message { return m.message }
+func (m *countingIncomingMessage) Release() {
+	atomic.AddInt32(&m.releases, 1)
+	m.once.Do(func() { m.message.Message().Release() })
+}
+
+func newQuestionReturnMessage(t *testing.T, noFinishNeeded, withCapability bool) *countingIncomingMessage {
+	t.Helper()
+	_, seg := capnp.NewSingleSegmentMessage(nil)
+	message, err := rpccp.NewRootMessage(seg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ret, err := message.NewReturn()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ret.SetAnswerId(0)
+	ret.SetNoFinishNeeded(noFinishNeeded)
+	results, err := ret.NewResults()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if withCapability {
+		caps, err := results.NewCapTable(1)
+		if err != nil {
+			t.Fatal(err)
+		}
+		caps.At(0).SetSenderHosted(7)
+		if err := results.SetContent(capnp.NewInterface(results.Segment(), 0).ToPtr()); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return &countingIncomingMessage{message: message}
+}
+
+func newQuestionLifecycleFixture(t *testing.T) *questionLifecycleFixture {
+	t.Helper()
+	left, right := transportpkg.NewPipe(16)
+	f := &questionLifecycleFixture{
+		conn:           NewConn(NewTransport(left), nil),
+		peer:           NewTransport(right),
+		admitted:       make(chan struct{}, 1),
+		gate:           make(chan struct{}),
+		resolverResult: make(chan error, 1),
+	}
+	f.conn.withLocked(func(c *lockedConn) {
+		callSendDone := make(chan struct{})
+		close(callSendDone)
+		f.q = &question{
+			c:            f.conn,
+			release:      func() {},
+			callSend:     questionCallSendSucceeded,
+			callSendDone: callSendDone,
+			drainDone:    make(chan struct{}),
+		}
+		f.q.id = c.lk.questions.Add(f.q)
+		gate := &gatedQuestionCaller{inner: f.q, admitted: f.admitted, release: f.gate}
+		f.q.p = capnp.NewPromise(capnp.Method{}, gate, lifecycleResolver{result: f.resolverResult})
+		c.setAnswerQuestion(f.q.p.Answer(), f.q)
+		f.ans = f.q.p.Answer()
+	})
+	t.Cleanup(func() {
+		f.releaseGate()
+		_ = f.conn.Close()
+		f.q.p.ReleaseClients()
+		f.q.release()
+		_ = f.peer.Close()
+	})
+	return f
+}
+
+func (f *questionLifecycleFixture) releaseGate() {
+	f.gateOnce.Do(func() { close(f.gate) })
+}
+
+func (f *questionLifecycleFixture) startAdmittedCall() <-chan struct{} {
+	returned := make(chan struct{})
+	go func() {
+		defer close(returned)
+		_, _ = f.ans.PipelineSend(context.Background(), nil, capnp.Send{Method: capnp.Method{}})
+	}()
+	<-f.admitted
+	return returned
+}
+
+func sendQuestionReturn(t *testing.T, peer Transport, noFinishNeeded, withCapability bool) {
+	t.Helper()
+	out, err := peer.NewMessage()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer out.Release()
+	ret, err := out.Message().NewReturn()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ret.SetAnswerId(0)
+	ret.SetNoFinishNeeded(noFinishNeeded)
+	results, err := ret.NewResults()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if withCapability {
+		caps, err := results.NewCapTable(1)
+		if err != nil {
+			t.Fatal(err)
+		}
+		caps.At(0).SetSenderHosted(7)
+		if err := results.SetContent(capnp.NewInterface(results.Segment(), 0).ToPtr()); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := out.Send(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func sendBootstrapMarker(t *testing.T, peer Transport, id uint32) {
+	t.Helper()
+	out, err := peer.NewMessage()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer out.Release()
+	bootstrap, err := out.Message().NewBootstrap()
+	if err != nil {
+		t.Fatal(err)
+	}
+	bootstrap.SetQuestionId(id)
+	if err := out.Send(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func recvPeerMessage(t *testing.T, peer Transport) transportpkg.IncomingMessage {
+	t.Helper()
+	type result struct {
+		in  transportpkg.IncomingMessage
+		err error
+	}
+	resultCh := make(chan result, 1)
+	go func() {
+		in, err := peer.RecvMessage()
+		resultCh <- result{in: in, err: err}
+	}()
+	select {
+	case result := <-resultCh:
+		if result.err != nil {
+			t.Fatal(result.err)
+		}
+		return result.in
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for peer message")
+		return nil
+	}
+}
+
+func assertQuestionIDReusable(t *testing.T, conn *Conn, want questionID) {
+	t.Helper()
+	conn.withLocked(func(c *lockedConn) {
+		id := c.lk.questions.Add(nil)
+		if id != want {
+			t.Errorf("next question ID = %d; want %d", id, want)
+		}
+		c.lk.questions.Remove(id)
+	})
+}
+
+func TestQuestionReturnDrainsAdmittedCallBeforeFinish(t *testing.T) {
+	f := newQuestionLifecycleFixture(t)
+	const callCount = 4
+	callReturned := make([]<-chan struct{}, callCount)
+	for i := range callReturned {
+		callReturned[i] = f.startAdmittedCall()
+	}
+	incoming := newQuestionReturnMessage(t, false, false)
+	if err := f.conn.handleReturn(f.conn.bgctx, incoming); err != nil {
+		t.Fatal(err)
+	}
+	if err := <-f.resolverResult; err != nil {
+		t.Fatalf("Promise resolver error = %v; want nil", err)
+	}
+	f.conn.withLocked(func(c *lockedConn) {
+		if f.q.owner != questionOwnerReturn || f.q.drainComplete || f.q.finish != questionFinishNotQueued {
+			t.Errorf("question advanced before admitted call yielded: %+v", *f.q)
+		}
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	f.q.handleCancel(ctx)
+	f.conn.withLocked(func(c *lockedConn) {
+		if f.q.owner != questionOwnerReturn {
+			t.Errorf("cancellation stole terminal ownership after Return: owner %d", f.q.owner)
+		}
+	})
+
+	f.releaseGate()
+	for _, returned := range callReturned {
+		<-returned
+	}
+	for i := 0; i < callCount; i++ {
+		call := recvPeerMessage(t, f.peer)
+		if call.Message().Which() != rpccp.Message_Which_call {
+			t.Fatalf("message %d = %v; want Call", i, call.Message().Which())
+		}
+		call.Release()
+	}
+	finishMessage := recvPeerMessage(t, f.peer)
+	if finishMessage.Message().Which() != rpccp.Message_Which_finish {
+		t.Fatalf("message after Calls = %v; want Finish", finishMessage.Message().Which())
+	}
+	finish, err := finishMessage.Message().Finish()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if finish.ReleaseResultCaps() {
+		t.Error("normal Return sent Finish(releaseResultCaps=true)")
+	}
+	finishMessage.Release()
+
+	// A later outbound marker proves the Finish callback has run before ID
+	// reuse is checked, because the sender loop invokes callbacks serially.
+	sendBootstrapMarker(t, f.peer, 99)
+	marker := recvPeerMessage(t, f.peer)
+	if marker.Message().Which() != rpccp.Message_Which_return {
+		t.Fatalf("marker response = %v; want Return", marker.Message().Which())
+	}
+	marker.Release()
+	assertQuestionIDReusable(t, f.conn, 0)
+	if got := atomic.LoadInt32(&incoming.releases); got != 0 {
+		t.Fatalf("successful Return released incoming message before response release: %d", got)
+	}
+	f.q.release()
+	f.q.release = func() {}
+	if got := atomic.LoadInt32(&incoming.releases); got != 1 {
+		t.Fatalf("incoming message release count = %d; want 1", got)
+	}
+}
+
+func TestQuestionCancellationDrainsBeforeSingleFinish(t *testing.T) {
+	f := newQuestionLifecycleFixture(t)
+	callReturned := f.startAdmittedCall()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	cancelReturned := make(chan struct{})
+	go func() {
+		f.q.handleCancel(ctx)
+		close(cancelReturned)
+	}()
+	if err := <-f.resolverResult; !errors.Is(err, context.Canceled) {
+		t.Fatalf("Promise resolver error = %v; want context.Canceled", err)
+	}
+	f.conn.withLocked(func(c *lockedConn) {
+		if f.q.owner != questionOwnerCancel || f.q.drainComplete || f.q.finish != questionFinishNotQueued {
+			t.Errorf("cancellation advanced before admitted call yielded: %+v", *f.q)
+		}
+	})
+
+	f.releaseGate()
+	<-callReturned
+	<-cancelReturned
+	call := recvPeerMessage(t, f.peer)
+	if call.Message().Which() != rpccp.Message_Which_call {
+		t.Fatalf("first message = %v; want Call", call.Message().Which())
+	}
+	call.Release()
+	finishMessage := recvPeerMessage(t, f.peer)
+	finish, err := finishMessage.Message().Finish()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !finish.ReleaseResultCaps() {
+		t.Error("cancellation sent Finish(releaseResultCaps=false)")
+	}
+	finishMessage.Release()
+
+	// A late contradictory hint cannot suppress or duplicate cancellation's
+	// already-owned Finish(true).
+	lateReturn := newQuestionReturnMessage(t, true, false)
+	if err := f.conn.handleReturn(f.conn.bgctx, lateReturn); err != nil {
+		t.Fatal(err)
+	}
+	if got := atomic.LoadInt32(&lateReturn.releases); got != 1 {
+		t.Fatalf("late canceled Return release count = %d; want 1", got)
+	}
+	sendBootstrapMarker(t, f.peer, 99)
+	marker := recvPeerMessage(t, f.peer)
+	if marker.Message().Which() != rpccp.Message_Which_return {
+		t.Fatalf("message after late Return = %v; want marker Return (no second Finish)", marker.Message().Which())
+	}
+	marker.Release()
+	f.conn.withLocked(func(c *lockedConn) {
+		if !f.q.returnReceived || f.q.finish != questionFinishSent {
+			t.Errorf("late Return state = returnReceived %t, finish %d", f.q.returnReceived, f.q.finish)
+		}
+	})
+	assertQuestionIDReusable(t, f.conn, 0)
+}
+
+func TestQuestionNoFinishNeededSuppressesAndReusesID(t *testing.T) {
+	f := newQuestionLifecycleFixture(t)
+	incoming := newQuestionReturnMessage(t, true, false)
+	if err := f.conn.handleReturn(f.conn.bgctx, incoming); err != nil {
+		t.Fatal(err)
+	}
+	if err := <-f.resolverResult; err != nil {
+		t.Fatalf("Promise resolver error = %v; want nil", err)
+	}
+	<-f.q.drainDone
+	f.conn.withLocked(func(c *lockedConn) {
+		if !f.q.noFinishNeeded || !f.q.drainComplete || f.q.finish != questionFinishSuppressed {
+			t.Errorf("noFinishNeeded state = hint %t, drain %t, finish %d",
+				f.q.noFinishNeeded, f.q.drainComplete, f.q.finish)
+		}
+	})
+
+	// Once the drain is complete, a marker Return must be the next outbound
+	// message: a Finish would contradict the valid hint.
+	sendBootstrapMarker(t, f.peer, 99)
+	marker := recvPeerMessage(t, f.peer)
+	if marker.Message().Which() != rpccp.Message_Which_return {
+		t.Fatalf("message after noFinishNeeded drain = %v; want marker Return", marker.Message().Which())
+	}
+	marker.Release()
+	assertQuestionIDReusable(t, f.conn, 0)
+	if got := atomic.LoadInt32(&incoming.releases); got != 0 {
+		t.Fatalf("noFinishNeeded Return released response before ReleaseFunc: %d", got)
+	}
+	f.q.release()
+	f.q.release = func() {}
+	if got := atomic.LoadInt32(&incoming.releases); got != 1 {
+		t.Fatalf("noFinishNeeded incoming release count = %d; want 1", got)
+	}
+}
+
+func TestQuestionContradictoryNoFinishNeededSendsFinish(t *testing.T) {
+	f := newQuestionLifecycleFixture(t)
+	logger := new(recordingLogger)
+	f.conn.er = errReporter{Logger: logger}
+	sendQuestionReturn(t, f.peer, true, true)
+	if err := <-f.resolverResult; err != nil {
+		t.Fatalf("Promise resolver error = %v; want nil", err)
+	}
+	finishMessage := recvPeerMessage(t, f.peer)
+	if finishMessage.Message().Which() != rpccp.Message_Which_finish {
+		t.Fatalf("message = %v; want Finish", finishMessage.Message().Which())
+	}
+	finish, err := finishMessage.Message().Finish()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if finish.ReleaseResultCaps() {
+		t.Error("capability-bearing Return sent Finish(releaseResultCaps=true)")
+	}
+	finishMessage.Release()
+
+	logger.mu.Lock()
+	loggedErrors := append([]string(nil), logger.errors...)
+	logger.mu.Unlock()
+	if len(loggedErrors) != 1 || !strings.Contains(loggedErrors[0], "noFinishNeeded") {
+		t.Fatalf("logged errors = %q; want one noFinishNeeded diagnostic", loggedErrors)
+	}
+}
+
+func TestQuestionShutdownWaitsForReturnDrain(t *testing.T) {
+	f := newQuestionLifecycleFixture(t)
+	callReturned := f.startAdmittedCall()
+	incoming := newQuestionReturnMessage(t, false, false)
+	if err := f.conn.handleReturn(f.conn.bgctx, incoming); err != nil {
+		t.Fatal(err)
+	}
+	if err := <-f.resolverResult; err != nil {
+		t.Fatalf("Promise resolver error = %v; want nil", err)
+	}
+
+	closeReturned := make(chan error, 1)
+	go func() { closeReturned <- f.conn.Close() }()
+	<-f.conn.bgctx.Done()
+	select {
+	case err := <-closeReturned:
+		t.Fatalf("Close returned before admitted call yielded: %v", err)
+	default:
+	}
+	f.conn.withLocked(func(c *lockedConn) {
+		if f.q.finish != questionFinishNotQueued {
+			t.Errorf("Finish state during blocked drain = %d; want not queued", f.q.finish)
+		}
+	})
+
+	f.releaseGate()
+	<-callReturned
+	if err := <-closeReturned; err != nil {
+		t.Fatal(err)
+	}
+	if f.q.finish != questionFinishFailed {
+		t.Errorf("Finish state after shutdown = %d; want failed", f.q.finish)
+	}
+	if got := atomic.LoadInt32(&incoming.releases); got != 0 {
+		t.Fatalf("shutdown released successful response still owned by caller: %d", got)
+	}
+	f.q.release()
+	f.q.release = func() {}
+	if got := atomic.LoadInt32(&incoming.releases); got != 1 {
+		t.Fatalf("shutdown response release count = %d; want 1", got)
+	}
+}
+
+func TestQuestionReturnCancelRaceHasSingleOwner(t *testing.T) {
+	f := newQuestionLifecycleFixture(t)
+	incoming := newQuestionReturnMessage(t, false, false)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	start := make(chan struct{})
+	returnResult := make(chan error, 1)
+	cancelReturned := make(chan struct{})
+	go func() {
+		<-start
+		returnResult <- f.conn.handleReturn(f.conn.bgctx, incoming)
+	}()
+	go func() {
+		<-start
+		f.q.handleCancel(ctx)
+		close(cancelReturned)
+	}()
+	close(start)
+	if err := <-returnResult; err != nil {
+		t.Fatal(err)
+	}
+	<-cancelReturned
+	resolvedErr := <-f.resolverResult
+	<-f.q.drainDone
+
+	f.conn.withLocked(func(c *lockedConn) {
+		switch f.q.owner {
+		case questionOwnerReturn:
+			if resolvedErr != nil {
+				t.Errorf("Return winner rejected Promise: %v", resolvedErr)
+			}
+		case questionOwnerCancel:
+			if !errors.Is(resolvedErr, context.Canceled) {
+				t.Errorf("cancellation winner resolved with %v; want context.Canceled", resolvedErr)
+			}
+		default:
+			t.Errorf("terminal owner = %d; want Return or cancellation", f.q.owner)
+		}
+		if !f.q.returnReceived || (f.q.finish != questionFinishQueued && f.q.finish != questionFinishSent) {
+			t.Errorf("race state = returnReceived %t, finish %d", f.q.returnReceived, f.q.finish)
+		}
+	})
+
+	finishMessage := recvPeerMessage(t, f.peer)
+	finish, err := finishMessage.Message().Finish()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := finish.ReleaseResultCaps(); got != (f.q.owner == questionOwnerCancel) {
+		t.Errorf("Finish.releaseResultCaps = %t; owner %d", got, f.q.owner)
+	}
+	finishMessage.Release()
+	sendBootstrapMarker(t, f.peer, 99)
+	marker := recvPeerMessage(t, f.peer)
+	if marker.Message().Which() != rpccp.Message_Which_return {
+		t.Fatalf("message after race Finish = %v; want marker Return", marker.Message().Which())
+	}
+	marker.Release()
+	assertQuestionIDReusable(t, f.conn, 0)
+
+	beforeRelease := atomic.LoadInt32(&incoming.releases)
+	f.q.release()
+	f.q.release = func() {}
+	if f.q.owner == questionOwnerReturn {
+		if beforeRelease != 0 || atomic.LoadInt32(&incoming.releases) != 1 {
+			t.Errorf("Return winner incoming releases = %d before, %d after response release",
+				beforeRelease, atomic.LoadInt32(&incoming.releases))
+		}
+	} else if beforeRelease != 1 || atomic.LoadInt32(&incoming.releases) != 1 {
+		t.Errorf("cancellation winner incoming release count = %d before, %d after", beforeRelease,
+			atomic.LoadInt32(&incoming.releases))
+	}
+}
+
+type unusedPipelineCaller struct{}
+
+func (unusedPipelineCaller) PipelineSend(context.Context, []capnp.PipelineOp, capnp.Send) (*capnp.Answer, capnp.ReleaseFunc) {
+	panic("unexpected pipeline send")
+}
+
+func (unusedPipelineCaller) PipelineRecv(context.Context, []capnp.PipelineOp, capnp.Recv) capnp.PipelineCaller {
+	panic("unexpected pipeline recv")
+}
+
+func newUnsentQuestion() (*Conn, *question) {
+	c := &Conn{bgctx: context.Background()}
+	q := &question{c: c, release: func() {}, callSendDone: make(chan struct{})}
+	q.id = (*lockedConn)(c).lk.questions.Add(q)
+	q.p = capnp.NewPromise(capnp.Method{}, unusedPipelineCaller{}, nil)
+	return c, q
+}
+
+func TestQuestionInitialCallFailureIDPolicy(t *testing.T) {
+	t.Run("definitely unsent releases ID", func(t *testing.T) {
+		c, q := newUnsentQuestion()
+		queue := spsc.New[asyncSend]()
+		c.lk.sendTx = &queue.Tx
+		admitted := make(chan struct{}, 1)
+		gateRelease := make(chan struct{})
+		q.p = capnp.NewPromise(capnp.Method{}, &gatedQuestionCaller{
+			inner: q, admitted: admitted, release: gateRelease,
+		}, nil)
+		pipelineReturned := make(chan struct{})
+		go func() {
+			_, _ = q.p.Answer().PipelineSend(context.Background(), nil, capnp.Send{Method: capnp.Method{}})
+			close(pipelineReturned)
+		}()
+		<-admitted
+
+		handlerReturned := make(chan struct{})
+		go func() {
+			q.handleCallSend(context.Background(), sendOutcome{
+				disposition: sendDefinitelyUnsent,
+				err:         errors.New("build failed"),
+			}, "test call")
+			close(handlerReturned)
+		}()
+		<-q.callSendDone
+		select {
+		case <-handlerReturned:
+			t.Fatal("definitely-unsent handler did not drain admitted pipeline call")
+		default:
+		}
+		close(gateRelease)
+		<-pipelineReturned
+		<-handlerReturned
+		<-q.p.Answer().Done()
+		if _, ok := queue.Rx.TryRecv(); ok {
+			t.Fatal("dependent Call escaped after parent Call was definitely unsent")
+		}
+		assertQuestionIDReusable(t, c, q.id)
+	})
+
+	t.Run("delivery ambiguous retains ID", func(t *testing.T) {
+		c, q := newUnsentQuestion()
+		q.handleCallSend(context.Background(), sendOutcome{
+			disposition: sendDeliveryAmbiguous,
+			err:         errors.New("write failed"),
+			fatal:       true,
+		}, "test call")
+		<-q.p.Answer().Done()
+		if q.owner != questionOwnerSendFailure {
+			t.Fatalf("terminal owner = %d; want send failure", q.owner)
+		}
+		c.withLocked(func(c *lockedConn) {
+			if id := c.lk.questions.Add(nil); id == q.id {
+				t.Errorf("delivery-ambiguous question ID %d was reused", q.id)
+			}
+		})
+	})
+
+	t.Run("shutdown abort leaves cleanup to shutdown", func(t *testing.T) {
+		c, q := newUnsentQuestion()
+		q.handleCallSend(context.Background(), sendOutcome{
+			disposition: sendAbortedByShutdown,
+			err:         ErrConnClosed,
+		}, "test call")
+		select {
+		case <-q.p.Answer().Done():
+			t.Fatal("queue abort independently rejected question")
+		default:
+		}
+		c.withLocked(func(c *lockedConn) {
+			if current, ok := c.lk.questions.Find(q.id); !ok || current != q {
+				t.Fatal("queue abort removed question before shutdown cleanup")
+			}
+		})
+	})
+}
+
+func TestQuestionFinishFailureRetainsID(t *testing.T) {
+	tests := []struct {
+		name      string
+		transport Transport
+		abort     bool
+	}{
+		{
+			name:      "definitely unsent",
+			transport: newMessageErrorTransport{err: errors.New("allocate failed")},
+		},
+		{
+			name: "delivery ambiguous",
+			transport: func() Transport {
+				tr := newFailingSendTransport(errors.New("write failed"))
+				close(tr.firstSend)
+				return tr
+			}(),
+		},
+		{
+			name:      "shutdown abort",
+			transport: newMessageErrorTransport{err: errors.New("unused")},
+			abort:     true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			queue := spsc.New[asyncSend]()
+			c := &Conn{transport: test.transport, bgctx: context.Background()}
+			c.lk.sendTx = &queue.Tx
+			q := &question{
+				c:              c,
+				release:        func() {},
+				owner:          questionOwnerReturn,
+				drainComplete:  true,
+				returnReceived: true,
+			}
+			q.id = (*lockedConn)(c).lk.questions.Add(q)
+			(*lockedConn)(c).lk.questions.take(q.id)
+			q.queueFinish((*lockedConn)(c), false)
+
+			pending, ok := queue.Rx.TryRecv()
+			if !ok {
+				t.Fatal("Finish was not queued")
+			}
+			if test.abort {
+				pending.Abort(ErrConnClosed)
+			} else if err := pending.Send(); err == nil {
+				t.Fatal("Finish failure did not return fatal sender error")
+			}
+			if q.finish != questionFinishFailed {
+				t.Fatalf("Finish state = %d; want failed", q.finish)
+			}
+			c.withLocked(func(c *lockedConn) {
+				if id := c.lk.questions.Add(nil); id == q.id {
+					t.Errorf("failed Finish released question ID %d", q.id)
+				}
+			})
+		})
+	}
+}

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -332,26 +332,14 @@ func (c *Conn) Bootstrap(ctx context.Context) (bc capnp.Client) {
 			q.release()
 		})
 
-		c.sendMessage(ctx, func(m rpccp.Message) error {
+		c.sendMessageOutcome(ctx, func(m rpccp.Message) error {
 			boot, err := m.NewBootstrap()
 			if err == nil {
 				boot.SetQuestionId(uint32(q.id))
 			}
 			return err
 
-		}, func(err error) {
-			if err != nil {
-				syncutil.With(&c.lk, func() { c.lk.questions.Remove(q.id) })
-				q.p.Reject(exc.Annotate("rpc", "bootstrap", err))
-				return
-			}
-
-			c.tasks.Add(1)
-			go func() {
-				defer c.tasks.Done()
-				q.handleCancel(ctx)
-			}()
-		})
+		}, false, func(outcome sendOutcome) { q.handleCallSend(ctx, outcome, "bootstrap") })
 
 		return
 	})
@@ -499,12 +487,9 @@ func (c *lockedConn) releaseAnswers(dq *deferred.Queue, answers []*ansent) {
 
 func (c *lockedConn) releaseQuestions(dq *deferred.Queue, questions []*question) {
 	for _, q := range questions {
-		canceled := q != nil && q.flags.Contains(finished)
-		if !canceled {
-			// Only reject the question if it isn't already flagged
-			// as finished; otherwise it was rejected when the finished
-			// flag was set.
-
+		if q != nil && q.owner == questionOwnerNone {
+			// Terminal owners resolve or reject their own Promise. Questions
+			// without one are still pending and are rejected by shutdown.
 			qr := q // Capture a different variable each time through the loop.
 			dq.Defer(func() {
 				qr.Reject(ExcClosed)
@@ -1097,7 +1082,7 @@ func parseTransform(list rpccp.PromisedAnswer_Op_List) ([]capnp.PipelineOp, erro
 	return ops, nil
 }
 
-func (c *Conn) handleReturn(ctx context.Context, in transport.IncomingMessage) error {
+func (c *Conn) handleReturn(_ context.Context, in transport.IncomingMessage) error {
 	ret, err := in.Message().Return()
 	if err != nil {
 		in.Release()
@@ -1108,53 +1093,56 @@ func (c *Conn) handleReturn(ctx context.Context, in transport.IncomingMessage) e
 	dq := &deferred.Queue{}
 	defer dq.Run()
 
-	// Save this, so we can reference it from spawned goroutines that are not holding
-	// the lock; we reassign to c at the top of those functions.
-	unlockedConn := c
-
-	return withLockedConn1(c, func(c *lockedConn) error {
-
+	var drain func()
+	var taskStarted bool
+	var handleErr error
+	c.withLocked(func(c *lockedConn) {
 		qid := questionID(ret.AnswerId())
-		// Pop the question from the table.  Receiving the Return message
-		// will always remove the question from the table, because it's the
-		// only time the remote vat will use it.
 		q, ok := c.lk.questions.take(qid)
 		if !ok {
 			dq.Defer(in.Release)
-			return rpcerr.Failed(errors.New(
+			handleErr = rpcerr.Failed(errors.New(
 				"incoming return: question " + str.Utod(qid) + " does not exist",
 			))
+			return
 		}
-		canceled := q.flags.Contains(finished)
-		q.flags |= finished
-		if canceled {
-			// Wait for cancelation task to write the Finish message.  If the
-			// Finish message could not be sent to the remote vat, we can't
-			// reuse the ID.
-			select {
-			case <-q.finishMsgSend:
-				if q.flags.Contains(finishSent) {
-					c.lk.questions.release(qid)
-				}
-				dq.Defer(in.Release)
-			default:
-				dq.Defer(in.Release)
+		q.returnReceived = true
 
-				go func() {
-					c := unlockedConn
-					<-q.finishMsgSend
-					c.withLocked(func(c *lockedConn) {
-						if q.flags.Contains(finishSent) {
-							c.lk.questions.release(qid)
-						}
-					})
-				}()
+		switch q.owner {
+		case questionOwnerCancel:
+			// Cancellation owns the single Finish(true). A late Return never
+			// parses result capabilities and cannot suppress that Finish.
+			dq.Defer(in.Release)
+			if q.finish == questionFinishSent {
+				c.lk.questions.release(qid)
 			}
-			return nil
+			return
+		case questionOwnerSendFailure:
+			// Delivery was ambiguous and shutdown owns the retained ID.
+			dq.Defer(in.Release)
+			return
+		case questionOwnerNone:
+			q.owner = questionOwnerReturn
+		default:
+			dq.Defer(in.Release)
+			handleErr = rpcerr.Failed(errors.New(
+				"incoming return: question " + str.Utod(qid) + " has invalid terminal owner",
+			))
+			return
 		}
+
 		pr := c.parseReturn(dq, ret, q.called) // fills in CapTable and adds imports to local vat
 		if pr.parseFailed {
 			c.er.ReportError(rpcerr.Annotate(pr.err, "incoming return"))
+		}
+		if ret.NoFinishNeeded() {
+			if !returnHasCapabilities(ret) {
+				q.noFinishNeeded = true
+			} else {
+				c.er.ReportError(errors.New(
+					"incoming return: noFinishNeeded set on capability-bearing result; sending Finish",
+				))
+			}
 		}
 
 		if pr.err == nil {
@@ -1162,104 +1150,75 @@ func (c *Conn) handleReturn(ctx context.Context, in transport.IncomingMessage) e
 			// an error), so we save the ReleaseFunc for later:
 			q.release = in.Release
 		}
-		// We're going to potentially block fulfilling some promises so fork
-		// off a goroutine to avoid blocking the receive loop.
-		go func() {
-			c := unlockedConn
+
+		taskStarted = c.startTask()
+		drain = func() {
 			q.p.Resolve(pr.result, pr.err)
 			if pr.err != nil {
-				// We can release now; the result is an error, so data from the message
-				// won't be accessed:
+				// Error results do not retain data from the incoming message.
 				in.Release()
 			}
 
-			// Even though any imports added within the
-			// parseResults()  were added inside the locked conn
-			// mutex, there could still be references to the prior
-			// question `qid` that are (concurrent to the
-			// processing of this Return message) about to send a
-			// pipelined request to the remote host. Sending a
-			// Finish message now, could mean these other outbound
-			// messages enter the send queue _after_ the Finish,
-			// thus causing a remote error: the pipelined call
-			// referencing `qid` arrives after the Finish, which is
-			// a protocol violation.
-			//
-			// One way of seeing this bug manifest is on the
-			// TestPromiseOrdering test as of commit 2f9aa4f:
-			// removing the fix below triggers errors in the style
-			// of:
-			//
-			//   "handle Call: rpc: incoming call: use of unknown
-			//   or finished answer ID 0 for promised answer"
-			//
-			// Unfortunately, I (matheusd) cannot see _any_ way of
-			// doing a proper fix. What I consider a "proper" fix
-			// would be to couple (via some synchronization
-			// mechanism) the sending and receiving sides of the
-			// conn, such that sending this finish only happens
-			// after all references of the above question are
-			// released. Or something like that.
-			//
-			// Instead, we opt for a sleep here, to give a chance
-			// to any concurrent goroutines to complete their
-			// sending process, and then we send the finish. If
-			// production code is doing anything similar to what
-			// that test exercises, then unless the host system is
-			// under _significant_ load, the following sleep should
-			// be sufficient.
-			//
-			// Yes, I am aware this is an ugly solution. Hopefully
-			// some future refactor will make a better fix obvious
-			// or (even better) unnecessary.
-			select {
-			case <-ctx.Done():
-				return
-			case <-time.After(250 * time.Millisecond):
-			}
-
-			c.withLocked(func(c *lockedConn) {
-				// Send disembargoes.  Failing to send one of these just never lifts
-				// the embargo on our side, but doesn't cause a leak.
-				//
-				// TODO(soon): make embargo resolve to error client.
-				for _, s := range pr.disembargoes {
-					c.sendMessage(ctx, s.buildDisembargo, func(err error) {
-						if err != nil && !isFatalSendError(err) {
-							err = exc.WrapError("incoming return: send disembargo", err)
-							c.er.ReportError(err)
-						}
-					})
-				}
-
-				// Send finish.
-				c.sendMessage(ctx, func(m rpccp.Message) error {
-					fin, err := m.NewFinish()
-					if err == nil {
-						fin.SetQuestionId(uint32(qid))
-						fin.SetReleaseResultCaps(false)
-					}
-					return err
-				}, func(err error) {
-					c.lk.Lock()
-					defer c.lk.Unlock()
-					defer close(q.finishMsgSend)
-
-					if err != nil {
-						if !isFatalSendError(err) {
-							err = exc.WrapError("incoming return: send finish: build message", err)
-							c.er.ReportError(err)
-						}
-					} else {
-						q.flags |= finishSent
-						c.lk.questions.release(qid)
-					}
-				})
+			q.c.withLocked(func(c *lockedConn) {
+				q.completeReturn(c, pr.disembargoes)
 			})
-		}()
-
-		return nil
+		}
 	})
+
+	if handleErr != nil || drain == nil {
+		return handleErr
+	}
+	if taskStarted {
+		go func() {
+			defer c.tasks.Done()
+			drain()
+		}()
+	} else {
+		// Shutdown has already started. The receive task itself keeps table
+		// teardown from racing this synchronous drain.
+		drain()
+	}
+	return nil
+}
+
+// completeReturn records that Promise admission has drained and orders all
+// terminal messages after the admitted Calls. The caller MUST hold q.c.lk.
+func (q *question) completeReturn(c *lockedConn, disembargoes []senderLoopback) {
+	q.drainComplete = true
+	defer q.signalDrainDone()
+	if c.lk.closing {
+		q.finish = questionFinishFailed
+		return
+	}
+
+	// Failing to send a disembargo leaves the local embargo in place but
+	// does not leak peer-side question state.
+	for _, s := range disembargoes {
+		c.sendMessage(c.bgctx, s.buildDisembargo, func(err error) {
+			if err != nil && !isFatalSendError(err) {
+				c.er.ReportError(exc.WrapError("incoming return: send disembargo", err))
+			}
+		})
+	}
+
+	if q.noFinishNeeded {
+		q.finish = questionFinishSuppressed
+		c.lk.questions.release(q.id)
+		return
+	}
+	q.queueFinish(c, false)
+}
+
+func returnHasCapabilities(ret rpccp.Return) bool {
+	if ret.Which() != rpccp.Return_Which_results {
+		return false
+	}
+	results, err := ret.Results()
+	if err != nil {
+		return true
+	}
+	capTable, err := results.CapTable()
+	return err != nil || capTable.Len() > 0
 }
 
 func (c *lockedConn) parseReturn(dq *deferred.Queue, ret rpccp.Return, called [][]capnp.PipelineOp) parsedReturn {

--- a/rpc/senderpromise_test.go
+++ b/rpc/senderpromise_test.go
@@ -565,23 +565,27 @@ func TestDisembargoSenderPromiseWithPipeline(t *testing.T) {
 			},
 		}))
 
-		// P1 completes the pipelined call by returning the response to
-		// P2. This message is now ensured to arrive first due to the
-		// fix we did in handleReturn.
-		rmsg, release, err := recvMessage(ctx, p2)
-		assert.NoError(t, err)
-		defer release()
-		assert.Equal(t, rpccp.Message_Which_return, rmsg.Which)
-		assert.Equal(t, p2Call01Id, rmsg.Return.AnswerID)
-		// Anything else to assert?
-	}
-
-	{
-		// P2 receives the final finish.
-		rmsg, release, err := recvMessage(ctx, p2)
-		assert.NoError(t, err)
-		defer release()
-		assert.Equal(t, rpccp.Message_Which_finish, rmsg.Which)
+		// The nested Return and the original question's Finish are
+		// independent once the pipelined Call has been sent, so either may
+		// arrive first. The protocol invariant is Call-before-Finish, not
+		// nested-Return-before-Finish.
+		seenReturn, seenFinish := false, false
+		for i := 0; i < 2; i++ {
+			rmsg, release, err := recvMessage(ctx, p2)
+			assert.NoError(t, err)
+			switch rmsg.Which {
+			case rpccp.Message_Which_return:
+				seenReturn = true
+				assert.Equal(t, p2Call01Id, rmsg.Return.AnswerID)
+			case rpccp.Message_Which_finish:
+				seenFinish = true
+			default:
+				t.Errorf("unexpected message between pipelined Call and cleanup: %v", rmsg.Which)
+			}
+			release()
+		}
+		assert.True(t, seenReturn, "missing nested Return")
+		assert.True(t, seenFinish, "missing Finish")
 	}
 
 	// P2 detects that is a local capability (i.e. looped back), thus


### PR DESCRIPTION
## Summary

- drain admitted old-route calls before sending `Finish`
- reserve question IDs until `Finish` is confirmed sent
- send `Finish(false)` after normal Return and exactly one `Finish(true)` after cancellation
- honor capability-free `noFinishNeeded`, while conservatively sending Finish for contradictory capability-bearing results
- replace the 250 ms timing workaround with explicit completion ownership and deterministic ordering
- gate dependent pipeline sends on the initial Call send outcome so definitely-unsent parents cannot release their IDs ahead of admitted dependents

This is PR 3 of 3 for #626 and is stacked on #631.

Stack: #630 → #631 → **this PR**

Closes #626

## Test coverage

- full `go test ./...`
- full `go test -race ./...`
- 100-count targeted lifecycle stress tests under the race detector
- deterministic coverage for Return/cancellation race winners, shutdown, definite and ambiguous send failures, Finish failure, multiple admitted calls, exact release ownership, `noFinishNeeded`, and immediate ID reuse
- bidirectional Go to C++ and C++ to Go interoperability against Cap'n Proto C++ 1.5.0, covering normal pipelining, cancellation, capability-free `noFinishNeeded`, capability-bearing results, post-cancellation health, and immediate ID reuse

## Review

Independent concurrency-focused review traced success, Return-before-send-callback, ambiguous failure, shutdown-abort, cancellation, and failed-parent/dependent-call interactions. No remaining defects or wait cycles were found.

## Compatibility

No public API, schema, or wire-format changes.
