### PR TITLE
flowcontrol/bbr: add private gate-next actor foundation

### DIFF
--- a/flowcontrol/bbr/gate_state.go
+++ b/flowcontrol/bbr/gate_state.go
@@ -12,9 +12,9 @@ import (
 // its sole production owner.
 //
 // A reservation is provisional until it is acknowledged. A definitely-unsent
-// operation is removed from the active log so the actor can replay the suffix;
-// fatal completion preserves the first poison error and makes the controller
-// terminal.
+// operation is removed from the active log and reports replay to the actor;
+// surviving successors remain valid provisional entries. Fatal completion
+// preserves the first poison error and makes the controller terminal.
 type gateState struct {
 	nextID       uint64
 	reservations []*gateReservation
@@ -44,8 +44,9 @@ func (g *gateState) commit(size uint64) *gateReservation {
 }
 
 // complete records one terminal outcome. It returns true only for a
-// definitely-unsent reservation, which tells the actor it must rebuild its
-// provisional suffix before admitting another successor.
+// definitely-unsent reservation, which tells the actor it must replay that
+// operation before admitting another successor. Other provisional reservations
+// remain in the ledger and must not be committed again.
 func (g *gateState) complete(r *gateReservation, kind flowcontrol.MessageOutcomeKind, err error) (replay bool) {
 	if r == nil || r.state != gateReservationProvisional {
 		return false

--- a/flowcontrol/bbr/gate_state.go
+++ b/flowcontrol/bbr/gate_state.go
@@ -62,6 +62,7 @@ func (g *gateState) complete(r *gateReservation, kind flowcontrol.MessageOutcome
 		r.state = gateReservationPoisoned
 		g.poisonWith(err)
 	default:
+		r.state = gateReservationPoisoned
 		g.poisonWith(errors.New("bbr: invalid gate-next terminal outcome"))
 	}
 	return false

--- a/flowcontrol/bbr/gate_state.go
+++ b/flowcontrol/bbr/gate_state.go
@@ -36,6 +36,82 @@ type gateReservation struct {
 	state gateReservationState
 }
 
+type gateEventKind uint8
+
+const (
+	gateCommitEvent gateEventKind = iota
+	gateCompleteEvent
+	gatePoisonEvent
+)
+
+// gateEvent is private actor traffic. Its reply channel is buffered so the
+// actor never waits for a caller that has observed limiter shutdown.
+type gateEvent struct {
+	kind        gateEventKind
+	size        uint64
+	reservation *gateReservation
+	outcome     flowcontrol.MessageOutcomeKind
+	err         error
+	reply       chan gateEventResult
+}
+
+type gateEventResult struct {
+	reservation *gateReservation
+	replay      bool
+}
+
+func (l *Limiter) gateCommit(size uint64) (*gateReservation, error) {
+	result, err := l.gateEvent(gateEvent{kind: gateCommitEvent, size: size})
+	return result.reservation, err
+}
+
+func (l *Limiter) gateComplete(r *gateReservation, kind flowcontrol.MessageOutcomeKind, err error) (bool, error) {
+	result, eventErr := l.gateEvent(gateEvent{
+		kind:        gateCompleteEvent,
+		reservation: r,
+		outcome:     kind,
+		err:         err,
+	})
+	return result.replay, eventErr
+}
+
+func (l *Limiter) gatePoison(err error) error {
+	_, eventErr := l.gateEvent(gateEvent{kind: gatePoisonEvent, err: err})
+	return eventErr
+}
+
+func (l *Limiter) gateEvent(event gateEvent) (gateEventResult, error) {
+	event.reply = make(chan gateEventResult, 1)
+	select {
+	case <-l.ctx.Done():
+		return gateEventResult{}, l.ctx.Err()
+	case l.chGate <- event:
+	}
+	select {
+	case <-l.ctx.Done():
+		return gateEventResult{}, l.ctx.Err()
+	case result := <-event.reply:
+		return result, nil
+	}
+}
+
+func (l *Limiter) handleGateEvent(event gateEvent) {
+	var result gateEventResult
+	switch event.kind {
+	case gateCommitEvent:
+		if l.gate.poison == nil {
+			result.reservation = l.gate.commit(event.size)
+		}
+	case gateCompleteEvent:
+		result.replay = l.gate.complete(event.reservation, event.outcome, event.err)
+	case gatePoisonEvent:
+		l.gate.poisonWith(event.err)
+	default:
+		l.gate.poisonWith(errors.New("bbr: invalid gate-next event"))
+	}
+	event.reply <- result
+}
+
 func (g *gateState) commit(size uint64) *gateReservation {
 	g.nextID++
 	r := &gateReservation{id: g.nextID, size: size}

--- a/flowcontrol/bbr/gate_state.go
+++ b/flowcontrol/bbr/gate_state.go
@@ -1,0 +1,97 @@
+package bbr
+
+import (
+	"errors"
+
+	"capnproto.org/go/capnp/v3/flowcontrol"
+)
+
+// gateState is the actor-owned ledger for the GateNext adapter. It is kept
+// separate from the channel adapter so deterministic tests can exercise every
+// reservation transition without scheduling a goroutine. The Limiter actor is
+// its sole production owner.
+//
+// A reservation is provisional until it is acknowledged. A definitely-unsent
+// operation is removed from the active log so the actor can replay the suffix;
+// fatal completion preserves the first poison error and makes the controller
+// terminal.
+type gateState struct {
+	nextID       uint64
+	reservations []*gateReservation
+	poison       error
+}
+
+type gateReservationState uint8
+
+const (
+	gateReservationProvisional gateReservationState = iota
+	gateReservationAcknowledged
+	gateReservationAborted
+	gateReservationPoisoned
+)
+
+type gateReservation struct {
+	id    uint64
+	size  uint64
+	state gateReservationState
+}
+
+func (g *gateState) commit(size uint64) *gateReservation {
+	g.nextID++
+	r := &gateReservation{id: g.nextID, size: size}
+	g.reservations = append(g.reservations, r)
+	return r
+}
+
+// complete records one terminal outcome. It returns true only for a
+// definitely-unsent reservation, which tells the actor it must rebuild its
+// provisional suffix before admitting another successor.
+func (g *gateState) complete(r *gateReservation, kind flowcontrol.MessageOutcomeKind, err error) (replay bool) {
+	if r == nil || r.state != gateReservationProvisional {
+		return false
+	}
+	switch kind {
+	case flowcontrol.MessageOutcomeSucceeded:
+		r.state = gateReservationAcknowledged
+		g.compactAcknowledgedPrefix()
+	case flowcontrol.MessageOutcomeAbortedBeforeEnqueue:
+		r.state = gateReservationAborted
+		g.remove(r)
+		return true
+	case flowcontrol.MessageOutcomeFatal, flowcontrol.MessageOutcomeFailedAfterEnqueue:
+		r.state = gateReservationPoisoned
+		g.poisonWith(err)
+	default:
+		g.poisonWith(errors.New("bbr: invalid gate-next terminal outcome"))
+	}
+	return false
+}
+
+func (g *gateState) poisonWith(err error) {
+	if g.poison != nil {
+		return
+	}
+	if err == nil {
+		err = errors.New("bbr: gate-next poisoned")
+	}
+	g.poison = err
+}
+
+func (g *gateState) remove(r *gateReservation) {
+	for i, candidate := range g.reservations {
+		if candidate != r {
+			continue
+		}
+		copy(g.reservations[i:], g.reservations[i+1:])
+		g.reservations[len(g.reservations)-1] = nil
+		g.reservations = g.reservations[:len(g.reservations)-1]
+		return
+	}
+}
+
+func (g *gateState) compactAcknowledgedPrefix() {
+	for len(g.reservations) > 0 && g.reservations[0].state == gateReservationAcknowledged {
+		g.reservations[0] = nil
+		g.reservations = g.reservations[1:]
+	}
+}

--- a/flowcontrol/bbr/gate_state.go
+++ b/flowcontrol/bbr/gate_state.go
@@ -58,10 +58,14 @@ type gateEvent struct {
 type gateEventResult struct {
 	reservation *gateReservation
 	replay      bool
+	err         error
 }
 
 func (l *Limiter) gateCommit(size uint64) (*gateReservation, error) {
 	result, err := l.gateEvent(gateEvent{kind: gateCommitEvent, size: size})
+	if err == nil {
+		err = result.err
+	}
 	return result.reservation, err
 }
 
@@ -101,6 +105,8 @@ func (l *Limiter) handleGateEvent(event gateEvent) {
 	case gateCommitEvent:
 		if l.gate.poison == nil {
 			result.reservation = l.gate.commit(event.size)
+		} else {
+			result.err = l.gate.poison
 		}
 	case gateCompleteEvent:
 		result.replay = l.gate.complete(event.reservation, event.outcome, event.err)
@@ -124,7 +130,7 @@ func (g *gateState) commit(size uint64) *gateReservation {
 // operation before admitting another successor. Other provisional reservations
 // remain in the ledger and must not be committed again.
 func (g *gateState) complete(r *gateReservation, kind flowcontrol.MessageOutcomeKind, err error) (replay bool) {
-	if r == nil || r.state != gateReservationProvisional {
+	if g.poison != nil || r == nil || r.state != gateReservationProvisional {
 		return false
 	}
 	switch kind {

--- a/flowcontrol/bbr/gate_state.go
+++ b/flowcontrol/bbr/gate_state.go
@@ -1,6 +1,7 @@
 package bbr
 
 import (
+	"context"
 	"errors"
 
 	"capnproto.org/go/capnp/v3/flowcontrol"
@@ -18,6 +19,7 @@ import (
 type gateState struct {
 	nextID       uint64
 	reservations []*gateReservation
+	waiters      []*gateWaitAttempt
 	poison       error
 }
 
@@ -42,6 +44,9 @@ const (
 	gateCommitEvent gateEventKind = iota
 	gateCompleteEvent
 	gatePoisonEvent
+	gateWaitEvent
+	gateCancelWaitEvent
+	gateGrantWaitEvent
 )
 
 // gateEvent is private actor traffic. Its reply channel is buffered so the
@@ -53,12 +58,34 @@ type gateEvent struct {
 	outcome     flowcontrol.MessageOutcomeKind
 	err         error
 	reply       chan gateEventResult
+	waiter      *gateWaitAttempt
 }
 
 type gateEventResult struct {
 	reservation *gateReservation
 	replay      bool
 	err         error
+}
+
+type gateWaitState uint8
+
+const (
+	gateWaitWaiting gateWaitState = iota
+	gateWaitGranted
+	gateWaitCanceled
+	gateWaitFailed
+)
+
+// gateWaitAttempt represents one invocation of a retryable successor
+// permission. The actor alone changes state or sends result.
+type gateWaitAttempt struct {
+	reservation *gateReservation
+	state       gateWaitState
+	result      chan error
+}
+
+func newGateWaitAttempt(r *gateReservation) *gateWaitAttempt {
+	return &gateWaitAttempt{reservation: r, result: make(chan error, 1)}
 }
 
 func (l *Limiter) gateCommit(size uint64) (*gateReservation, error) {
@@ -82,6 +109,73 @@ func (l *Limiter) gateComplete(r *gateReservation, kind flowcontrol.MessageOutco
 func (l *Limiter) gatePoison(err error) error {
 	_, eventErr := l.gateEvent(gateEvent{kind: gatePoisonEvent, err: err})
 	return eventErr
+}
+
+// gateWait waits for one successor permission. Cancellation is resolved by
+// the actor: a canceled attempt is removed without consuming permission, while
+// a grant that won the race is returned as success.
+func (l *Limiter) gateWait(ctx context.Context, r *gateReservation) error {
+	a, err := l.gateStartWait(ctx, r)
+	if err != nil {
+		return err
+	}
+	return l.gateWaitResult(ctx, a)
+}
+
+func (l *Limiter) gateStartWait(ctx context.Context, r *gateReservation) (*gateWaitAttempt, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	a := newGateWaitAttempt(r)
+	event := gateEvent{kind: gateWaitEvent, waiter: a, reply: make(chan gateEventResult, 1)}
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-l.ctx.Done():
+		return nil, l.ctx.Err()
+	case l.chGate <- event:
+	}
+	select {
+	case result := <-event.reply:
+		if result.err != nil {
+			return nil, result.err
+		}
+	case <-ctx.Done():
+		return nil, l.gateCancelWait(a, ctx.Err())
+	case <-l.ctx.Done():
+		return nil, l.ctx.Err()
+	}
+	return a, nil
+}
+
+func (l *Limiter) gateWaitResult(ctx context.Context, a *gateWaitAttempt) error {
+	select {
+	case err := <-a.result:
+		return err
+	case <-ctx.Done():
+		return l.gateCancelWait(a, ctx.Err())
+	case <-l.ctx.Done():
+		return l.ctx.Err()
+	}
+}
+
+func (l *Limiter) gateCancelWait(a *gateWaitAttempt, cancelErr error) error {
+	result, err := l.gateEvent(gateEvent{
+		kind:   gateCancelWaitEvent,
+		waiter: a,
+		err:    cancelErr,
+	})
+	if err != nil {
+		return err
+	}
+	return result.err
+}
+
+// gateGrant is a private deterministic test seam. Production admission will
+// call the same actor transition once BBR's pacing/cwnd state permits it.
+func (l *Limiter) gateGrant(r *gateReservation) (bool, error) {
+	result, err := l.gateEvent(gateEvent{kind: gateGrantWaitEvent, reservation: r})
+	return result.replay, err
 }
 
 func (l *Limiter) gateEvent(event gateEvent) (gateEventResult, error) {
@@ -110,10 +204,19 @@ func (l *Limiter) handleGateEvent(event gateEvent) {
 		}
 	case gateCompleteEvent:
 		result.replay = l.gate.complete(event.reservation, event.outcome, event.err)
+		l.gate.failWaiters()
 	case gatePoisonEvent:
 		l.gate.poisonWith(event.err)
+		l.gate.failWaiters()
+	case gateWaitEvent:
+		result.err = l.gate.registerWait(event.waiter)
+	case gateCancelWaitEvent:
+		result.err = l.gate.cancelWait(event.waiter, event.err)
+	case gateGrantWaitEvent:
+		result.replay = l.gate.grantWait(event.reservation)
 	default:
 		l.gate.poisonWith(errors.New("bbr: invalid gate-next event"))
+		l.gate.failWaiters()
 	}
 	event.reply <- result
 }
@@ -159,6 +262,97 @@ func (g *gateState) poisonWith(err error) {
 		err = errors.New("bbr: gate-next poisoned")
 	}
 	g.poison = err
+}
+
+func (g *gateState) registerWait(a *gateWaitAttempt) error {
+	if a == nil || a.reservation == nil {
+		return errors.New("bbr: invalid gate-next wait")
+	}
+	if g.poison != nil {
+		return g.poison
+	}
+	if a.reservation.state != gateReservationProvisional && a.reservation.state != gateReservationAborted {
+		return errors.New("bbr: gate-next permission is no longer available")
+	}
+	for _, waiter := range g.waiters {
+		if waiter.reservation == a.reservation && waiter.state == gateWaitWaiting {
+			return errors.New("bbr: gate-next permission already has a waiter")
+		}
+	}
+	g.waiters = append(g.waiters, a)
+	return nil
+}
+
+func (g *gateState) cancelWait(a *gateWaitAttempt, err error) error {
+	if a == nil {
+		return errors.New("bbr: invalid gate-next wait")
+	}
+	switch a.state {
+	case gateWaitWaiting:
+		g.removeWait(a)
+		a.state = gateWaitCanceled
+		if err == nil {
+			err = context.Canceled
+		}
+		a.result <- err
+		return err
+	case gateWaitGranted:
+		return nil
+	case gateWaitCanceled:
+		return err
+	case gateWaitFailed:
+		if g.poison != nil {
+			return g.poison
+		}
+		return errors.New("bbr: gate-next wait failed")
+	default:
+		panic("bbr: invalid gate-next wait state")
+	}
+}
+
+// grantWait grants at most one retryable successor permission. The bool result
+// means a waiter was granted; it does not request reservation replay.
+func (g *gateState) grantWait(r *gateReservation) bool {
+	if g.poison != nil || r == nil {
+		return false
+	}
+	for _, a := range g.waiters {
+		if a.reservation != r || a.state != gateWaitWaiting {
+			continue
+		}
+		g.removeWait(a)
+		a.state = gateWaitGranted
+		a.result <- nil
+		return true
+	}
+	return false
+}
+
+func (g *gateState) failWaiters() {
+	if g.poison == nil {
+		return
+	}
+	for len(g.waiters) > 0 {
+		a := g.waiters[0]
+		g.removeWait(a)
+		if a.state != gateWaitWaiting {
+			continue
+		}
+		a.state = gateWaitFailed
+		a.result <- g.poison
+	}
+}
+
+func (g *gateState) removeWait(a *gateWaitAttempt) {
+	for i, waiter := range g.waiters {
+		if waiter != a {
+			continue
+		}
+		copy(g.waiters[i:], g.waiters[i+1:])
+		g.waiters[len(g.waiters)-1] = nil
+		g.waiters = g.waiters[:len(g.waiters)-1]
+		return
+	}
 }
 
 func (g *gateState) remove(r *gateReservation) {

--- a/flowcontrol/bbr/gate_state.go
+++ b/flowcontrol/bbr/gate_state.go
@@ -3,6 +3,7 @@ package bbr
 import (
 	"context"
 	"errors"
+	"time"
 
 	"capnproto.org/go/capnp/v3/flowcontrol"
 )
@@ -33,10 +34,22 @@ const (
 )
 
 type gateReservation struct {
-	id    uint64
-	size  uint64
-	state gateReservationState
+	id     uint64
+	size   uint64
+	state  gateReservationState
+	packet packetMeta
 }
+
+// gateCompleteAction tells the limiter actor which BBR lifecycle operation a
+// terminal reservation transition requires. gateState deliberately does not
+// mutate BBR state itself so it remains a timeless, actor-owned ledger.
+type gateCompleteAction uint8
+
+const (
+	gateActionNone gateCompleteAction = iota
+	gateActionAck
+	gateActionUnsend
+)
 
 type gateEventKind uint8
 
@@ -63,7 +76,8 @@ type gateEvent struct {
 
 type gateEventResult struct {
 	reservation *gateReservation
-	replay      bool
+	action      gateCompleteAction
+	granted     bool
 	err         error
 }
 
@@ -96,14 +110,14 @@ func (l *Limiter) gateCommit(size uint64) (*gateReservation, error) {
 	return result.reservation, err
 }
 
-func (l *Limiter) gateComplete(r *gateReservation, kind flowcontrol.MessageOutcomeKind, err error) (bool, error) {
+func (l *Limiter) gateComplete(r *gateReservation, kind flowcontrol.MessageOutcomeKind, err error) (gateCompleteAction, error) {
 	result, eventErr := l.gateEvent(gateEvent{
 		kind:        gateCompleteEvent,
 		reservation: r,
 		outcome:     kind,
 		err:         err,
 	})
-	return result.replay, eventErr
+	return result.action, eventErr
 }
 
 func (l *Limiter) gatePoison(err error) error {
@@ -175,7 +189,7 @@ func (l *Limiter) gateCancelWait(a *gateWaitAttempt, cancelErr error) error {
 // call the same actor transition once BBR's pacing/cwnd state permits it.
 func (l *Limiter) gateGrant(r *gateReservation) (bool, error) {
 	result, err := l.gateEvent(gateEvent{kind: gateGrantWaitEvent, reservation: r})
-	return result.replay, err
+	return result.granted, err
 }
 
 func (l *Limiter) gateEvent(event gateEvent) (gateEventResult, error) {
@@ -193,17 +207,24 @@ func (l *Limiter) gateEvent(event gateEvent) (gateEventResult, error) {
 	}
 }
 
-func (l *Limiter) handleGateEvent(event gateEvent) {
+func (l *Limiter) handleGateEvent(now time.Time, event gateEvent) {
 	var result gateEventResult
 	switch event.kind {
 	case gateCommitEvent:
 		if l.gate.poison == nil {
 			result.reservation = l.gate.commit(event.size)
+			result.reservation.packet = l.doSendAt(now, event.size)
 		} else {
 			result.err = l.gate.poison
 		}
 	case gateCompleteEvent:
-		result.replay = l.gate.complete(event.reservation, event.outcome, event.err)
+		result.action = l.gate.complete(event.reservation, event.outcome, event.err)
+		switch result.action {
+		case gateActionAck:
+			l.onAckAt(now, event.reservation.packet)
+		case gateActionUnsend:
+			l.unsend(event.reservation)
+		}
 		l.gate.failWaiters()
 	case gatePoisonEvent:
 		l.gate.poisonWith(event.err)
@@ -213,7 +234,7 @@ func (l *Limiter) handleGateEvent(event gateEvent) {
 	case gateCancelWaitEvent:
 		result.err = l.gate.cancelWait(event.waiter, event.err)
 	case gateGrantWaitEvent:
-		result.replay = l.gate.grantWait(event.reservation)
+		result.granted = l.gate.grantWait(event.reservation)
 	default:
 		l.gate.poisonWith(errors.New("bbr: invalid gate-next event"))
 		l.gate.failWaiters()
@@ -228,22 +249,22 @@ func (g *gateState) commit(size uint64) *gateReservation {
 	return r
 }
 
-// complete records one terminal outcome. It returns true only for a
-// definitely-unsent reservation, which tells the actor it must replay that
-// operation before admitting another successor. Other provisional reservations
-// remain in the ledger and must not be committed again.
-func (g *gateState) complete(r *gateReservation, kind flowcontrol.MessageOutcomeKind, err error) (replay bool) {
+// complete records one terminal outcome and returns the BBR lifecycle action
+// the owning limiter actor must apply. Other provisional reservations remain in
+// the ledger after an abort and must not be committed again.
+func (g *gateState) complete(r *gateReservation, kind flowcontrol.MessageOutcomeKind, err error) gateCompleteAction {
 	if g.poison != nil || r == nil || r.state != gateReservationProvisional {
-		return false
+		return gateActionNone
 	}
 	switch kind {
 	case flowcontrol.MessageOutcomeSucceeded:
 		r.state = gateReservationAcknowledged
 		g.compactAcknowledgedPrefix()
+		return gateActionAck
 	case flowcontrol.MessageOutcomeAbortedBeforeEnqueue:
 		r.state = gateReservationAborted
 		g.remove(r)
-		return true
+		return gateActionUnsend
 	case flowcontrol.MessageOutcomeFatal, flowcontrol.MessageOutcomeFailedAfterEnqueue:
 		r.state = gateReservationPoisoned
 		g.poisonWith(err)
@@ -251,7 +272,7 @@ func (g *gateState) complete(r *gateReservation, kind flowcontrol.MessageOutcome
 		r.state = gateReservationPoisoned
 		g.poisonWith(errors.New("bbr: invalid gate-next terminal outcome"))
 	}
-	return false
+	return gateActionNone
 }
 
 func (g *gateState) poisonWith(err error) {

--- a/flowcontrol/bbr/gate_state_test.go
+++ b/flowcontrol/bbr/gate_state_test.go
@@ -1,6 +1,7 @@
 package bbr
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -89,4 +90,31 @@ func TestGateStateInvalidOutcomePoisonsReservation(t *testing.T) {
 	assert.EqualError(t, g.poison, "bbr: invalid gate-next terminal outcome")
 	assert.False(t, g.complete(a, flowcontrol.MessageOutcomeAbortedBeforeEnqueue, nil))
 	assert.Same(t, a, g.reservations[0])
+}
+
+func TestGateEventsAreOwnedByLimiterActor(t *testing.T) {
+	lim := NewLimiter(nil)
+	defer lim.Release()
+
+	a, err := lim.gateCommit(10)
+	if !assert.NoError(t, err) {
+		return
+	}
+	assert.NotNil(t, a)
+	replay, err := lim.gateComplete(a, flowcontrol.MessageOutcomeAbortedBeforeEnqueue, nil)
+	assert.NoError(t, err)
+	assert.True(t, replay)
+
+	lim.whilePaused(func() {
+		assert.Empty(t, lim.gate.reservations)
+	})
+}
+
+func TestGateEventsFailAfterLimiterRelease(t *testing.T) {
+	lim := NewLimiter(nil)
+	lim.Release()
+	<-lim.done
+
+	_, err := lim.gateCommit(10)
+	assert.ErrorIs(t, err, context.Canceled)
 }

--- a/flowcontrol/bbr/gate_state_test.go
+++ b/flowcontrol/bbr/gate_state_test.go
@@ -185,3 +185,61 @@ func TestGateEventsInvalidKindPoisonsLedger(t *testing.T) {
 		assert.EqualError(t, lim.gate.poison, "bbr: invalid gate-next event")
 	})
 }
+
+func TestGateWaitCancellationDoesNotConsumePermission(t *testing.T) {
+	lim := NewLimiter(nil)
+	defer lim.Release()
+	r, err := lim.gateCommit(10)
+	if !assert.NoError(t, err) {
+		return
+	}
+	a, err := lim.gateStartWait(context.Background(), r)
+	if !assert.NoError(t, err) {
+		return
+	}
+	cancelErr := errors.New("canceled")
+	assert.ErrorIs(t, lim.gateCancelWait(a, cancelErr), cancelErr)
+	assert.ErrorIs(t, <-a.result, cancelErr)
+
+	retry, err := lim.gateStartWait(context.Background(), r)
+	if !assert.NoError(t, err) {
+		return
+	}
+	granted, err := lim.gateGrant(r)
+	assert.NoError(t, err)
+	assert.True(t, granted)
+	assert.NoError(t, <-retry.result)
+}
+
+func TestGatePoisonWakesWaitingAttempt(t *testing.T) {
+	lim := NewLimiter(nil)
+	defer lim.Release()
+	r, err := lim.gateCommit(10)
+	if !assert.NoError(t, err) {
+		return
+	}
+	a, err := lim.gateStartWait(context.Background(), r)
+	if !assert.NoError(t, err) {
+		return
+	}
+	poison := errors.New("poison")
+	assert.NoError(t, lim.gatePoison(poison))
+	assert.ErrorIs(t, <-a.result, poison)
+}
+
+func TestGateFatalCompletionWakesWaitingAttempt(t *testing.T) {
+	lim := NewLimiter(nil)
+	defer lim.Release()
+	r, err := lim.gateCommit(10)
+	if !assert.NoError(t, err) {
+		return
+	}
+	a, err := lim.gateStartWait(context.Background(), r)
+	if !assert.NoError(t, err) {
+		return
+	}
+	poison := errors.New("fatal")
+	_, err = lim.gateComplete(r, flowcontrol.MessageOutcomeFatal, poison)
+	assert.NoError(t, err)
+	assert.ErrorIs(t, <-a.result, poison)
+}

--- a/flowcontrol/bbr/gate_state_test.go
+++ b/flowcontrol/bbr/gate_state_test.go
@@ -1,0 +1,60 @@
+package bbr
+
+import (
+	"errors"
+	"testing"
+
+	"capnproto.org/go/capnp/v3/flowcontrol"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGateStateAbortRemovesReservationAndPreservesSuffix(t *testing.T) {
+	var g gateState
+	a := g.commit(10)
+	b := g.commit(20)
+
+	assert.True(t, g.complete(a, flowcontrol.MessageOutcomeAbortedBeforeEnqueue, nil))
+	if assert.Len(t, g.reservations, 1) {
+		assert.Same(t, b, g.reservations[0])
+		assert.Equal(t, gateReservationProvisional, b.state)
+	}
+}
+
+func TestGateStateAcknowledgedHolesCompactOnlyAtPrefix(t *testing.T) {
+	var g gateState
+	a := g.commit(10)
+	b := g.commit(20)
+	c := g.commit(30)
+
+	g.complete(b, flowcontrol.MessageOutcomeSucceeded, nil)
+	if assert.Len(t, g.reservations, 3) {
+		assert.Same(t, a, g.reservations[0])
+		assert.Same(t, b, g.reservations[1])
+		assert.Same(t, c, g.reservations[2])
+	}
+	g.complete(a, flowcontrol.MessageOutcomeSucceeded, nil)
+	if assert.Len(t, g.reservations, 1) {
+		assert.Same(t, c, g.reservations[0])
+	}
+}
+
+func TestGateStateFatalPreservesFirstPoison(t *testing.T) {
+	var g gateState
+	a := g.commit(10)
+	b := g.commit(20)
+	first := errors.New("first")
+
+	assert.False(t, g.complete(a, flowcontrol.MessageOutcomeFatal, first))
+	assert.False(t, g.complete(b, flowcontrol.MessageOutcomeFailedAfterEnqueue, errors.New("second")))
+	assert.ErrorIs(t, g.poison, first)
+}
+
+func TestGateStateTerminalCompletionIsIdempotent(t *testing.T) {
+	var g gateState
+	a := g.commit(10)
+
+	assert.True(t, g.complete(a, flowcontrol.MessageOutcomeAbortedBeforeEnqueue, nil))
+	assert.False(t, g.complete(a, flowcontrol.MessageOutcomeAbortedBeforeEnqueue, nil))
+	assert.Empty(t, g.reservations)
+}

--- a/flowcontrol/bbr/gate_state_test.go
+++ b/flowcontrol/bbr/gate_state_test.go
@@ -59,12 +59,34 @@ func TestGateStateTerminalCompletionIsIdempotent(t *testing.T) {
 	assert.Empty(t, g.reservations)
 }
 
+func TestGateStateContradictoryTerminalOutcomeIsIgnored(t *testing.T) {
+	var g gateState
+	a := g.commit(10)
+
+	assert.False(t, g.complete(a, flowcontrol.MessageOutcomeSucceeded, nil))
+	assert.False(t, g.complete(a, flowcontrol.MessageOutcomeFatal, errors.New("late")))
+	assert.NoError(t, g.poison)
+	assert.False(t, g.complete(a, flowcontrol.MessageOutcomeSucceeded, nil))
+}
+
+func TestGateStateNilAndPoisonedCompletionAreIdempotent(t *testing.T) {
+	var g gateState
+	assert.False(t, g.complete(nil, flowcontrol.MessageOutcomeFatal, errors.New("ignored")))
+
+	a := g.commit(10)
+	assert.False(t, g.complete(a, flowcontrol.MessageOutcomeFatal, nil))
+	assert.EqualError(t, g.poison, "bbr: gate-next poisoned")
+	assert.False(t, g.complete(a, flowcontrol.MessageOutcomeFatal, errors.New("late")))
+	assert.EqualError(t, g.poison, "bbr: gate-next poisoned")
+}
+
 func TestGateStateInvalidOutcomePoisonsReservation(t *testing.T) {
 	var g gateState
 	a := g.commit(10)
 
 	assert.False(t, g.complete(a, flowcontrol.MessageOutcomeUnknown, nil))
 	assert.Equal(t, gateReservationPoisoned, a.state)
+	assert.EqualError(t, g.poison, "bbr: invalid gate-next terminal outcome")
 	assert.False(t, g.complete(a, flowcontrol.MessageOutcomeAbortedBeforeEnqueue, nil))
 	assert.Same(t, a, g.reservations[0])
 }

--- a/flowcontrol/bbr/gate_state_test.go
+++ b/flowcontrol/bbr/gate_state_test.go
@@ -3,9 +3,12 @@ package bbr
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"testing"
+	"time"
 
+	"capnproto.org/go/capnp/v3/exp/clock"
 	"capnproto.org/go/capnp/v3/flowcontrol"
 
 	"github.com/stretchr/testify/assert"
@@ -16,7 +19,7 @@ func TestGateStateAbortRemovesReservationAndPreservesSuffix(t *testing.T) {
 	a := g.commit(10)
 	b := g.commit(20)
 
-	assert.True(t, g.complete(a, flowcontrol.MessageOutcomeAbortedBeforeEnqueue, nil))
+	assert.Equal(t, gateActionUnsend, g.complete(a, flowcontrol.MessageOutcomeAbortedBeforeEnqueue, nil))
 	if assert.Len(t, g.reservations, 1) {
 		assert.Same(t, b, g.reservations[0])
 		assert.Equal(t, gateReservationProvisional, b.state)
@@ -47,8 +50,8 @@ func TestGateStateFatalPreservesFirstPoison(t *testing.T) {
 	b := g.commit(20)
 	first := errors.New("first")
 
-	assert.False(t, g.complete(a, flowcontrol.MessageOutcomeFatal, first))
-	assert.False(t, g.complete(b, flowcontrol.MessageOutcomeFailedAfterEnqueue, errors.New("second")))
+	assert.Equal(t, gateActionNone, g.complete(a, flowcontrol.MessageOutcomeFatal, first))
+	assert.Equal(t, gateActionNone, g.complete(b, flowcontrol.MessageOutcomeFailedAfterEnqueue, errors.New("second")))
 	assert.ErrorIs(t, g.poison, first)
 }
 
@@ -56,8 +59,8 @@ func TestGateStateTerminalCompletionIsIdempotent(t *testing.T) {
 	var g gateState
 	a := g.commit(10)
 
-	assert.True(t, g.complete(a, flowcontrol.MessageOutcomeAbortedBeforeEnqueue, nil))
-	assert.False(t, g.complete(a, flowcontrol.MessageOutcomeAbortedBeforeEnqueue, nil))
+	assert.Equal(t, gateActionUnsend, g.complete(a, flowcontrol.MessageOutcomeAbortedBeforeEnqueue, nil))
+	assert.Equal(t, gateActionNone, g.complete(a, flowcontrol.MessageOutcomeAbortedBeforeEnqueue, nil))
 	assert.Empty(t, g.reservations)
 }
 
@@ -65,20 +68,20 @@ func TestGateStateContradictoryTerminalOutcomeIsIgnored(t *testing.T) {
 	var g gateState
 	a := g.commit(10)
 
-	assert.False(t, g.complete(a, flowcontrol.MessageOutcomeSucceeded, nil))
-	assert.False(t, g.complete(a, flowcontrol.MessageOutcomeFatal, errors.New("late")))
+	assert.Equal(t, gateActionAck, g.complete(a, flowcontrol.MessageOutcomeSucceeded, nil))
+	assert.Equal(t, gateActionNone, g.complete(a, flowcontrol.MessageOutcomeFatal, errors.New("late")))
 	assert.NoError(t, g.poison)
-	assert.False(t, g.complete(a, flowcontrol.MessageOutcomeSucceeded, nil))
+	assert.Equal(t, gateActionNone, g.complete(a, flowcontrol.MessageOutcomeSucceeded, nil))
 }
 
 func TestGateStateNilAndPoisonedCompletionAreIdempotent(t *testing.T) {
 	var g gateState
-	assert.False(t, g.complete(nil, flowcontrol.MessageOutcomeFatal, errors.New("ignored")))
+	assert.Equal(t, gateActionNone, g.complete(nil, flowcontrol.MessageOutcomeFatal, errors.New("ignored")))
 
 	a := g.commit(10)
-	assert.False(t, g.complete(a, flowcontrol.MessageOutcomeFatal, nil))
+	assert.Equal(t, gateActionNone, g.complete(a, flowcontrol.MessageOutcomeFatal, nil))
 	assert.EqualError(t, g.poison, "bbr: gate-next poisoned")
-	assert.False(t, g.complete(a, flowcontrol.MessageOutcomeFatal, errors.New("late")))
+	assert.Equal(t, gateActionNone, g.complete(a, flowcontrol.MessageOutcomeFatal, errors.New("late")))
 	assert.EqualError(t, g.poison, "bbr: gate-next poisoned")
 }
 
@@ -86,10 +89,10 @@ func TestGateStateInvalidOutcomePoisonsReservation(t *testing.T) {
 	var g gateState
 	a := g.commit(10)
 
-	assert.False(t, g.complete(a, flowcontrol.MessageOutcomeUnknown, nil))
+	assert.Equal(t, gateActionNone, g.complete(a, flowcontrol.MessageOutcomeUnknown, nil))
 	assert.Equal(t, gateReservationPoisoned, a.state)
 	assert.EqualError(t, g.poison, "bbr: invalid gate-next terminal outcome")
-	assert.False(t, g.complete(a, flowcontrol.MessageOutcomeAbortedBeforeEnqueue, nil))
+	assert.Equal(t, gateActionNone, g.complete(a, flowcontrol.MessageOutcomeAbortedBeforeEnqueue, nil))
 	assert.Same(t, a, g.reservations[0])
 }
 
@@ -102,9 +105,9 @@ func TestGateEventsAreOwnedByLimiterActor(t *testing.T) {
 		return
 	}
 	assert.NotNil(t, a)
-	replay, err := lim.gateComplete(a, flowcontrol.MessageOutcomeAbortedBeforeEnqueue, nil)
+	action, err := lim.gateComplete(a, flowcontrol.MessageOutcomeAbortedBeforeEnqueue, nil)
 	assert.NoError(t, err)
-	assert.True(t, replay)
+	assert.Equal(t, gateActionUnsend, action)
 
 	lim.whilePaused(func() {
 		assert.Empty(t, lim.gate.reservations)
@@ -132,14 +135,14 @@ func TestGateEventsPoisonRejectsCommitAndReplay(t *testing.T) {
 		return
 	}
 	poison := errors.New("poison")
-	replay, err := lim.gateComplete(a, flowcontrol.MessageOutcomeFatal, poison)
+	action, err := lim.gateComplete(a, flowcontrol.MessageOutcomeFatal, poison)
 	assert.NoError(t, err)
-	assert.False(t, replay)
+	assert.Equal(t, gateActionNone, action)
 	_, err = lim.gateCommit(30)
 	assert.ErrorIs(t, err, poison)
-	replay, err = lim.gateComplete(b, flowcontrol.MessageOutcomeAbortedBeforeEnqueue, nil)
+	action, err = lim.gateComplete(b, flowcontrol.MessageOutcomeAbortedBeforeEnqueue, nil)
 	assert.NoError(t, err)
-	assert.False(t, replay)
+	assert.Equal(t, gateActionNone, action)
 }
 
 func TestGateEventsSerializeConcurrentCommits(t *testing.T) {
@@ -242,4 +245,99 @@ func TestGateFatalCompletionWakesWaitingAttempt(t *testing.T) {
 	_, err = lim.gateComplete(r, flowcontrol.MessageOutcomeFatal, poison)
 	assert.NoError(t, err)
 	assert.ErrorIs(t, <-a.result, poison)
+}
+
+func TestGateCommitChargesAndSuccessAcknowledgesBBR(t *testing.T) {
+	now := time.Unix(1, 0)
+	lim := newLimiterState(clock.NewManual(now), limiterOptions{})
+	commit := applyGateEvent(lim, now, gateEvent{kind: gateCommitEvent, size: 10})
+	r := commit.reservation
+	if !assert.NotNil(t, r) {
+		return
+	}
+	assert.Equal(t, uint64(10), r.packet.Size)
+	assert.Equal(t, now, r.packet.SendTime)
+	assert.Equal(t, uint64(10), lim.inflight())
+	assert.Equal(t, uint64(1), lim.packetsInflight)
+
+	ack := applyGateEvent(lim, now.Add(time.Millisecond), gateEvent{
+		kind:        gateCompleteEvent,
+		reservation: r,
+		outcome:     flowcontrol.MessageOutcomeSucceeded,
+	})
+	assert.Equal(t, gateActionAck, ack.action)
+	assert.Zero(t, lim.inflight())
+	assert.Zero(t, lim.packetsInflight)
+	assert.Equal(t, uint64(10), lim.delivered)
+}
+
+func TestGateAbortReversesOnlyOnWireAccounting(t *testing.T) {
+	now := time.Unix(1, 0)
+	lim := newLimiterState(clock.NewManual(now), limiterOptions{})
+	a := applyGateEvent(lim, now, gateEvent{kind: gateCommitEvent, size: 10}).reservation
+	b := applyGateEvent(lim, now, gateEvent{kind: gateCommitEvent, size: 20}).reservation
+	nextSendTime := lim.nextSendTime
+	pacingReady := lim.pacingReady
+	delivered := lim.delivered
+	stateType := fmt.Sprintf("%T", lim.state)
+
+	abort := applyGateEvent(lim, now, gateEvent{
+		kind:        gateCompleteEvent,
+		reservation: a,
+		outcome:     flowcontrol.MessageOutcomeAbortedBeforeEnqueue,
+	})
+	assert.Equal(t, gateActionUnsend, abort.action)
+	assert.Equal(t, uint64(20), lim.sent)
+	assert.Equal(t, uint64(1), lim.packetsInflight)
+	assert.Equal(t, uint64(20), lim.inflight())
+	assert.Equal(t, nextSendTime, lim.nextSendTime)
+	assert.Equal(t, pacingReady, lim.pacingReady)
+	assert.Equal(t, delivered, lim.delivered)
+	assert.Equal(t, stateType, fmt.Sprintf("%T", lim.state))
+	assert.Same(t, b, lim.gate.reservations[0])
+}
+
+func TestGateAbortOfLaterReservationDoesNotBreakEarlierAck(t *testing.T) {
+	now := time.Unix(1, 0)
+	lim := newLimiterState(clock.NewManual(now), limiterOptions{})
+	a := applyGateEvent(lim, now, gateEvent{kind: gateCommitEvent, size: 10}).reservation
+	b := applyGateEvent(lim, now, gateEvent{kind: gateCommitEvent, size: 20}).reservation
+
+	abort := applyGateEvent(lim, now, gateEvent{
+		kind:        gateCompleteEvent,
+		reservation: b,
+		outcome:     flowcontrol.MessageOutcomeAbortedBeforeEnqueue,
+	})
+	assert.Equal(t, gateActionUnsend, abort.action)
+	ack := applyGateEvent(lim, now.Add(time.Millisecond), gateEvent{
+		kind:        gateCompleteEvent,
+		reservation: a,
+		outcome:     flowcontrol.MessageOutcomeSucceeded,
+	})
+	assert.Equal(t, gateActionAck, ack.action)
+	assert.Zero(t, lim.inflight())
+	assert.Zero(t, lim.packetsInflight)
+	assert.Equal(t, uint64(10), lim.delivered)
+}
+
+func TestGateFatalDoesNotAcknowledgeOrUnsendBBR(t *testing.T) {
+	now := time.Unix(1, 0)
+	lim := newLimiterState(clock.NewManual(now), limiterOptions{})
+	r := applyGateEvent(lim, now, gateEvent{kind: gateCommitEvent, size: 10}).reservation
+	action := applyGateEvent(lim, now, gateEvent{
+		kind:        gateCompleteEvent,
+		reservation: r,
+		outcome:     flowcontrol.MessageOutcomeFatal,
+		err:         errors.New("fatal"),
+	}).action
+	assert.Equal(t, gateActionNone, action)
+	assert.Equal(t, uint64(10), lim.inflight())
+	assert.Equal(t, uint64(1), lim.packetsInflight)
+	assert.Zero(t, lim.delivered)
+}
+
+func applyGateEvent(lim *Limiter, now time.Time, event gateEvent) gateEventResult {
+	event.reply = make(chan gateEventResult, 1)
+	lim.handleGateEvent(now, event)
+	return <-event.reply
 }

--- a/flowcontrol/bbr/gate_state_test.go
+++ b/flowcontrol/bbr/gate_state_test.go
@@ -3,6 +3,7 @@ package bbr
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 
 	"capnproto.org/go/capnp/v3/flowcontrol"
@@ -117,4 +118,70 @@ func TestGateEventsFailAfterLimiterRelease(t *testing.T) {
 
 	_, err := lim.gateCommit(10)
 	assert.ErrorIs(t, err, context.Canceled)
+}
+
+func TestGateEventsPoisonRejectsCommitAndReplay(t *testing.T) {
+	lim := NewLimiter(nil)
+	defer lim.Release()
+	a, err := lim.gateCommit(10)
+	if !assert.NoError(t, err) {
+		return
+	}
+	b, err := lim.gateCommit(20)
+	if !assert.NoError(t, err) {
+		return
+	}
+	poison := errors.New("poison")
+	replay, err := lim.gateComplete(a, flowcontrol.MessageOutcomeFatal, poison)
+	assert.NoError(t, err)
+	assert.False(t, replay)
+	_, err = lim.gateCommit(30)
+	assert.ErrorIs(t, err, poison)
+	replay, err = lim.gateComplete(b, flowcontrol.MessageOutcomeAbortedBeforeEnqueue, nil)
+	assert.NoError(t, err)
+	assert.False(t, replay)
+}
+
+func TestGateEventsSerializeConcurrentCommits(t *testing.T) {
+	lim := NewLimiter(nil)
+	defer lim.Release()
+	const n = 16
+	ids := make(chan uint64, n)
+	errs := make(chan error, n)
+	var wg sync.WaitGroup
+	for range n {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			r, err := lim.gateCommit(1)
+			if err == nil {
+				ids <- r.id
+			}
+			errs <- err
+		}()
+	}
+	wg.Wait()
+	close(ids)
+	close(errs)
+	seen := make(map[uint64]struct{}, n)
+	for err := range errs {
+		assert.NoError(t, err)
+	}
+	for id := range ids {
+		if _, ok := seen[id]; !assert.False(t, ok, "duplicate id %d", id) {
+			continue
+		}
+		seen[id] = struct{}{}
+	}
+	assert.Len(t, seen, n)
+}
+
+func TestGateEventsInvalidKindPoisonsLedger(t *testing.T) {
+	lim := NewLimiter(nil)
+	defer lim.Release()
+	_, err := lim.gateEvent(gateEvent{kind: gateEventKind(99)})
+	assert.NoError(t, err)
+	lim.whilePaused(func() {
+		assert.EqualError(t, lim.gate.poison, "bbr: invalid gate-next event")
+	})
 }

--- a/flowcontrol/bbr/gate_state_test.go
+++ b/flowcontrol/bbr/gate_state_test.go
@@ -247,6 +247,64 @@ func TestGateFatalCompletionWakesWaitingAttempt(t *testing.T) {
 	assert.ErrorIs(t, <-a.result, poison)
 }
 
+func TestGateWaitResultGrantWinsCanceledCaller(t *testing.T) {
+	lim := NewLimiter(nil)
+	defer lim.Release()
+	r, err := lim.gateCommit(10)
+	if !assert.NoError(t, err) {
+		return
+	}
+	a, err := lim.gateStartWait(context.Background(), r)
+	if !assert.NoError(t, err) {
+		return
+	}
+	granted, err := lim.gateGrant(r)
+	if !assert.NoError(t, err) || !assert.True(t, granted) {
+		return
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	assert.NoError(t, lim.gateWaitResult(ctx, a))
+}
+
+func TestGateWaitRegistrationRejectsDuplicateAndTerminalReservation(t *testing.T) {
+	lim := NewLimiter(nil)
+	defer lim.Release()
+	r, err := lim.gateCommit(10)
+	if !assert.NoError(t, err) {
+		return
+	}
+	_, err = lim.gateStartWait(context.Background(), r)
+	assert.NoError(t, err)
+	_, err = lim.gateStartWait(context.Background(), r)
+	assert.EqualError(t, err, "bbr: gate-next permission already has a waiter")
+
+	terminal, err := lim.gateCommit(20)
+	if !assert.NoError(t, err) {
+		return
+	}
+	_, err = lim.gateComplete(terminal, flowcontrol.MessageOutcomeSucceeded, nil)
+	assert.NoError(t, err)
+	_, err = lim.gateStartWait(context.Background(), terminal)
+	assert.EqualError(t, err, "bbr: gate-next permission is no longer available")
+}
+
+func TestGateGrantRejectsMissingAndPoisonedWaiter(t *testing.T) {
+	lim := NewLimiter(nil)
+	defer lim.Release()
+	r, err := lim.gateCommit(10)
+	if !assert.NoError(t, err) {
+		return
+	}
+	granted, err := lim.gateGrant(r)
+	assert.NoError(t, err)
+	assert.False(t, granted)
+	assert.NoError(t, lim.gatePoison(errors.New("poison")))
+	granted, err = lim.gateGrant(r)
+	assert.NoError(t, err)
+	assert.False(t, granted)
+}
+
 func TestGateCommitChargesAndSuccessAcknowledgesBBR(t *testing.T) {
 	now := time.Unix(1, 0)
 	lim := newLimiterState(clock.NewManual(now), limiterOptions{})

--- a/flowcontrol/bbr/gate_state_test.go
+++ b/flowcontrol/bbr/gate_state_test.go
@@ -58,3 +58,13 @@ func TestGateStateTerminalCompletionIsIdempotent(t *testing.T) {
 	assert.False(t, g.complete(a, flowcontrol.MessageOutcomeAbortedBeforeEnqueue, nil))
 	assert.Empty(t, g.reservations)
 }
+
+func TestGateStateInvalidOutcomePoisonsReservation(t *testing.T) {
+	var g gateState
+	a := g.commit(10)
+
+	assert.False(t, g.complete(a, flowcontrol.MessageOutcomeUnknown, nil))
+	assert.Equal(t, gateReservationPoisoned, a.state)
+	assert.False(t, g.complete(a, flowcontrol.MessageOutcomeAbortedBeforeEnqueue, nil))
+	assert.Same(t, a, g.reservations[0])
+}

--- a/flowcontrol/bbr/limiter.go
+++ b/flowcontrol/bbr/limiter.go
@@ -188,6 +188,8 @@ func (l *Limiter) run(ctx context.Context) {
 			event = limiterEvent{kind: limiterSendEvent, size: req.size}
 			replyChan = req.replyChan
 			handleEvent = true
+		case gateEvent := <-l.chGate:
+			l.handleGateEvent(gateEvent)
 		case <-l.chPause:
 			paused = true
 		}
@@ -304,6 +306,11 @@ type Limiter struct {
 
 	// Private test seam for deterministic ProbeBW initialization.
 	randInt func() int
+
+	// Private actor-owned GateNext reservation ledger. It is not exposed until
+	// the capnp admission surface is complete.
+	gate   gateState
+	chGate chan gateEvent
 }
 
 // For testing purpoes; temporarily pauses the goroutine managing the limiter,
@@ -361,6 +368,7 @@ func newLimiterState(clk clock.Clock, options limiterOptions) *Limiter {
 
 		chSend: make(chan sendRequest),
 		chAck:  make(chan packetMeta),
+		chGate: make(chan gateEvent),
 
 		rtPropFilter: newRtPropFilter(),
 		btlBwFilter:  newBtlBwFilter(),

--- a/flowcontrol/bbr/limiter.go
+++ b/flowcontrol/bbr/limiter.go
@@ -189,7 +189,7 @@ func (l *Limiter) run(ctx context.Context) {
 			replyChan = req.replyChan
 			handleEvent = true
 		case gateEvent := <-l.chGate:
-			l.handleGateEvent(gateEvent)
+			l.handleGateEvent(l.clock.Now(), gateEvent)
 		case <-l.chPause:
 			paused = true
 		}
@@ -227,6 +227,18 @@ func (l *Limiter) doSendAt(now time.Time, size uint64) packetMeta {
 	))
 	l.sent += size
 	return p
+}
+
+// unsend reverses the on-wire accounting for a definitely-unsent GateNext
+// reservation. Pacing and filter state intentionally remain monotone: rolling
+// them back after later commits would be unreconstructable and less
+// conservative than leaving the existing pacing deadline in place.
+func (l *Limiter) unsend(r *gateReservation) {
+	if r == nil || l.packetsInflight == 0 || r.size > l.sent-l.delivered {
+		panic("bbr: invalid gate-next unsend")
+	}
+	l.packetsInflight--
+	l.sent -= r.size
 }
 
 // A Limiter implements flowcontrol.FlowLimiter using the BBR algorithm.

--- a/flowcontrol/bbr/limiter.go
+++ b/flowcontrol/bbr/limiter.go
@@ -232,7 +232,9 @@ func (l *Limiter) doSendAt(now time.Time, size uint64) packetMeta {
 // unsend reverses the on-wire accounting for a definitely-unsent GateNext
 // reservation. Pacing and filter state intentionally remain monotone: rolling
 // them back after later commits would be unreconstructable and less
-// conservative than leaving the existing pacing deadline in place.
+// conservative than leaving the existing pacing deadline in place. In
+// particular, a probeRTTState that captured sent before this reversal can stay
+// in probeRTT until later delivery crosses that conservative snapshot.
 func (l *Limiter) unsend(r *gateReservation) {
 	if r == nil || l.packetsInflight == 0 || r.size > l.sent-l.delivered {
 		panic("bbr: invalid gate-next unsend")


### PR DESCRIPTION
Adds the private, actor-owned BBR GateNext foundation without exposing bbr.Limiter.GateNext or activating any RPC path.

Includes reservation accounting, retryable wait attempts, terminal/poison handling, and deterministic BBR lifecycle tests. Production window-gated admission and RPC activation remain deferred to subsequent PRs.