### PR TITLE
rpc: prepare imported and pipelined calls before enqueue

### DIFF
--- a/answer.go
+++ b/answer.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	"capnproto.org/go/capnp/v3/exc"
+	"capnproto.org/go/capnp/v3/flowcontrol"
 	"capnproto.org/go/capnp/v3/internal/str"
 	"capnproto.org/go/capnp/v3/util/deferred"
 	"capnproto.org/go/capnp/v3/util/sync/mutex"
@@ -342,6 +343,18 @@ func (ans *Answer) PipelineSend(ctx context.Context, transform []PipelineOp, s S
 		l.Value().ongoingCalls++
 		l.Unlock()
 		defer p.pipelineCallDone()
+		if preparer, ok := caller.(PipelineCallerPreparer); ok {
+			prepared, err := preparer.PreparePipelineSend(ctx, transform, s)
+			if err != nil {
+				return ErrorAnswer(s.Method, err), func() {}
+			}
+			ans, release, err := prepared.Commit(func(flowcontrol.MessageOutcomeKind, error) {})
+			if err != nil {
+				prepared.Abort()
+				return ErrorAnswer(s.Method, err), func() {}
+			}
+			return ans, release
+		}
 		return caller.PipelineSend(ctx, transform, s)
 	case l.Value().isPendingResolution():
 		// Block new calls until resolved.

--- a/flowcontrol/nop_test.go
+++ b/flowcontrol/nop_test.go
@@ -1,0 +1,23 @@
+package flowcontrol
+
+import (
+	"context"
+	"testing"
+)
+
+func TestNopLimiterGateNext(t *testing.T) {
+	controller := NopLimiter.GateNext()
+	waitNext, complete := controller.CommitMessage(1024)
+	if err := waitNext(context.Background()); err != nil {
+		t.Fatalf("waitNext() = %v; want nil", err)
+	}
+	complete(MessageOutcomeSucceeded, nil)
+	controller.Poison(context.Canceled)
+
+	// Nop's controller is deliberately zero-cost even after Poison.
+	waitNext, complete = controller.CommitMessage(1)
+	if err := waitNext(context.Background()); err != nil {
+		t.Fatalf("waitNext() after Poison = %v; want nil", err)
+	}
+	complete(MessageOutcomeFatal, context.Canceled)
+}

--- a/rpc/import.go
+++ b/rpc/import.go
@@ -118,6 +118,23 @@ func (ic *importClient) Send(ctx context.Context, s capnp.Send) (*capnp.Answer, 
 	})
 }
 
