### PR TITLE
capnp: document fixed-buffer external arenas

### DIFF
--- a/arena.go
+++ b/arena.go
@@ -34,8 +34,16 @@ type Arena interface {
 	// responsible for preserving the existing data.
 	Allocate(minsz Size, msg *Message, seg *Segment) (*Segment, Address, error)
 
-	// Release all resources associated with the Arena. Callers MUST NOT
-	// use the Arena after it has been released.
+	// Release all resources associated with a Message's use of the Arena.
+	// Message.Reset and Message.Release call Release when they end a
+	// Message's association with its Arena.
+	//
+	// Whether an Arena may be reused after Release is implementation-defined.
+	// An implementation may invalidate itself, return storage to a pool, or
+	// reset caller-owned storage for a later Message. Callers MUST NOT assume
+	// an Arena can be reused unless its concrete documentation says so.
+	// Callers MUST NOT call Arena.Release directly while an Arena is attached
+	// to a live Message.
 	//
 	// Calling Release() is OPTIONAL, but may reduce allocations.
 	//
@@ -469,8 +477,15 @@ func (r *ReadOnlySingleSegment) Allocate(minsz Size, msg *Message, seg *Segment)
 	return nil, 0, errors.New("readOnly segment cannot allocate data")
 }
 
-// Release all resources associated with the Arena. Callers MUST NOT
-// use the Arena after it has been released.
+// Release all resources associated with a Message's use of the Arena.
+// Message.Reset and Message.Release call Release when they end a Message's
+// association with its Arena.
+//
+// Whether an Arena may be reused after Release is implementation-defined.
+// An implementation may invalidate itself, return storage to a pool, or
+// reset caller-owned storage for a later Message. Callers MUST NOT assume an
+// Arena can be reused unless its concrete documentation says so. Callers MUST
+// NOT call Arena.Release directly while an Arena is attached to a live Message.
 //
 // Calling Release() is OPTIONAL, but may reduce allocations.
 //

--- a/arena_example_test.go
+++ b/arena_example_test.go
@@ -1,0 +1,98 @@
+package capnp_test
+
+import (
+	"errors"
+	"fmt"
+
+	"capnproto.org/go/capnp/v3"
+)
+
+var (
+	errFixedArenaCapacity = errors.New("fixed arena: capacity exceeded")
+	errFixedArenaSegment  = errors.New("fixed arena: segment is not associated with arena")
+)
+
+// fixedArena is a single-segment Arena backed by caller-owned storage.
+// It never grows, copies, pools, or adds segments.
+type fixedArena struct {
+	seg *capnp.Segment
+}
+
+func newFixedArena(buffer []byte) fixedArena {
+	// Starting with buffer[:0] keeps data word-aligned during normal message
+	// construction, which passes word-padded allocation sizes to Arena.Allocate.
+	return fixedArena{seg: capnp.NewSegment(0, buffer[:0])}
+}
+
+func (*fixedArena) NumSegments() int64 {
+	return 1
+}
+
+func (a *fixedArena) Segment(id capnp.SegmentID) *capnp.Segment {
+	if id == 0 {
+		return a.seg
+	}
+	return nil
+}
+
+func (a *fixedArena) Allocate(minsz capnp.Size, msg *capnp.Message, preferred *capnp.Segment) (*capnp.Segment, capnp.Address, error) {
+	if preferred == nil || preferred != a.seg {
+		return nil, 0, errFixedArenaSegment
+	}
+	data := a.seg.Data()
+	if minsz > capnp.Size(cap(data)-len(data)) {
+		// Callers must Reset the Message before reusing the Arena after a
+		// construction failure.
+		return nil, 0, errFixedArenaCapacity
+	}
+	addr := capnp.Address(len(data))
+	a.seg.SetData(data[:len(data)+int(minsz)])
+	a.seg.BindTo(msg)
+	return a.seg, addr, nil
+}
+
+func (a *fixedArena) Release() {
+	// This makes the previous message unavailable without scrubbing buffer.
+	// Callers that need to clear sensitive data must do so themselves.
+	a.seg.SetData(a.seg.Data()[:0])
+	a.seg.BindTo(nil)
+}
+
+func ExampleArena() {
+	// The caller owns this buffer for the arena's entire lifetime.
+	var buffer [64]byte
+	arena := newFixedArena(buffer[:])
+	msg, seg, err := capnp.NewMessage(&arena)
+	if err != nil {
+		panic(err)
+	}
+
+	root, err := capnp.NewRootStruct(seg, capnp.ObjectSize{PointerCount: 1})
+	if err != nil {
+		panic(err)
+	}
+	if err := root.SetText(0, "first"); err != nil {
+		panic(err)
+	}
+
+	// Reset invalidates root and all other pointers from the first message.
+	seg, err = msg.Reset(&arena)
+	if err != nil {
+		panic(err)
+	}
+	root, err = capnp.NewRootStruct(seg, capnp.ObjectSize{PointerCount: 1})
+	if err != nil {
+		panic(err)
+	}
+	if err := root.SetText(0, "second"); err != nil {
+		panic(err)
+	}
+	p, err := root.Ptr(0)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(p.Text())
+
+	// Output:
+	// second
+}

--- a/arena_external_test.go
+++ b/arena_external_test.go
@@ -1,10 +1,17 @@
 package capnp_test
 
 import (
+	"bytes"
+	"errors"
 	"testing"
 
 	"capnproto.org/go/capnp/v3"
+	air "capnproto.org/go/capnp/v3/internal/aircraftlib"
 )
