### PR TITLE
capnp: add dormant prepared-send admission mechanics

### DIFF
--- a/answer.go
+++ b/answer.go
@@ -298,12 +298,13 @@ func (c *pipelineCallClaim) Done() {
 // Promise. A successful claim increments ongoingCalls; callers must defer
 // claim.Done. Once resolution has started, no claim is made and the returned
 // state tells the caller whether to wait for or use the resolved target.
-func (p *Promise) claimPipelineCall(expected PipelineCaller) (*pipelineCallClaim, pipelineResolutionState) {
+func (p *Promise) claimPipelineCall(expected pipelineAdmissionController) (*pipelineCallClaim, pipelineResolutionState) {
 	l := p.state.Lock()
 	defer l.Unlock()
 	s := l.Value()
 	if s.isUnresolved() {
-		if s.caller != expected {
+		current, ok := s.caller.(pipelineAdmissionController)
+		if !ok || current != expected {
 			panic("pipeline call claimed by non-current controller")
 		}
 		s.ongoingCalls++

--- a/answer.go
+++ b/answer.go
@@ -267,8 +267,10 @@ type PipelineCaller interface {
 // predecessor's permission without holding Promise resolution open.
 type pipelineAdmissionController interface {
 	PipelineCaller
-	pipelineAdmissionController()
+	pipelineAdmissionToken() *pipelineAdmissionToken
 }
+
+type pipelineAdmissionToken struct{ _ byte }
 
 // pipelineResolutionState reports the result of a late pipeline-call claim.
 // A caller that loses the claim because resolution has begun must use the
@@ -304,7 +306,8 @@ func (p *Promise) claimPipelineCall(expected pipelineAdmissionController) (*pipe
 	s := l.Value()
 	if s.isUnresolved() {
 		current, ok := s.caller.(pipelineAdmissionController)
-		if !ok || current != expected {
+		expectedToken := expected.pipelineAdmissionToken()
+		if !ok || expectedToken == nil || current.pipelineAdmissionToken() != expectedToken {
 			panic("pipeline call claimed by non-current controller")
 		}
 		s.ongoingCalls++

--- a/answer.go
+++ b/answer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"strconv"
+	"sync"
 
 	"capnproto.org/go/capnp/v3/exc"
 	"capnproto.org/go/capnp/v3/flowcontrol"
@@ -255,6 +256,63 @@ func (p *Promise) ReleaseClients() {
 type PipelineCaller interface {
 	PipelineSend(ctx context.Context, transform []PipelineOp, s Send) (*Answer, ReleaseFunc)
 	PipelineRecv(ctx context.Context, transform []PipelineOp, r Recv) PipelineCaller
+}
+
+// pipelineAdmissionController marks a PipelineCaller that performs admission
+// before delegating a pipelined send. It is private so only the capnp package
+// can opt into the late-claim protocol.
+//
+// The marker is intentionally dormant until the admitted RPC pipeline wrapper
+// is installed. Keeping the protocol private lets that wrapper wait for a
+// predecessor's permission without holding Promise resolution open.
+type pipelineAdmissionController interface {
+	PipelineCaller
+	pipelineAdmissionController()
+}
+
+// pipelineResolutionState reports the result of a late pipeline-call claim.
+// A caller that loses the claim because resolution has begun must use the
+// Promise's resolved-client path instead of the old pipeline caller.
+type pipelineResolutionState uint8
+
+const (
+	pipelineUnresolved pipelineResolutionState = iota
+	pipelinePendingResolution
+	pipelineResolved
+)
+
+// pipelineCallClaim owns one admission counted in Promise.ongoingCalls.
+// Done is safe to call more than once, including from a panic defer.
+type pipelineCallClaim struct {
+	p    *Promise
+	done sync.Once
+}
+
+// Done releases the claim's admission.
+func (c *pipelineCallClaim) Done() {
+	c.done.Do(c.p.pipelineCallDone)
+}
+
+// claimPipelineCall atomically claims an unresolved Promise's current
+// PipelineCaller. expected must be the exact controller installed in the
+// Promise. A successful claim increments ongoingCalls; callers must defer
+// claim.Done. Once resolution has started, no claim is made and the returned
+// state tells the caller whether to wait for or use the resolved target.
+func (p *Promise) claimPipelineCall(expected PipelineCaller) (*pipelineCallClaim, pipelineResolutionState) {
+	l := p.state.Lock()
+	defer l.Unlock()
+	s := l.Value()
+	if s.isUnresolved() {
+		if s.caller != expected {
+			panic("pipeline call claimed by non-current controller")
+		}
+		s.ongoingCalls++
+		return &pipelineCallClaim{p: p}, pipelineUnresolved
+	}
+	if s.isPendingResolution() {
+		return nil, pipelinePendingResolution
+	}
+	return nil, pipelineResolved
 }
 
 // An Answer is a deferred result of a client call.  Conceptually, this is a

--- a/answer_claim_test.go
+++ b/answer_claim_test.go
@@ -1,0 +1,77 @@
+package capnp
+
+import (
+	"testing"
+)
+
+type testAdmissionPipelineCaller struct {
+	dummyPipelineCaller
+}
+
+func (*testAdmissionPipelineCaller) pipelineAdmissionController() {}
+
+var _ pipelineAdmissionController = (*testAdmissionPipelineCaller)(nil)
+
+func TestPromisePipelineCallClaimDrainsOnce(t *testing.T) {
+	caller := new(testAdmissionPipelineCaller)
+	resolverCalled := make(chan struct{})
+	p := NewPromise(Method{}, caller, signalingPtrResolver{called: resolverCalled})
+
+	claim, state := p.claimPipelineCall(caller)
+	if state != pipelineUnresolved || claim == nil {
+		t.Fatalf("claimPipelineCall = (%v, %v); want non-nil, unresolved", claim, state)
+	}
+
+	resolved := make(chan struct{})
+	go func() {
+		p.Resolve(Ptr{}, nil)
+		close(resolved)
+	}()
+	<-resolverCalled
+	select {
+	case <-resolved:
+		t.Fatal("Resolve returned while claim was outstanding")
+	default:
+	}
+
+	claim.Done()
+	claim.Done()
+	<-resolved
+}
+
+func TestPromisePipelineCallClaimReportsResolutionState(t *testing.T) {
+	t.Run("pending", func(t *testing.T) {
+		caller := new(testAdmissionPipelineCaller)
+		resolverCalled := make(chan struct{})
+		p := NewPromise(Method{}, caller, signalingPtrResolver{called: resolverCalled})
+		claim, state := p.claimPipelineCall(caller)
+		if state != pipelineUnresolved || claim == nil {
+			t.Fatalf("initial claim = (%v, %v); want non-nil, unresolved", claim, state)
+		}
+
+		resolved := make(chan struct{})
+		go func() {
+			p.Resolve(Ptr{}, nil)
+			close(resolved)
+		}()
+		<-resolverCalled
+
+		lateClaim, state := p.claimPipelineCall(caller)
+		if state != pipelinePendingResolution || lateClaim != nil {
+			t.Fatalf("claim during resolution = (%v, %v); want nil, pending", lateClaim, state)
+		}
+		claim.Done()
+		<-resolved
+	})
+
+	t.Run("resolved", func(t *testing.T) {
+		caller := new(testAdmissionPipelineCaller)
+		p := NewPromise(Method{}, caller, nil)
+		p.Resolve(Ptr{}, nil)
+
+		claim, state := p.claimPipelineCall(caller)
+		if state != pipelineResolved || claim != nil {
+			t.Fatalf("claim after resolution = (%v, %v); want nil, resolved", claim, state)
+		}
+	})
+}

--- a/answer_claim_test.go
+++ b/answer_claim_test.go
@@ -6,11 +6,26 @@ import (
 
 type testAdmissionPipelineCaller struct {
 	dummyPipelineCaller
+	token pipelineAdmissionToken
 }
 
-func (*testAdmissionPipelineCaller) pipelineAdmissionController() {}
+func (c *testAdmissionPipelineCaller) pipelineAdmissionToken() *pipelineAdmissionToken {
+	return &c.token
+}
 
 var _ pipelineAdmissionController = (*testAdmissionPipelineCaller)(nil)
+
+type nonComparableAdmissionPipelineCaller struct {
+	dummyPipelineCaller
+	token *pipelineAdmissionToken
+	data  []byte
+}
+
+func (c nonComparableAdmissionPipelineCaller) pipelineAdmissionToken() *pipelineAdmissionToken {
+	return c.token
+}
+
+var _ pipelineAdmissionController = nonComparableAdmissionPipelineCaller{}
 
 func TestPromisePipelineCallClaimDrainsOnce(t *testing.T) {
 	caller := new(testAdmissionPipelineCaller)
@@ -74,4 +89,18 @@ func TestPromisePipelineCallClaimReportsResolutionState(t *testing.T) {
 			t.Fatalf("claim after resolution = (%v, %v); want nil, resolved", claim, state)
 		}
 	})
+}
+
+func TestPromisePipelineCallClaimSupportsNonComparableController(t *testing.T) {
+	caller := nonComparableAdmissionPipelineCaller{
+		token: new(pipelineAdmissionToken),
+		data:  []byte{1},
+	}
+	p := NewPromise(Method{}, caller, nil)
+	claim, state := p.claimPipelineCall(caller)
+	if state != pipelineUnresolved || claim == nil {
+		t.Fatalf("claimPipelineCall = (%v, %v); want non-nil, unresolved", claim, state)
+	}
+	claim.Done()
+	p.Resolve(Ptr{}, nil)
 }

--- a/capability.go
+++ b/capability.go
@@ -601,41 +601,7 @@ func (c Client) sendCall(ctx context.Context, s Send) (*Answer, ReleaseFunc, err
 			ticket.finish()
 			return nil, nil, err
 		}
-		lim := ticket.gen.limiter
-		if rich, ok := lim.(flowcontrol.GateNextFlowLimiter); ok {
-			waitNext, complete := rich.GateNext().CommitMessage(prepared.Size())
-			ticket.publish(waitNext)
-			var terminalOnce sync.Once
-			terminal := func(kind flowcontrol.MessageOutcomeKind, e error) {
-				terminalOnce.Do(func() { complete(kind, e); ticket.finish() })
-			}
-			ans, rel, err := prepared.Commit(terminal)
-			if err != nil {
-				prepared.Abort()
-				terminal(flowcontrol.MessageOutcomeAbortedBeforeEnqueue, err)
-				return nil, nil, err
-			}
-			return ans, rel, nil
-		}
-		got, err := lim.StartMessage(ctx, prepared.Size())
-		if err != nil {
-			prepared.Abort()
-			ticket.publish(nil)
-			ticket.finish()
-			return nil, nil, err
-		}
-		ticket.publish(nil)
-		var terminalOnce sync.Once
-		terminal := func(flowcontrol.MessageOutcomeKind, error) {
-			terminalOnce.Do(func() { got(); ticket.finish() })
-		}
-		ans, rel, err := prepared.Commit(terminal)
-		if err != nil {
-			prepared.Abort()
-			terminal(flowcontrol.MessageOutcomeAbortedBeforeEnqueue, err)
-			return nil, nil, err
-		}
-		return ans, rel, nil
+		return admitPreparedSend(ctx, ticket, prepared)
 	}
 
 	limiter := ticket.gen.limiter
@@ -707,6 +673,89 @@ func (c Client) sendCall(ctx context.Context, s Send) (*Answer, ReleaseFunc, err
 		l.Unlock()
 	}
 
+	return ans, rel, nil
+}
+
+// admitPreparedSend commits a prepared send after ticket has consumed its
+// predecessor's permission. The ticket's successor is published only after
+// enqueueing, or after the reservation has been retired on a local failure.
+//
+// This helper is shared by direct prepared sends today and by the promised
+// pipeline admission wrapper once that wrapper is installed. It deliberately
+// leaves legacy ClientHook.Send behavior in sendCall unchanged.
+func admitPreparedSend(ctx context.Context, ticket *flowTicket, prepared PreparedSend) (ans *Answer, rel ReleaseFunc, err error) {
+	const (
+		preparedBeforeReservation = iota
+		preparedCommitInProgress
+		preparedCommitted
+	)
+	phase := preparedBeforeReservation
+	var waitNext func(context.Context) error
+	var terminal func(flowcontrol.MessageOutcomeKind, error)
+
+	defer func() {
+		if r := recover(); r != nil {
+			switch phase {
+			case preparedBeforeReservation:
+				prepared.Abort()
+				ticket.publish(nil)
+				ticket.finish()
+			case preparedCommitInProgress:
+				// Commit may have enqueued before panicking, so the reservation
+				// cannot be safely replayed.
+				terminal(flowcontrol.MessageOutcomeFatal, errors.New("panic during prepared send commit"))
+				ticket.publish(waitNext)
+			case preparedCommitted:
+				// The terminal callback owns the reservation after a successful
+				// Commit. Only publish the already-created successor here.
+				ticket.publish(waitNext)
+			}
+			panic(r)
+		}
+	}()
+
+	lim := ticket.gen.limiter
+	if rich, ok := lim.(flowcontrol.GateNextFlowLimiter); ok {
+		var complete func(flowcontrol.MessageOutcomeKind, error)
+		waitNext, complete = rich.GateNext().CommitMessage(prepared.Size())
+		var terminalOnce sync.Once
+		terminal = func(kind flowcontrol.MessageOutcomeKind, e error) {
+			terminalOnce.Do(func() { complete(kind, e); ticket.finish() })
+		}
+		phase = preparedCommitInProgress
+		ans, rel, err = prepared.Commit(terminal)
+		if err != nil {
+			prepared.Abort()
+			terminal(flowcontrol.MessageOutcomeAbortedBeforeEnqueue, err)
+			ticket.publish(waitNext)
+			return nil, nil, err
+		}
+		phase = preparedCommitted
+		ticket.publish(waitNext)
+		return ans, rel, nil
+	}
+
+	got, err := lim.StartMessage(ctx, prepared.Size())
+	if err != nil {
+		prepared.Abort()
+		ticket.publish(nil)
+		ticket.finish()
+		return nil, nil, err
+	}
+	var terminalOnce sync.Once
+	terminal = func(flowcontrol.MessageOutcomeKind, error) {
+		terminalOnce.Do(func() { got(); ticket.finish() })
+	}
+	phase = preparedCommitInProgress
+	ans, rel, err = prepared.Commit(terminal)
+	if err != nil {
+		prepared.Abort()
+		terminal(flowcontrol.MessageOutcomeAbortedBeforeEnqueue, err)
+		ticket.publish(nil)
+		return nil, nil, err
+	}
+	phase = preparedCommitted
+	ticket.publish(nil)
 	return ans, rel, nil
 }
 

--- a/capability.go
+++ b/capability.go
@@ -188,14 +188,30 @@ func (f *clientFlow) ticket(lim flowcontrol.FlowLimiter) *flowTicket {
 			}
 		}
 	}
-	g := f.gen
-	g.leases++
-	t := &flowTicket{prev: f.tail, ready: make(chan struct{}), flow: f, gen: g}
-	f.tail = t
+	t := f.ticketLocked()
 	f.mu.Unlock()
 	if release != nil {
 		release.Release()
 	}
+	return t
+}
+
+// ticketCurrent appends a ticket to the flow's current generation. It lets a
+// promised-answer handoff retain FIFO ordering after its source Client has
+// been released, without consulting that Client's state.
+func (f *clientFlow) ticketCurrent() *flowTicket {
+	f.mu.Lock()
+	t := f.ticketLocked()
+	f.mu.Unlock()
+	return t
+}
+
+// ticketLocked appends a ticket to f. The caller must hold f.mu.
+func (f *clientFlow) ticketLocked() *flowTicket {
+	g := f.gen
+	g.leases++
+	t := &flowTicket{prev: f.tail, ready: make(chan struct{}), flow: f, gen: g}
+	f.tail = t
 	return t
 }
 
@@ -246,6 +262,13 @@ func (t *flowTicket) await(ctx context.Context) error {
 	}
 	select {
 	case <-prev.ready:
+		// A replacement generation still waits for the old ticket to publish,
+		// preserving FIFO handoff order, but it must not call a retired
+		// limiter's GateNext permission.
+		if prev.gen != t.gen {
+			t.prev = nil
+			return nil
+		}
 		err := prev.wait(ctx)
 		if err == nil {
 			t.prev = nil

--- a/capability.go
+++ b/capability.go
@@ -151,13 +151,14 @@ type limiterGeneration struct {
 }
 
 type flowTicket struct {
-	prev  *flowTicket
-	ready chan struct{}
-	wait  func(context.Context) error
-	once  sync.Once
-	done  sync.Once
-	flow  *clientFlow
-	gen   *limiterGeneration
+	prev       *flowTicket
+	ready      chan struct{}
+	wait       func(context.Context) error
+	forwarding bool
+	once       sync.Once
+	done       sync.Once
+	flow       *clientFlow
+	gen        *limiterGeneration
 }
 
 // streamTail is a completion prefix: closing it means every stream call
@@ -255,28 +256,45 @@ func (t *flowTicket) publish(wait func(context.Context) error) {
 	t.once.Do(func() { t.wait = wait; close(t.ready) })
 }
 
+// abandon publishes a forwarding ticket. A successor must walk through a
+// forwarding ticket to preserve the abandoned call's FIFO position.
+func (t *flowTicket) abandon() {
+	t.once.Do(func() {
+		t.forwarding = true
+		t.wait = t.forward
+		close(t.ready)
+	})
+}
+
 func (t *flowTicket) await(ctx context.Context) error {
 	prev := t.prev
-	if prev == nil {
-		return nil
-	}
-	select {
-	case <-prev.ready:
-		// A replacement generation still waits for the old ticket to publish,
-		// preserving FIFO handoff order, but it must not call a retired
-		// limiter's GateNext permission.
-		if prev.gen != t.gen {
-			t.prev = nil
-			return nil
+	for prev != nil {
+		select {
+		case <-prev.ready:
+			// Abandoned tickets publish before their predecessors have cleared.
+			// Walk through them so their transitive FIFO position is preserved.
+			if prev.forwarding {
+				prev = prev.prev
+				continue
+			}
+			// A replacement generation still waits for the old ticket to
+			// publish, preserving FIFO handoff order, but it must not call a
+			// retired limiter's GateNext permission.
+			if prev.gen != t.gen {
+				t.prev = nil
+				return nil
+			}
+			err := prev.wait(ctx)
+			if err == nil {
+				t.prev = nil
+			}
+			return err
+		case <-ctx.Done():
+			return ctx.Err()
 		}
-		err := prev.wait(ctx)
-		if err == nil {
-			t.prev = nil
-		}
-		return err
-	case <-ctx.Done():
-		return ctx.Err()
 	}
+	t.prev = nil
+	return nil
 }
 
 // forward preserves FIFO admission when this ticket is abandoned before it
@@ -580,13 +598,13 @@ func (c Client) sendCall(ctx context.Context, s Send) (*Answer, ReleaseFunc, err
 	}
 	defer func() {
 		if r := recover(); r != nil {
-			ticket.publish(ticket.forward)
+			ticket.abandon()
 			ticket.finish()
 			panic(r)
 		}
 	}()
 	if err := ticket.await(ctx); err != nil {
-		ticket.publish(ticket.forward)
+		ticket.abandon()
 		ticket.finish()
 		return nil, nil, err
 	}

--- a/capability_admit_test.go
+++ b/capability_admit_test.go
@@ -125,9 +125,20 @@ func TestAdmitPreparedSendPublishesAfterCommit(t *testing.T) {
 	}
 
 	terminal(flowcontrol.MessageOutcomeSucceeded, nil)
+	terminal(flowcontrol.MessageOutcomeFatal, errors.New("duplicate terminal"))
 	completion := <-lim.gate.completions
 	if completion.kind != flowcontrol.MessageOutcomeSucceeded || completion.err != nil {
 		t.Fatalf("completion = %+v; want success", completion)
+	}
+	select {
+	case completion := <-lim.gate.completions:
+		t.Fatalf("duplicate completion = %+v", completion)
+	default:
+	}
+	select {
+	case <-lim.gate.waitCalled:
+		t.Fatal("successor invoked GateNext permission more than once")
+	default:
 	}
 	second.finish()
 	if release := flow.close(); release != lim {
@@ -169,6 +180,16 @@ func TestAdmitPreparedSendFailureRetiresBeforePublishing(t *testing.T) {
 		t.Fatalf("successor await() = %v; want nil", err)
 	}
 	<-lim.gate.waitCalled
+	select {
+	case completion := <-lim.gate.completions:
+		t.Fatalf("duplicate completion = %+v", completion)
+	default:
+	}
+	select {
+	case <-lim.gate.waitCalled:
+		t.Fatal("successor invoked GateNext permission more than once")
+	default:
+	}
 
 	second.finish()
 	if release := flow.close(); release != lim {
@@ -213,6 +234,16 @@ func TestAdmitPreparedSendPanicPoisonsAndPublishes(t *testing.T) {
 		t.Fatalf("successor await() = %v; want nil", err)
 	}
 	<-lim.gate.waitCalled
+	select {
+	case completion := <-lim.gate.completions:
+		t.Fatalf("duplicate completion = %+v", completion)
+	default:
+	}
+	select {
+	case <-lim.gate.waitCalled:
+		t.Fatal("successor invoked GateNext permission more than once")
+	default:
+	}
 
 	second.finish()
 	if release := flow.close(); release != lim {

--- a/capability_admit_test.go
+++ b/capability_admit_test.go
@@ -1,0 +1,222 @@
+package capnp
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"capnproto.org/go/capnp/v3/flowcontrol"
+)
+
+type gateCompletion struct {
+	kind flowcontrol.MessageOutcomeKind
+	err  error
+}
+
+type testGateController struct {
+	waitCalled  chan struct{}
+	completions chan gateCompletion
+}
+
+func (g *testGateController) CommitMessage(uint64) (func(context.Context) error, func(flowcontrol.MessageOutcomeKind, error)) {
+	return func(context.Context) error {
+			g.waitCalled <- struct{}{}
+			return nil
+		}, func(kind flowcontrol.MessageOutcomeKind, err error) {
+			g.completions <- gateCompletion{kind: kind, err: err}
+		}
+}
+
+func (*testGateController) Poison(error) {}
+
+type testGateLimiter struct {
+	*ticketTestLimiter
+	gate *testGateController
+}
+
+func (l *testGateLimiter) GateNext() flowcontrol.GateNextController { return l.gate }
+
+var _ flowcontrol.GateNextFlowLimiter = (*testGateLimiter)(nil)
+
+type testPreparedSend struct {
+	size   uint64
+	commit func(func(flowcontrol.MessageOutcomeKind, error)) (*Answer, ReleaseFunc, error)
+
+	mu     sync.Mutex
+	aborts int
+}
+
+func (p *testPreparedSend) Size() uint64 { return p.size }
+
+func (p *testPreparedSend) Commit(terminal func(flowcontrol.MessageOutcomeKind, error)) (*Answer, ReleaseFunc, error) {
+	return p.commit(terminal)
+}
+
+func (p *testPreparedSend) Abort() {
+	p.mu.Lock()
+	p.aborts++
+	p.mu.Unlock()
+}
+
+func (p *testPreparedSend) abortCount() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.aborts
+}
+
+var _ PreparedSend = (*testPreparedSend)(nil)
+
+func newTestGateLimiter() *testGateLimiter {
+	return &testGateLimiter{
+		ticketTestLimiter: new(ticketTestLimiter),
+		gate: &testGateController{
+			waitCalled:  make(chan struct{}, 1),
+			completions: make(chan gateCompletion, 2),
+		},
+	}
+}
+
+func TestAdmitPreparedSendPublishesAfterCommit(t *testing.T) {
+	lim := newTestGateLimiter()
+	flow := newClientFlow(lim)
+	first := flow.ticketCurrent()
+	second := flow.ticketCurrent()
+	commitStarted := make(chan struct{})
+	finishCommit := make(chan struct{})
+	var terminal func(flowcontrol.MessageOutcomeKind, error)
+	prepared := &testPreparedSend{
+		size: 1,
+		commit: func(t func(flowcontrol.MessageOutcomeKind, error)) (*Answer, ReleaseFunc, error) {
+			terminal = t
+			close(commitStarted)
+			<-finishCommit
+			return nil, nil, nil
+		},
+	}
+
+	admitted := make(chan error, 1)
+	go func() {
+		_, _, err := admitPreparedSend(context.Background(), first, prepared)
+		admitted <- err
+	}()
+	<-commitStarted
+	select {
+	case <-first.ready:
+		t.Fatal("published successor before Commit returned")
+	default:
+	}
+	close(finishCommit)
+	if err := <-admitted; err != nil {
+		t.Fatalf("admitPreparedSend() = %v; want nil", err)
+	}
+	select {
+	case <-first.ready:
+	default:
+		t.Fatal("did not publish successor after Commit returned")
+	}
+	if err := second.await(context.Background()); err != nil {
+		t.Fatalf("successor await() = %v; want nil", err)
+	}
+	select {
+	case <-lim.gate.waitCalled:
+	default:
+		t.Fatal("successor did not use GateNext permission")
+	}
+
+	terminal(flowcontrol.MessageOutcomeSucceeded, nil)
+	completion := <-lim.gate.completions
+	if completion.kind != flowcontrol.MessageOutcomeSucceeded || completion.err != nil {
+		t.Fatalf("completion = %+v; want success", completion)
+	}
+	second.finish()
+	if release := flow.close(); release != lim {
+		t.Fatalf("close release = %v; want limiter", release)
+	}
+	lim.Release()
+}
+
+func TestAdmitPreparedSendFailureRetiresBeforePublishing(t *testing.T) {
+	lim := newTestGateLimiter()
+	flow := newClientFlow(lim)
+	first := flow.ticketCurrent()
+	second := flow.ticketCurrent()
+	want := errors.New("commit failed before enqueue")
+	prepared := &testPreparedSend{
+		size: 1,
+		commit: func(func(flowcontrol.MessageOutcomeKind, error)) (*Answer, ReleaseFunc, error) {
+			return nil, nil, want
+		},
+	}
+
+	_, _, err := admitPreparedSend(context.Background(), first, prepared)
+	if !errors.Is(err, want) {
+		t.Fatalf("admitPreparedSend() = %v; want %v", err, want)
+	}
+	if got := prepared.abortCount(); got != 1 {
+		t.Fatalf("Abort called %d times; want 1", got)
+	}
+	completion := <-lim.gate.completions
+	if completion.kind != flowcontrol.MessageOutcomeAbortedBeforeEnqueue || !errors.Is(completion.err, want) {
+		t.Fatalf("completion = %+v; want aborted with %v", completion, want)
+	}
+	select {
+	case <-first.ready:
+	default:
+		t.Fatal("did not publish successor after local cleanup")
+	}
+	if err := second.await(context.Background()); err != nil {
+		t.Fatalf("successor await() = %v; want nil", err)
+	}
+	<-lim.gate.waitCalled
+
+	second.finish()
+	if release := flow.close(); release != lim {
+		t.Fatalf("close release = %v; want limiter", release)
+	}
+	lim.Release()
+}
+
+func TestAdmitPreparedSendPanicPoisonsAndPublishes(t *testing.T) {
+	lim := newTestGateLimiter()
+	flow := newClientFlow(lim)
+	first := flow.ticketCurrent()
+	second := flow.ticketCurrent()
+	prepared := &testPreparedSend{
+		size: 1,
+		commit: func(func(flowcontrol.MessageOutcomeKind, error)) (*Answer, ReleaseFunc, error) {
+			panic("commit panic")
+		},
+	}
+
+	func() {
+		defer func() {
+			if got := recover(); got != "commit panic" {
+				t.Fatalf("panic = %v; want commit panic", got)
+			}
+		}()
+		_, _, _ = admitPreparedSend(context.Background(), first, prepared)
+	}()
+	if got := prepared.abortCount(); got != 0 {
+		t.Fatalf("Abort called %d times after ambiguous panic; want 0", got)
+	}
+	completion := <-lim.gate.completions
+	if completion.kind != flowcontrol.MessageOutcomeFatal {
+		t.Fatalf("completion kind = %v; want fatal", completion.kind)
+	}
+	select {
+	case <-first.ready:
+	default:
+		t.Fatal("did not publish successor after panic")
+	}
+	if err := second.await(context.Background()); err != nil {
+		t.Fatalf("successor await() = %v; want nil", err)
+	}
+	<-lim.gate.waitCalled
+
+	second.finish()
+	if release := flow.close(); release != lim {
+		t.Fatalf("close release = %v; want limiter", release)
+	}
+	lim.Release()
+}

--- a/capability_ticket_test.go
+++ b/capability_ticket_test.go
@@ -33,6 +33,16 @@ func (c *observedAwaitContext) Done() <-chan struct{} {
 	return c.Context.Done()
 }
 
+type steppedAwaitContext struct {
+	context.Context
+	steps chan struct{}
+}
+
+func (c *steppedAwaitContext) Done() <-chan struct{} {
+	c.steps <- struct{}{}
+	return c.Context.Done()
+}
+
 func TestFlowTicketAwaitSameGenerationUsesPredecessorGate(t *testing.T) {
 	lim := new(ticketTestLimiter)
 	flow := newClientFlow(lim)
@@ -107,4 +117,89 @@ func TestFlowTicketAwaitCrossGenerationOnlyWaitsForPublication(t *testing.T) {
 		t.Fatalf("close release = %v; want current limiter", release)
 	}
 	replacement.Release()
+}
+
+func TestFlowTicketAwaitCrossGenerationWalksAbandonedPredecessor(t *testing.T) {
+	old := new(ticketTestLimiter)
+	replacement := new(ticketTestLimiter)
+	flow := newClientFlow(old)
+	first := flow.ticketCurrent()
+	abandoned := flow.ticketCurrent()
+	abandoned.abandon()
+	abandoned.finish()
+	if release := flow.replace(replacement); release != nil {
+		t.Fatal("replacement released old limiter before its first ticket drained")
+	}
+	successor := flow.ticketCurrent()
+
+	ctx := &steppedAwaitContext{
+		Context: context.Background(),
+		steps:   make(chan struct{}),
+	}
+	awaited := make(chan error, 1)
+	go func() { awaited <- successor.await(ctx) }()
+
+	// The first step observes the already-published abandoned ticket. The
+	// second proves await walked through it and reached first.ready.
+	<-ctx.steps
+	select {
+	case <-ctx.steps:
+	case err := <-awaited:
+		t.Fatalf("await returned before transitive predecessor publication: %v", err)
+	}
+
+	oldGateCalled := make(chan struct{}, 1)
+	first.publish(func(context.Context) error {
+		oldGateCalled <- struct{}{}
+		return nil
+	})
+	if err := <-awaited; err != nil {
+		t.Fatalf("await() = %v; want nil", err)
+	}
+	select {
+	case <-oldGateCalled:
+		t.Fatal("cross-generation await invoked the retired limiter gate")
+	default:
+	}
+
+	first.finish()
+	if old.releases != 1 {
+		t.Fatalf("old Release called %d times after old tickets drained; want 1", old.releases)
+	}
+	successor.finish()
+	if release := flow.close(); release != replacement {
+		t.Fatalf("close release = %v; want current limiter", release)
+	}
+	replacement.Release()
+}
+
+func TestFlowTicketAwaitSameGenerationWalksAbandonedPredecessor(t *testing.T) {
+	lim := new(ticketTestLimiter)
+	flow := newClientFlow(lim)
+	first := flow.ticketCurrent()
+	abandoned := flow.ticketCurrent()
+	abandoned.abandon()
+	abandoned.finish()
+	successor := flow.ticketCurrent()
+
+	gateCalled := make(chan struct{}, 1)
+	first.publish(func(context.Context) error {
+		gateCalled <- struct{}{}
+		return nil
+	})
+	if err := successor.await(context.Background()); err != nil {
+		t.Fatalf("await() = %v; want nil", err)
+	}
+	select {
+	case <-gateCalled:
+	default:
+		t.Fatal("same-generation successor skipped transitive predecessor gate")
+	}
+
+	first.finish()
+	successor.finish()
+	if release := flow.close(); release != lim {
+		t.Fatalf("close release = %v; want limiter", release)
+	}
+	lim.Release()
 }

--- a/capability_ticket_test.go
+++ b/capability_ticket_test.go
@@ -1,0 +1,110 @@
+package capnp
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"capnproto.org/go/capnp/v3/flowcontrol"
+)
+
+type ticketTestLimiter struct {
+	releases int
+}
+
+func (*ticketTestLimiter) StartMessage(context.Context, uint64) (func(), error) {
+	return func() {}, nil
+}
+
+func (l *ticketTestLimiter) Release() {
+	l.releases++
+}
+
+var _ flowcontrol.FlowLimiter = (*ticketTestLimiter)(nil)
+
+type observedAwaitContext struct {
+	context.Context
+	entered chan struct{}
+	once    sync.Once
+}
+
+func (c *observedAwaitContext) Done() <-chan struct{} {
+	c.once.Do(func() { close(c.entered) })
+	return c.Context.Done()
+}
+
+func TestFlowTicketAwaitSameGenerationUsesPredecessorGate(t *testing.T) {
+	lim := new(ticketTestLimiter)
+	flow := newClientFlow(lim)
+	first := flow.ticketCurrent()
+	second := flow.ticketCurrent()
+	called := make(chan struct{}, 1)
+	first.publish(func(context.Context) error {
+		called <- struct{}{}
+		return nil
+	})
+
+	if err := second.await(context.Background()); err != nil {
+		t.Fatalf("await() = %v; want nil", err)
+	}
+	select {
+	case <-called:
+	default:
+		t.Fatal("await did not invoke the predecessor gate")
+	}
+
+	first.finish()
+	second.finish()
+	if release := flow.close(); release != lim {
+		t.Fatalf("close release = %v; want current limiter", release)
+	}
+	if lim.releases != 0 {
+		t.Fatalf("Release called %d times before caller released returned limiter", lim.releases)
+	}
+	lim.Release()
+}
+
+func TestFlowTicketAwaitCrossGenerationOnlyWaitsForPublication(t *testing.T) {
+	old := new(ticketTestLimiter)
+	replacement := new(ticketTestLimiter)
+	flow := newClientFlow(old)
+	first := flow.ticketCurrent()
+	if release := flow.replace(replacement); release != nil {
+		t.Fatal("replacement released old limiter before its ticket drained")
+	}
+	second := flow.ticketCurrent()
+
+	ctx := &observedAwaitContext{Context: context.Background(), entered: make(chan struct{})}
+	awaited := make(chan error, 1)
+	go func() { awaited <- second.await(ctx) }()
+	<-ctx.entered
+	select {
+	case err := <-awaited:
+		t.Fatalf("await returned before predecessor publication: %v", err)
+	default:
+	}
+
+	oldGateCalled := make(chan struct{}, 1)
+	first.publish(func(context.Context) error {
+		oldGateCalled <- struct{}{}
+		return nil
+	})
+	if err := <-awaited; err != nil {
+		t.Fatalf("await() = %v; want nil", err)
+	}
+	select {
+	case <-oldGateCalled:
+		t.Fatal("cross-generation await invoked the retired limiter gate")
+	default:
+	}
+
+	first.finish()
+	if old.releases != 1 {
+		t.Fatalf("old Release called %d times after old ticket drained; want 1", old.releases)
+	}
+	second.finish()
+	if release := flow.close(); release != replacement {
+		t.Fatalf("close release = %v; want current limiter", release)
+	}
+	replacement.Release()
+}


### PR DESCRIPTION
Builds the private capnp mechanics needed to activate GateNext for unresolved RPC pipeline sends in a later PR.

- adds atomic late Promise claims and one-shot drain ownership;
- makes ticket handoff generation-aware while preserving FIFO publication;
- centralizes prepared-send admission with delayed successor publication and phase-aware abort/panic handling;
- adds deterministic fake-controller and barrier tests.

This deliberately does not install the pipeline wrapper or expose bbr.Limiter.GateNext().