+// PrepareSend lets Client's flow-control path reserve against the fully built
+// RPC message before it is placed on the transport queue.
+func (ic *importClient) PrepareSend(ctx context.Context, s capnp.Send) (capnp.PreparedSend, error) {
+	return withLockedConn2(ic.c, func(c *lockedConn) (capnp.PreparedSend, error) {
+		return c.prepareCall(ctx, s, func(c *lockedConn) error {
+			ent, _ := c.lk.imports.Find(ic.id)
+			if ent == nil || ic.generation != ent.generation {
+				return rpcerr.Disconnected(errors.New("send on closed import"))
+			}
+			return nil
+		}, func(target rpccp.MessageTarget) error {
+			target.SetImportedCap(uint32(ic.id))
+			return nil
+		})
+	})
+}
+
 func (ic *importClient) Recv(ctx context.Context, r capnp.Recv) capnp.PipelineCaller {
 	ans, finish := ic.Send(ctx, capnp.Send{
 		Method:   r.Method,

--- a/rpc/import.go
+++ b/rpc/import.go
@@ -121,17 +121,15 @@ func (ic *importClient) Send(ctx context.Context, s capnp.Send) (*capnp.Answer, 
 // PrepareSend lets Client's flow-control path reserve against the fully built
 // RPC message before it is placed on the transport queue.
 func (ic *importClient) PrepareSend(ctx context.Context, s capnp.Send) (capnp.PreparedSend, error) {
-	return withLockedConn2(ic.c, func(c *lockedConn) (capnp.PreparedSend, error) {
-		return c.prepareCall(ctx, s, func(c *lockedConn) error {
-			ent, _ := c.lk.imports.Find(ic.id)
-			if ent == nil || ic.generation != ent.generation {
-				return rpcerr.Disconnected(errors.New("send on closed import"))
-			}
-			return nil
-		}, func(target rpccp.MessageTarget) error {
-			target.SetImportedCap(uint32(ic.id))
-			return nil
-		})
+	return ic.c.prepareCall(ctx, s, func(c *lockedConn) error {
+		ent, _ := c.lk.imports.Find(ic.id)
+		if ent == nil || ic.generation != ent.generation {
+			return rpcerr.Disconnected(errors.New("send on closed import"))
+		}
+		return nil
+	}, func(target rpccp.MessageTarget) error {
+		target.SetImportedCap(uint32(ic.id))
+		return nil
 	})
 }
 

--- a/rpc/question.go
+++ b/rpc/question.go
@@ -2,8 +2,11 @@ package rpc
 
 import (
 	"context"
+	"errors"
+	"sync"
 
 	"capnproto.org/go/capnp/v3"
+	"capnproto.org/go/capnp/v3/flowcontrol"
 	"capnproto.org/go/capnp/v3/internal/syncutil"
 	rpccp "capnproto.org/go/capnp/v3/std/capnp/rpc"
 )
@@ -283,6 +286,40 @@ func (q *question) PipelineSend(ctx context.Context, transform []capnp.PipelineO
 	})
 }
 
+// PreparePipelineSend preserves the same initial-call admission ordering as
+// PipelineSend.  In particular, a pipelined Call is never constructed or
+// enqueued until its parent Call has been accepted by the sender.
+func (q *question) PreparePipelineSend(ctx context.Context, transform []capnp.PipelineOp, s capnp.Send) (capnp.PreparedSend, error) {
+	select {
+	case <-q.callSendDone:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-q.c.bgctx.Done():
+		return nil, ExcClosed
+	}
+	return withLockedConn2(q.c, func(c *lockedConn) (capnp.PreparedSend, error) {
+		if q.callSend != questionCallSendSucceeded {
+			return nil, q.callSendErr
+		}
+		q.mark(transform)
+		return c.prepareCall(ctx, s, nil, func(target rpccp.MessageTarget) error {
+			pa, err := target.NewPromisedAnswer()
+			if err != nil {
+				return rpcerr.WrapFailed("build call message", err)
+			}
+			pa.SetQuestionId(uint32(q.id))
+			oplist, err := pa.NewTransform(int32(len(transform)))
+			if err != nil {
+				return rpcerr.WrapFailed("build call message", err)
+			}
+			for i, op := range transform {
+				oplist.At(i).SetGetPointerField(op.Field)
+			}
+			return nil
+		})
+	})
+}
+
 // startCall starts an outbound question.  populateTarget selects either an
 // imported capability or a promised answer without duplicating the question
 // lifecycle around those two target encodings.
@@ -308,6 +345,104 @@ func (c *lockedConn) startCall(ctx context.Context, s capnp.Send, preflight func
 		q.p.ReleaseClients()
 		q.release()
 	}
+}
+
+// preparedCall is the RPC implementation of capnp.PreparedSend.  The Call and
+// question exist before it is returned, but the transport message is not made
+// visible to the sender until Commit succeeds.
+type preparedCall struct {
+	c         *Conn
+	q         *question
+	msg       *preparedMessage
+	ctx       context.Context
+	preflight func(*lockedConn) error
+
+	mu        sync.Mutex
+	committed bool
+	aborted   bool
+}
+
+func (c *lockedConn) prepareCall(ctx context.Context, s capnp.Send, preflight func(*lockedConn) error, populateTarget func(rpccp.MessageTarget) error) (*preparedCall, error) {
+	if !c.startTask() {
+		return nil, ExcClosed
+	}
+	defer c.tasks.Done()
+	if preflight != nil {
+		if err := preflight(c); err != nil {
+			return nil, err
+		}
+	}
+	q := c.newQuestion(s.Method)
+	p := &preparedCall{c: (*Conn)(c), q: q, ctx: ctx, preflight: preflight}
+	p.msg = c.prepareMessage(func(m rpccp.Message) error {
+		return c.newCallMessage(m, q.id, s, populateTarget)
+	})
+	if p.msg.preErr != nil {
+		p.Abort()
+		return nil, p.msg.preErr
+	}
+	return p, nil
+}
+
+func (p *preparedCall) Size() uint64 { return p.msg.size }
+
+func (p *preparedCall) Commit(terminal func(flowcontrol.MessageOutcomeKind, error)) (*capnp.Answer, capnp.ReleaseFunc, error) {
+	p.mu.Lock()
+	if p.committed || p.aborted {
+		p.mu.Unlock()
+		return nil, nil, errors.New("prepared RPC send already completed")
+	}
+	p.committed = true
+	p.mu.Unlock()
+
+	var committed bool
+	p.c.withLocked(func(c *lockedConn) {
+		if p.ctx.Err() != nil || c.bgctx.Err() != nil || (p.preflight != nil && p.preflight(c) != nil) {
+			return
+		}
+		committed = p.msg.commit(p.ctx, false, func(outcome sendOutcome) {
+			p.q.handleCallSend(p.ctx, outcome, "send message")
+			switch outcome.disposition {
+			case sendSucceeded:
+				go func() { <-p.q.p.Answer().Done(); terminal(flowcontrol.MessageOutcomeSucceeded, nil) }()
+			case sendDefinitelyUnsent:
+				terminal(flowcontrol.MessageOutcomeAbortedBeforeEnqueue, outcome.err)
+			default:
+				terminal(flowcontrol.MessageOutcomeFatal, outcome.err)
+			}
+		})
+	})
+	if !committed {
+		p.msg.abort()
+		p.removeQuestion()
+		return nil, nil, ExcClosed
+	}
+	ans := p.q.p.Answer()
+	return ans, func() {
+		<-ans.Done()
+		p.q.p.ReleaseClients()
+		p.q.release()
+	}, nil
+}
+
+func (p *preparedCall) removeQuestion() {
+	p.c.withLocked(func(c *lockedConn) {
+		if q, ok := c.lk.questions.Find(p.q.id); ok && q == p.q {
+			c.lk.questions.Remove(p.q.id)
+		}
+	})
+}
+
+func (p *preparedCall) Abort() {
+	p.mu.Lock()
+	if p.committed || p.aborted {
+		p.mu.Unlock()
+		return
+	}
+	p.aborted = true
+	p.mu.Unlock()
+	p.msg.abort()
+	p.removeQuestion()
 }
 
 func (c *lockedConn) newCallMessage(msg rpccp.Message, qid questionID, s capnp.Send, populateTarget func(rpccp.MessageTarget) error) error {

--- a/rpc/question.go
+++ b/rpc/question.go
@@ -297,26 +297,30 @@ func (q *question) PreparePipelineSend(ctx context.Context, transform []capnp.Pi
 	case <-q.c.bgctx.Done():
 		return nil, ExcClosed
 	}
-	return withLockedConn2(q.c, func(c *lockedConn) (capnp.PreparedSend, error) {
+	err := withLockedConn1(q.c, func(c *lockedConn) error {
 		if q.callSend != questionCallSendSucceeded {
-			return nil, q.callSendErr
+			return q.callSendErr
 		}
 		q.mark(transform)
-		return c.prepareCall(ctx, s, nil, func(target rpccp.MessageTarget) error {
-			pa, err := target.NewPromisedAnswer()
-			if err != nil {
-				return rpcerr.WrapFailed("build call message", err)
-			}
-			pa.SetQuestionId(uint32(q.id))
-			oplist, err := pa.NewTransform(int32(len(transform)))
-			if err != nil {
-				return rpcerr.WrapFailed("build call message", err)
-			}
-			for i, op := range transform {
-				oplist.At(i).SetGetPointerField(op.Field)
-			}
-			return nil
-		})
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return q.c.prepareCall(ctx, s, nil, func(target rpccp.MessageTarget) error {
+		pa, err := target.NewPromisedAnswer()
+		if err != nil {
+			return rpcerr.WrapFailed("build call message", err)
+		}
+		pa.SetQuestionId(uint32(q.id))
+		oplist, err := pa.NewTransform(int32(len(transform)))
+		if err != nil {
+			return rpcerr.WrapFailed("build call message", err)
+		}
+		for i, op := range transform {
+			oplist.At(i).SetGetPointerField(op.Field)
+		}
+		return nil
 	})
 }
 
@@ -356,26 +360,38 @@ type preparedCall struct {
 	msg       *preparedMessage
 	ctx       context.Context
 	preflight func(*lockedConn) error
+	payload   rpccp.Payload
 
 	mu        sync.Mutex
 	committed bool
 	aborted   bool
 }
 
-func (c *lockedConn) prepareCall(ctx context.Context, s capnp.Send, preflight func(*lockedConn) error, populateTarget func(rpccp.MessageTarget) error) (*preparedCall, error) {
-	if !c.startTask() {
-		return nil, ExcClosed
-	}
-	defer c.tasks.Done()
-	if preflight != nil {
-		if err := preflight(c); err != nil {
-			return nil, err
+func (c *Conn) prepareCall(ctx context.Context, s capnp.Send, preflight func(*lockedConn) error, populateTarget func(rpccp.MessageTarget) error) (*preparedCall, error) {
+	var q *question
+	var err error
+	c.withLocked(func(lc *lockedConn) {
+		if !lc.startTask() {
+			err = ExcClosed
+			return
 		}
+		defer lc.tasks.Done()
+		if preflight != nil {
+			err = preflight(lc)
+			if err != nil {
+				return
+			}
+		}
+		q = lc.newQuestion(s.Method)
+	})
+	if err != nil {
+		return nil, err
 	}
-	q := c.newQuestion(s.Method)
-	p := &preparedCall{c: (*Conn)(c), q: q, ctx: ctx, preflight: preflight}
-	p.msg = c.prepareMessage(func(m rpccp.Message) error {
-		return c.newCallMessage(m, q.id, s, populateTarget)
+	p := &preparedCall{c: c, q: q, ctx: ctx, preflight: preflight}
+	p.msg = (*lockedConn)(c).prepareMessage(func(m rpccp.Message) error {
+		payload, err := newCallMessageUnsealed(m, q.id, s, populateTarget)
+		p.payload = payload
+		return err
 	})
 	if p.msg.preErr != nil {
 		p.Abort()
@@ -396,8 +412,24 @@ func (p *preparedCall) Commit(terminal func(flowcontrol.MessageOutcomeKind, erro
 	p.mu.Unlock()
 
 	var committed bool
+	var commitErr error
 	p.c.withLocked(func(c *lockedConn) {
-		if p.ctx.Err() != nil || c.bgctx.Err() != nil || (p.preflight != nil && p.preflight(c) != nil) {
+		if p.ctx.Err() != nil {
+			commitErr = p.ctx.Err()
+			return
+		}
+		if c.bgctx.Err() != nil {
+			commitErr = ExcClosed
+			return
+		}
+		if p.preflight != nil {
+			if err := p.preflight(c); err != nil {
+				commitErr = err
+				return
+			}
+		}
+		if _, err := c.fillPayloadCapTable(p.payload); err != nil {
+			commitErr = rpcerr.Annotate(err, "build call message")
 			return
 		}
 		committed = p.msg.commit(p.ctx, false, func(outcome sendOutcome) {
@@ -415,7 +447,7 @@ func (p *preparedCall) Commit(terminal func(flowcontrol.MessageOutcomeKind, erro
 	if !committed {
 		p.msg.abort()
 		p.removeQuestion()
-		return nil, nil, ExcClosed
+		return nil, nil, commitErr
 	}
 	ans := p.q.p.Answer()
 	return ans, func() {
@@ -446,9 +478,24 @@ func (p *preparedCall) Abort() {
 }
 
 func (c *lockedConn) newCallMessage(msg rpccp.Message, qid questionID, s capnp.Send, populateTarget func(rpccp.MessageTarget) error) error {
+	payload, err := newCallMessageUnsealed(msg, qid, s, populateTarget)
+	if err != nil {
+		return err
+	}
+	if s.PlaceArgs == nil {
+		return nil
+	}
+	_, err = c.fillPayloadCapTable(payload)
+	if err != nil {
+		return rpcerr.Annotate(err, "build call message")
+	}
+	return nil
+}
+
+func newCallMessageUnsealed(msg rpccp.Message, qid questionID, s capnp.Send, populateTarget func(rpccp.MessageTarget) error) (rpccp.Payload, error) {
 	call, err := msg.NewCall()
 	if err != nil {
-		return rpcerr.WrapFailed("build call message", err)
+		return rpccp.Payload{}, rpcerr.WrapFailed("build call message", err)
 	}
 	call.SetQuestionId(uint32(qid))
 	call.SetInterfaceId(s.Method.InterfaceID)
@@ -456,38 +503,31 @@ func (c *lockedConn) newCallMessage(msg rpccp.Message, qid questionID, s capnp.S
 
 	target, err := call.NewTarget()
 	if err != nil {
-		return rpcerr.WrapFailed("build call message", err)
+		return rpccp.Payload{}, rpcerr.WrapFailed("build call message", err)
 	}
 	if err := populateTarget(target); err != nil {
-		return err
+		return rpccp.Payload{}, err
 	}
 
 	payload, err := call.NewParams()
 	if err != nil {
-		return rpcerr.WrapFailed("build call message", err)
+		return rpccp.Payload{}, rpcerr.WrapFailed("build call message", err)
 	}
 	args, err := capnp.NewStruct(payload.Segment(), s.ArgsSize)
 	if err != nil {
-		return rpcerr.WrapFailed("build call message", err)
+		return rpccp.Payload{}, rpcerr.WrapFailed("build call message", err)
 	}
 	if err := payload.SetContent(args.ToPtr()); err != nil {
-		return rpcerr.WrapFailed("build call message", err)
+		return rpccp.Payload{}, rpcerr.WrapFailed("build call message", err)
 	}
 
 	if s.PlaceArgs == nil {
-		return nil
+		return payload, nil
 	}
 	if err := s.PlaceArgs(args); err != nil {
-		return rpcerr.WrapFailed("place arguments", err)
+		return rpccp.Payload{}, rpcerr.WrapFailed("place arguments", err)
 	}
-	// TODO(soon): save param refs
-	_, err = c.fillPayloadCapTable(payload)
-
-	if err != nil {
-		return rpcerr.Annotate(err, "build call message")
-	}
-
-	return err
+	return payload, nil
 }
 
 func (q *question) PipelineRecv(ctx context.Context, transform []capnp.PipelineOp, r capnp.Recv) capnp.PipelineCaller {

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -1936,29 +1936,62 @@ func (c *lockedConn) sendMessageOutcome(
 	fatalIfUnsent bool,
 	onSent func(sendOutcome),
 ) {
-	outMsg, err := c.transport.NewMessage()
-	var send func() error
-	var release capnp.ReleaseFunc
-	var preSendErr error
-	if err != nil {
-		release = func() {}
-		preSendErr = rpcerr.WrapFailed("create message", err)
-	} else if err = build(outMsg.Message()); err != nil {
-		release = outMsg.Release
-		preSendErr = rpcerr.WrapFailed("build message", err)
-	} else {
-		send = outMsg.Send
-		release = outMsg.Release
-	}
+	prepared := c.prepareMessage(build)
+	prepared.commit(ctx, fatalIfUnsent, onSent)
+}
 
-	c.lk.sendTx.Send(asyncSend{
-		ctx:           ctx,
-		preSendErr:    preSendErr,
-		fatalIfUnsent: fatalIfUnsent,
-		release:       release,
-		send:          send,
-		onSent:        onSent,
+// preparedMessage owns an outgoing transport message until exactly one of
+// commit or abort is called.  It is deliberately internal: callers that need
+// to defer enqueueing must also arrange their own protocol cleanup.
+type preparedMessage struct {
+	c       *lockedConn
+	send    func() error
+	release capnp.ReleaseFunc
+	preErr  error
+	size    uint64
+	once    sync.Once
+}
+
+func (c *lockedConn) prepareMessage(build func(rpccp.Message) error) *preparedMessage {
+	p := &preparedMessage{c: c, release: func() {}}
+	outMsg, err := c.transport.NewMessage()
+	if err != nil {
+		p.preErr = rpcerr.WrapFailed("create message", err)
+	} else if err = build(outMsg.Message()); err != nil {
+		p.release = outMsg.Release
+		p.preErr = rpcerr.WrapFailed("build message", err)
+	} else {
+		p.send = outMsg.Send
+		p.release = outMsg.Release
+		p.size, err = outMsg.Message().Message().TotalSize()
+		if err != nil {
+			p.preErr = rpcerr.WrapFailed("measure message", err)
+		}
+	}
+	return p
+}
+
+func (p *preparedMessage) commit(ctx context.Context, fatalIfUnsent bool, onSent func(sendOutcome)) bool {
+	committed := false
+	p.once.Do(func() {
+		if p.c.lk.closing {
+			return
+		}
+		p.c.lk.sendTx.Send(asyncSend{
+			ctx:           ctx,
+			preSendErr:    p.preErr,
+			fatalIfUnsent: fatalIfUnsent,
+			release:       p.release,
+			send:          p.send,
+			onSent:        onSent,
+		})
+		committed = true
 	})
+	return committed
+}
+
+func (p *preparedMessage) abort() {
+	p.once.Do(func() { p.release() })
 }
 
 // reader reads messages from the transport in a loop, and send them down the

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -1974,9 +1974,6 @@ func (c *lockedConn) prepareMessage(build func(rpccp.Message) error) *preparedMe
 func (p *preparedMessage) commit(ctx context.Context, fatalIfUnsent bool, onSent func(sendOutcome)) bool {
 	committed := false
 	p.once.Do(func() {
-		if p.c.lk.closing {
-			return
-		}
 		p.c.lk.sendTx.Send(asyncSend{
 			ctx:           ctx,
 			preSendErr:    p.preErr,

--- a/rpc/rpc_test.go
+++ b/rpc/rpc_test.go
@@ -111,7 +111,13 @@ func TestConnection_BaseContext(t *testing.T) {
 				return st.SetData(make([]byte, 1))
 			})
 
-			require.NoError(t, err)
+			// The server has already begun shutdown. A legacy send could return
+			// before the transport noticed it, while a prepared send revalidates
+			// immediately before enqueueing. Both outcomes are valid; a failure
+			// must be the expected disconnection rather than an application error.
+			if err != nil && !capnp.IsDisconnected(err) {
+				require.NoError(t, err)
+			}
 		}()
 
 		wg.Wait()

--- a/rpc/send_outcome_test.go
+++ b/rpc/send_outcome_test.go
@@ -58,6 +58,37 @@ func TestSendMessageNewMessageError(t *testing.T) {
 	}
 }
 
+// Closing after a protocol handler has transferred ownership to sendMessage
+// must still enqueue the message.  The shutdown drain owns aborting it, which
+// runs both the terminal callback and the transport release outside c.lk.
+func TestSendMessageClosingQueuesForShutdownAbort(t *testing.T) {
+	tr := newFailingSendTransport(errors.New("unused"))
+	queue := spsc.New[asyncSend]()
+	c := &Conn{transport: tr}
+	c.lk.sendTx = &queue.Tx
+	c.lk.closing = true
+
+	var outcomes []sendOutcome
+	(*lockedConn)(c).sendMessageOutcome(context.Background(), func(m rpccp.Message) error {
+		_, err := m.NewUnimplemented()
+		return err
+	}, false, func(outcome sendOutcome) { outcomes = append(outcomes, outcome) })
+
+	pending, ok := queue.Rx.TryRecv()
+	if !ok {
+		t.Fatal("closing connection did not transfer message to shutdown queue")
+	}
+	pending.Abort(errors.New("connection closed"))
+	if len(outcomes) != 1 || outcomes[0].disposition != sendAbortedByShutdown {
+		t.Fatalf("outcomes = %+v; want one shutdown-aborted outcome", outcomes)
+	}
+	select {
+	case <-tr.firstRelease:
+	default:
+		t.Fatal("shutdown abort did not release outgoing message")
+	}
+}
+
 func TestAsyncSendOutcomes(t *testing.T) {
 	canceled, cancel := context.WithCancel(context.Background())
 	cancel()


### PR DESCRIPTION
Adds prepared-send integration for RPC imports and normal question pipelines, plus the Nop gate-next contract test.

Also preserves shutdown ownership by routing prepared messages through the sender queue for drain/abort cleanup, and updates the base-context test for the valid prepared-send shutdown race.

Validation:
- go test ./...
- go test -race -short ./...
- go test ./rpc -count=10
- go test -race -short ./rpc -count=5
- git diff --check

GOARCH=386 is unsupported on this macOS host (darwin/386).