+
+const fixedArenaText = "fixed arena text"
+
+var fixedArenaTextBytes = []byte(fixedArenaText)
 
 type externalArena struct {
 	segs []*capnp.Segment
@@ -79,5 +86,168 @@ func TestExternalArena(t *testing.T) {
 	}
 	if got.Struct().Uint64(0) != 42 {
 		t.Errorf("decoded child data = %d; want 42", got.Struct().Uint64(0))
+	}
+}
+
+func TestFixedArenaReset(t *testing.T) {
+	var backing [128]byte
+	arena := newFixedArena(backing[:])
+	msg, seg, err := capnp.NewMessage(&arena)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, text := range []string{"first", "second"} {
+		root, err := air.NewRootHoldsText(seg)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := root.SetTxt(text); err != nil {
+			t.Fatal(err)
+		}
+		got, err := root.Txt()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != text {
+			t.Errorf("root.Txt() = %q; want %q", got, text)
+		}
+		if got, want := &seg.Data()[0], &backing[0]; got != want {
+			t.Errorf("segment data starts at %p; want %p", got, want)
+		}
+		if got, want := cap(seg.Data()), cap(backing); got != want {
+			t.Errorf("segment data capacity = %d; want %d", got, want)
+		}
+
+		seg, err = msg.Reset(&arena)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func TestFixedArenaErrorsAndRecovery(t *testing.T) {
+	// HoldsText needs a root word (8 bytes), three pointers (24 bytes), and
+	// an 8-byte text allocation. The short text fits exactly; the long one does not.
+	var backing [40]byte
+	arena := newFixedArena(backing[:])
+	msg, seg, err := capnp.NewMessage(&arena)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	root, err := air.NewRootHoldsText(seg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := root.SetTxt("too long"); !errors.Is(err, errFixedArenaCapacity) {
+		t.Fatalf("SetTxt() error = %v; want errors.Is(err, errFixedArenaCapacity)", err)
+	}
+
+	seg, err = msg.Reset(&arena)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root, err = air.NewRootHoldsText(seg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := root.SetTxt("ok"); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := root.Txt(); err != nil || got != "ok" {
+		t.Errorf("root.Txt() = %q, %v; want %q, nil", got, err, "ok")
+	}
+
+	if _, _, err := arena.Allocate(0, msg, nil); !errors.Is(err, errFixedArenaSegment) {
+		t.Fatalf("Allocate(nil) error = %v; want errors.Is(err, errFixedArenaSegment)", err)
+	}
+	foreign := capnp.NewSegment(1, nil)
+	if _, _, err := arena.Allocate(0, msg, foreign); !errors.Is(err, errFixedArenaSegment) {
+		t.Fatalf("Allocate(foreign) error = %v; want errors.Is(err, errFixedArenaSegment)", err)
+	}
+}
+
+func TestFixedArenaAllocs(t *testing.T) {
+	var backing [128]byte
+	arena := newFixedArena(backing[:])
+	msg, _, err := capnp.NewMessage(&arena)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	seg, err := msg.Reset(&arena)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root, err := air.NewRootHoldsText(seg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := root.SetTxt(fixedArenaText); err != nil {
+		t.Fatal(err)
+	}
+	got, err := root.TxtBytes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, fixedArenaTextBytes) {
+		t.Fatalf("root.TxtBytes() = %q; want %q", got, fixedArenaTextBytes)
+	}
+
+	allocs := testing.AllocsPerRun(100, func() {
+		seg, err := msg.Reset(&arena)
+		if err != nil {
+			t.Fatal(err)
+		}
+		root, err := air.NewRootHoldsText(seg)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := root.SetTxt(fixedArenaText); err != nil {
+			t.Fatal(err)
+		}
+		got, err := root.TxtBytes()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(got, fixedArenaTextBytes) {
+			t.Fatalf("root.TxtBytes() = %q; want %q", got, fixedArenaTextBytes)
+		}
+	})
+	if allocs != 0 {
+		t.Errorf("allocations per run = %f; want 0", allocs)
+	}
+}
+
+func BenchmarkFixedArena(b *testing.B) {
+	var backing [128]byte
+	arena := newFixedArena(backing[:])
+	msg, _, err := capnp.NewMessage(&arena)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		seg, err := msg.Reset(&arena)
+		if err != nil {
+			b.Fatal(err)
+		}
+		root, err := air.NewRootHoldsText(seg)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if err := root.SetTxt(fixedArenaText); err != nil {
+			b.Fatal(err)
+		}
+		got, err := root.TxtBytes()
+		if err != nil {
+			b.Fatal(err)
+		}
+		if !bytes.Equal(got, fixedArenaTextBytes) {
+			b.Fatalf("root.TxtBytes() = %q; want %q", got, fixedArenaTextBytes)
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- clarify implementation-defined `Arena.Release` reuse semantics
- add a runnable caller-owned fixed-buffer Arena example
- add reset, capacity recovery, and zero-allocation regression coverage

## Verification
- `go test ./...`
- `go test -run 'ExampleArena|TestExternalArena|TestFixed' .`\n- `go test -run '^$' -bench 'BenchmarkFixedArena' -benchmem .`\n\nBenchmark on Apple M5 Max: 0 B/op, 0 allocs/op.