### PR TITLE
flowcontrol: activate BBR gate-next RPC admission

### DIFF
--- a/answer.go
+++ b/answer.go
@@ -262,8 +262,7 @@ type PipelineCaller interface {
 // before delegating a pipelined send. It is private so only the capnp package
 // can opt into the late-claim protocol.
 //
-// The marker is intentionally dormant until the admitted RPC pipeline wrapper
-// is installed. Keeping the protocol private lets that wrapper wait for a
+// Keeping the protocol private lets the RPC admission wrapper wait for a
 // predecessor's permission without holding Promise resolution open.
 type pipelineAdmissionController interface {
 	PipelineCaller

--- a/answer.go
+++ b/answer.go
@@ -270,6 +270,12 @@ type pipelineAdmissionController interface {
 	pipelineAdmissionToken() *pipelineAdmissionToken
 }
 
+type pipelineAdmissionSender interface {
+	pipelineAdmissionController
+	pipelineTicket() *flowTicket
+	pipelineSendWithTicket(context.Context, []PipelineOp, Send, *flowTicket) (*Answer, ReleaseFunc)
+}
+
 type pipelineAdmissionToken struct{ _ byte }
 
 // pipelineResolutionState reports the result of a late pipeline-call claim.
@@ -402,6 +408,18 @@ func (ans *Answer) PipelineSend(ctx context.Context, transform []PipelineOp, s S
 	switch {
 	case l.Value().isUnresolved():
 		caller := l.Value().caller
+		if admitted, ok := caller.(pipelineAdmissionSender); ok {
+			// Keep resolution from retiring the origin limiter during the
+			// brief ticket acquisition. The potentially blocking gate wait
+			// happens only after this admission has been released.
+			l.Value().ongoingCalls++
+			l.Unlock()
+			ticket := func() *flowTicket {
+				defer p.pipelineCallDone()
+				return admitted.pipelineTicket()
+			}()
+			return admitted.pipelineSendWithTicket(ctx, transform, s, ticket)
+		}
 		l.Value().ongoingCalls++
 		l.Unlock()
 		defer p.pipelineCallDone()

--- a/capability.go
+++ b/capability.go
@@ -207,6 +207,28 @@ func (f *clientFlow) ticketCurrent() *flowTicket {
 	return t
 }
 
+func (f *clientFlow) handoff(origin *flowTicket, lim flowcontrol.FlowLimiter) (ticket *flowTicket, release flowcontrol.FlowLimiter) {
+	f.mu.Lock()
+	if f.gen == nil || f.gen.limiter != lim {
+		old := f.gen
+		f.gen = &limiterGeneration{limiter: lim}
+		if old != nil {
+			old.retired = true
+			if old.leases == 0 && !old.released {
+				release = old.limiter
+				old.released = true
+			}
+		}
+	}
+	if origin != nil && origin.flow == f && origin.gen == f.gen {
+		ticket = origin
+	} else {
+		ticket = f.ticketLocked()
+	}
+	f.mu.Unlock()
+	return ticket, release
+}
+
 // ticketLocked appends a ticket to f. The caller must hold f.mu.
 func (f *clientFlow) ticketLocked() *flowTicket {
 	g := f.gen
@@ -519,6 +541,33 @@ func (c Client) newFlowTicket() *flowTicket {
 	})
 }
 
+// handoffFlowTicket acquires the resolved target's FIFO position before the
+// origin position is published. When both positions are the same flow
+// generation, the origin ticket itself is reused.
+func (c Client) handoffFlowTicket(origin *flowTicket) *flowTicket {
+	var (
+		ticket  *flowTicket
+		release flowcontrol.FlowLimiter
+	)
+	c.state.With(func(s *clientState) {
+		if s.released {
+			return
+		}
+		lim := s.limiter
+		if lim == nil {
+			lim = flowcontrol.NopLimiter
+		}
+		if s.flow == nil {
+			s.flow = newClientFlow(lim)
+		}
+		ticket, release = s.flow.handoff(origin, lim)
+	})
+	if release != nil {
+		release.Release()
+	}
+	return ticket
+}
+
 // Update the flowcontrol.FlowLimiter used to manage flow control for
 // this client. This affects all future calls, but not calls already
 // waiting to send. Passing nil sets the value to flowcontrol.NopLimiter,
@@ -576,12 +625,33 @@ func (c Client) SendCall(ctx context.Context, s Send) (*Answer, ReleaseFunc) {
 // sendCall returns a synchronous error only for a prepared send that did not
 // enqueue anything. The legacy hook path remains source-compatible.
 func (c Client) sendCall(ctx context.Context, s Send) (*Answer, ReleaseFunc, error) {
+	return c.sendCallWithTicket(ctx, s, nil)
+}
+
+// sendCallWithTicket is sendCall with an optional FIFO position acquired by a
+// promised-answer handoff. It owns ticket on entry.
+func (c Client) sendCallWithTicket(ctx context.Context, s Send, ticket *flowTicket) (*Answer, ReleaseFunc, error) {
+	discardTicket := func() {
+		if ticket != nil {
+			ticket.abandon()
+			ticket.finish()
+		}
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			discardTicket()
+			panic(r)
+		}
+	}()
+
 	h, _, released := c.startCall()
 	defer h.Release()
 	if released {
+		discardTicket()
 		return nil, nil, errors.New("call on released client")
 	}
 	if h == nil {
+		discardTicket()
 		return nil, nil, errors.New("call on null client")
 	}
 
@@ -590,19 +660,15 @@ func (c Client) sendCall(ctx context.Context, s Send) (*Answer, ReleaseFunc, err
 	})
 
 	if err != nil {
+		discardTicket()
 		return nil, nil, exc.WrapError("stream error", err)
 	}
-	ticket := c.newFlowTicket()
 	if ticket == nil {
-		return nil, nil, errors.New("call on released client")
-	}
-	defer func() {
-		if r := recover(); r != nil {
-			ticket.abandon()
-			ticket.finish()
-			panic(r)
+		ticket = c.newFlowTicket()
+		if ticket == nil {
+			return nil, nil, errors.New("call on released client")
 		}
-	}()
+	}
 	if err := ticket.await(ctx); err != nil {
 		ticket.abandon()
 		ticket.finish()
@@ -615,7 +681,7 @@ func (c Client) sendCall(ctx context.Context, s Send) (*Answer, ReleaseFunc, err
 	if p, ok := h.Value().ClientHook.(ClientHookPreparer); ok {
 		prepared, err := p.PrepareSend(ctx, s)
 		if err != nil {
-			ticket.publish(nil)
+			ticket.abandon()
 			ticket.finish()
 			return nil, nil, err
 		}
@@ -716,7 +782,7 @@ func admitPreparedSend(ctx context.Context, ticket *flowTicket, prepared Prepare
 			switch phase {
 			case preparedBeforeReservation:
 				prepared.Abort()
-				ticket.publish(nil)
+				ticket.abandon()
 				ticket.finish()
 			case preparedCommitInProgress:
 				// Commit may have enqueued before panicking, so the reservation
@@ -749,6 +815,7 @@ func admitPreparedSend(ctx context.Context, ticket *flowTicket, prepared Prepare
 			return nil, nil, err
 		}
 		phase = preparedCommitted
+		installPipelineAdmission(ans, ticket.flow)
 		ticket.publish(waitNext)
 		return ans, rel, nil
 	}
@@ -756,7 +823,7 @@ func admitPreparedSend(ctx context.Context, ticket *flowTicket, prepared Prepare
 	got, err := lim.StartMessage(ctx, prepared.Size())
 	if err != nil {
 		prepared.Abort()
-		ticket.publish(nil)
+		ticket.abandon()
 		ticket.finish()
 		return nil, nil, err
 	}
@@ -773,9 +840,141 @@ func admitPreparedSend(ctx context.Context, ticket *flowTicket, prepared Prepare
 		return nil, nil, err
 	}
 	phase = preparedCommitted
+	installPipelineAdmission(ans, ticket.flow)
 	ticket.publish(nil)
 	return ans, rel, nil
 }
+
+// admittedPipelineCaller waits for its origin flow's predecessor before it
+// claims an unresolved Promise. It intentionally does not implement
+// PipelineCallerPreparer: Answer must not bypass this admission path.
+type admittedPipelineCaller struct {
+	promise    *Promise
+	flow       *clientFlow
+	underlying PipelineCaller
+	preparer   PipelineCallerPreparer
+	token      pipelineAdmissionToken
+}
+
+func (c *admittedPipelineCaller) pipelineAdmissionToken() *pipelineAdmissionToken {
+	return &c.token
+}
+
+func (c *admittedPipelineCaller) PipelineSend(ctx context.Context, transform []PipelineOp, s Send) (*Answer, ReleaseFunc) {
+	return c.pipelineSendWithTicket(ctx, transform, s, c.pipelineTicket())
+}
+
+func (c *admittedPipelineCaller) pipelineTicket() *flowTicket {
+	return c.flow.ticketCurrent()
+}
+
+func (c *admittedPipelineCaller) pipelineSendWithTicket(ctx context.Context, transform []PipelineOp, s Send, ticket *flowTicket) (*Answer, ReleaseFunc) {
+	ans, rel, err := c.pipelineSend(ctx, transform, s, ticket)
+	if err != nil {
+		return ErrorAnswer(s.Method, err), func() {}
+	}
+	return ans, rel
+}
+
+func (c *admittedPipelineCaller) pipelineSend(ctx context.Context, transform []PipelineOp, s Send, ticket *flowTicket) (ans *Answer, rel ReleaseFunc, err error) {
+	ownedTicket := ticket
+	defer func() {
+		if r := recover(); r != nil {
+			if ownedTicket != nil {
+				ownedTicket.abandon()
+				ownedTicket.finish()
+			}
+			panic(r)
+		}
+	}()
+	if err := ticket.await(ctx); err != nil {
+		ticket.abandon()
+		ticket.finish()
+		ownedTicket = nil
+		return nil, nil, err
+	}
+
+	claim, state := c.promise.claimPipelineCall(c)
+	if claim != nil {
+		defer claim.Done()
+		prepared, err := c.preparer.PreparePipelineSend(ctx, transform, s)
+		if err != nil {
+			ticket.abandon()
+			ticket.finish()
+			ownedTicket = nil
+			return nil, nil, err
+		}
+		ownedTicket = nil
+		return admitPreparedSend(ctx, ticket, prepared)
+	}
+
+	if state == pipelinePendingResolution {
+		select {
+		case <-c.promise.resolved:
+		case <-ctx.Done():
+			ticket.abandon()
+			ticket.finish()
+			ownedTicket = nil
+			return nil, nil, ctx.Err()
+		}
+	}
+	l := c.promise.state.Lock()
+	if !l.Value().isResolved() {
+		l.Unlock()
+		panic("pipeline admission handoff before resolution")
+	}
+	res := l.Value().resolution(c.promise.method)
+	l.Unlock()
+	target := res.client(transform)
+	targetTicket := target.handoffFlowTicket(ticket)
+	if targetTicket == nil {
+		ticket.abandon()
+		ticket.finish()
+		ownedTicket = nil
+		return nil, nil, errors.New("call on released client")
+	}
+	if targetTicket != ticket {
+		ownedTicket = targetTicket
+		ticket.abandon()
+		ticket.finish()
+	}
+	ownedTicket = nil
+	return target.sendCallWithTicket(ctx, s, targetTicket)
+}
+
+// PipelineRecv remains ungated because it may run on an RPC connection's
+// receive goroutine; waiting there can deadlock the Return that opens a gate.
+func (c *admittedPipelineCaller) PipelineRecv(ctx context.Context, transform []PipelineOp, r Recv) PipelineCaller {
+	return c.underlying.PipelineRecv(ctx, transform, r)
+}
+
+func installPipelineAdmission(ans *Answer, flow *clientFlow) {
+	if ans == nil || ans.f.promise == nil || flow == nil {
+		return
+	}
+	p := ans.f.promise
+	p.state.With(func(s *promiseState) {
+		if !s.isUnresolved() {
+			return
+		}
+		if _, ok := s.caller.(pipelineAdmissionController); ok {
+			return
+		}
+		preparer, ok := s.caller.(PipelineCallerPreparer)
+		if !ok {
+			return
+		}
+		s.caller = &admittedPipelineCaller{
+			promise:    p,
+			flow:       flow,
+			underlying: s.caller,
+			preparer:   preparer,
+		}
+	})
+}
+
+var _ pipelineAdmissionController = (*admittedPipelineCaller)(nil)
+var _ pipelineAdmissionSender = (*admittedPipelineCaller)(nil)
 
 // SendStreamCall is like SendCall except that:
 //

--- a/capability.go
+++ b/capability.go
@@ -283,7 +283,6 @@ func (t *flowTicket) publish(wait func(context.Context) error) {
 func (t *flowTicket) abandon() {
 	t.once.Do(func() {
 		t.forwarding = true
-		t.wait = t.forward
 		close(t.ready)
 	})
 }
@@ -317,12 +316,6 @@ func (t *flowTicket) await(ctx context.Context) error {
 	}
 	t.prev = nil
 	return nil
-}
-
-// forward preserves FIFO admission when this ticket is abandoned before it
-// consumes its predecessor's gate.
-func (t *flowTicket) forward(ctx context.Context) error {
-	return t.await(ctx)
 }
 
 func (t *flowTicket) finish() {
@@ -764,9 +757,9 @@ func (c Client) sendCallWithTicket(ctx context.Context, s Send, ticket *flowTick
 // predecessor's permission. The ticket's successor is published only after
 // enqueueing, or after the reservation has been retired on a local failure.
 //
-// This helper is shared by direct prepared sends today and by the promised
-// pipeline admission wrapper once that wrapper is installed. It deliberately
-// leaves legacy ClientHook.Send behavior in sendCall unchanged.
+// This helper is shared by direct prepared sends and promised pipeline
+// admission. It deliberately leaves legacy ClientHook.Send behavior in
+// sendCall unchanged.
 func admitPreparedSend(ctx context.Context, ticket *flowTicket, prepared PreparedSend) (ans *Answer, rel ReleaseFunc, err error) {
 	const (
 		preparedBeforeReservation = iota

--- a/capability_admit_test.go
+++ b/capability_admit_test.go
@@ -17,11 +17,15 @@ type gateCompletion struct {
 type testGateController struct {
 	waitCalled  chan struct{}
 	completions chan gateCompletion
+	wait        func(context.Context) error
 }
 
 func (g *testGateController) CommitMessage(uint64) (func(context.Context) error, func(flowcontrol.MessageOutcomeKind, error)) {
-	return func(context.Context) error {
+	return func(ctx context.Context) error {
 			g.waitCalled <- struct{}{}
+			if g.wait != nil {
+				return g.wait(ctx)
+			}
 			return nil
 		}, func(kind flowcontrol.MessageOutcomeKind, err error) {
 			g.completions <- gateCompletion{kind: kind, err: err}
@@ -66,6 +70,24 @@ func (p *testPreparedSend) abortCount() int {
 }
 
 var _ PreparedSend = (*testPreparedSend)(nil)
+
+type testPipelinePreparer struct {
+	dummyPipelineCaller
+	prepared PreparedSend
+	called   chan struct{}
+}
+
+func (p *testPipelinePreparer) PreparePipelineSend(_ context.Context, _ []PipelineOp, s Send) (PreparedSend, error) {
+	close(p.called)
+	if s.PlaceArgs != nil {
+		if err := s.PlaceArgs(Struct{}); err != nil {
+			return nil, err
+		}
+	}
+	return p.prepared, nil
+}
+
+var _ PipelineCallerPreparer = (*testPipelinePreparer)(nil)
 
 func newTestGateLimiter() *testGateLimiter {
 	return &testGateLimiter{
@@ -141,6 +163,151 @@ func TestAdmitPreparedSendPublishesAfterCommit(t *testing.T) {
 	default:
 	}
 	second.finish()
+	if release := flow.close(); release != lim {
+		t.Fatalf("close release = %v; want limiter", release)
+	}
+	lim.Release()
+}
+
+func TestAdmittedPipelineSendWaitsBeforePreparation(t *testing.T) {
+	grant := make(chan struct{})
+	lim := newTestGateLimiter()
+	lim.gate.wait = func(ctx context.Context) error {
+		select {
+		case <-grant:
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	flow := newClientFlow(lim)
+	parentTicket := flow.ticketCurrent()
+
+	childDone := make(chan func(flowcontrol.MessageOutcomeKind, error), 1)
+	childPrepared := &testPreparedSend{
+		size: 1,
+		commit: func(terminal func(flowcontrol.MessageOutcomeKind, error)) (*Answer, ReleaseFunc, error) {
+			childDone <- terminal
+			return ImmediateAnswer(Method{}, Ptr{}), func() {}, nil
+		},
+	}
+	preparer := &testPipelinePreparer{
+		prepared: childPrepared,
+		called:   make(chan struct{}),
+	}
+	parentPromise := NewPromise(Method{}, preparer, nil)
+	parentDone := make(chan func(flowcontrol.MessageOutcomeKind, error), 1)
+	parentPrepared := &testPreparedSend{
+		size: 1,
+		commit: func(terminal func(flowcontrol.MessageOutcomeKind, error)) (*Answer, ReleaseFunc, error) {
+			parentDone <- terminal
+			return parentPromise.Answer(), func() {}, nil
+		},
+	}
+	if _, _, err := admitPreparedSend(context.Background(), parentTicket, parentPrepared); err != nil {
+		t.Fatalf("admit parent = %v", err)
+	}
+
+	l := parentPromise.state.Lock()
+	current := l.Value().caller
+	l.Unlock()
+	if _, ok := current.(*admittedPipelineCaller); !ok {
+		t.Fatalf("parent caller = %T; want *admittedPipelineCaller", current)
+	}
+	if _, ok := current.(PipelineCallerPreparer); ok {
+		t.Fatal("admitted pipeline caller implements PipelineCallerPreparer")
+	}
+
+	placeArgs := make(chan struct{})
+	callDone := make(chan *Answer, 1)
+	go func() {
+		ans, _ := parentPromise.Answer().PipelineSend(context.Background(), nil, Send{
+			PlaceArgs: func(Struct) error {
+				close(placeArgs)
+				return nil
+			},
+		})
+		callDone <- ans
+	}()
+	<-lim.gate.waitCalled
+	select {
+	case <-preparer.called:
+		t.Fatal("prepared pipeline call behind a closed gate")
+	default:
+	}
+	select {
+	case <-placeArgs:
+		t.Fatal("called PlaceArgs behind a closed gate")
+	default:
+	}
+
+	close(grant)
+	<-preparer.called
+	<-placeArgs
+	if ans := <-callDone; ans == nil {
+		t.Fatal("PipelineSend returned a nil Answer")
+	}
+
+	(<-childDone)(flowcontrol.MessageOutcomeSucceeded, nil)
+	(<-parentDone)(flowcontrol.MessageOutcomeSucceeded, nil)
+	parentPromise.Resolve(Ptr{}, nil)
+	if release := flow.close(); release != lim {
+		t.Fatalf("close release = %v; want limiter", release)
+	}
+	lim.Release()
+}
+
+func TestAdmittedPipelineWaitDoesNotBlockResolution(t *testing.T) {
+	grant := make(chan struct{})
+	lim := newTestGateLimiter()
+	lim.gate.wait = func(ctx context.Context) error {
+		select {
+		case <-grant:
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	flow := newClientFlow(lim)
+	parentTicket := flow.ticketCurrent()
+	waitNext, complete := lim.gate.CommitMessage(1)
+	parentTicket.publish(waitNext)
+
+	preparer := &testPipelinePreparer{
+		prepared: &testPreparedSend{
+			size: 1,
+			commit: func(func(flowcontrol.MessageOutcomeKind, error)) (*Answer, ReleaseFunc, error) {
+				t.Fatal("prepared unresolved route after Promise rejection")
+				return nil, nil, nil
+			},
+		},
+		called: make(chan struct{}),
+	}
+	p := NewPromise(Method{}, preparer, nil)
+	installPipelineAdmission(p.Answer(), flow)
+
+	callDone := make(chan *Answer, 1)
+	go func() {
+		ans, _ := p.Answer().PipelineSend(context.Background(), nil, Send{})
+		callDone <- ans
+	}()
+	<-lim.gate.waitCalled
+
+	resolvedErr := errors.New("resolved while gated")
+	p.Reject(resolvedErr)
+	close(grant)
+	ans := <-callDone
+	if _, err := ans.Struct(); !errors.Is(err, resolvedErr) {
+		t.Fatalf("pipelined call after resolution = %v; want %v", err, resolvedErr)
+	}
+	select {
+	case <-preparer.called:
+		t.Fatal("used unresolved preparer after Promise resolution won")
+	default:
+	}
+
+	complete(flowcontrol.MessageOutcomeSucceeded, nil)
+	parentTicket.finish()
 	if release := flow.close(); release != lim {
 		t.Fatalf("close release = %v; want limiter", release)
 	}

--- a/capability_ticket_test.go
+++ b/capability_ticket_test.go
@@ -74,6 +74,29 @@ func TestFlowTicketAwaitSameGenerationUsesPredecessorGate(t *testing.T) {
 	lim.Release()
 }
 
+func TestClientFlowHandoffReusesSameGenerationTicket(t *testing.T) {
+	lim := new(ticketTestLimiter)
+	flow := newClientFlow(lim)
+	origin := flow.ticketCurrent()
+
+	ticket, release := flow.handoff(origin, lim)
+	if ticket != origin {
+		t.Fatalf("handoff ticket = %p; want origin %p", ticket, origin)
+	}
+	if release != nil {
+		t.Fatalf("handoff released limiter %v", release)
+	}
+	if got := origin.gen.leases; got != 1 {
+		t.Fatalf("generation leases = %d; want 1", got)
+	}
+
+	origin.finish()
+	if release := flow.close(); release != lim {
+		t.Fatalf("close release = %v; want limiter", release)
+	}
+	lim.Release()
+}
+
 func TestFlowTicketAwaitCrossGenerationOnlyWaitsForPublication(t *testing.T) {
 	old := new(ticketTestLimiter)
 	replacement := new(ticketTestLimiter)

--- a/flowcontrol/bbr/gate_state.go
+++ b/flowcontrol/bbr/gate_state.go
@@ -34,10 +34,11 @@ const (
 )
 
 type gateReservation struct {
-	id     uint64
-	size   uint64
-	state  gateReservationState
-	packet packetMeta
+	id               uint64
+	size             uint64
+	state            gateReservationState
+	packet           packetMeta
+	successorGranted bool
 }
 
 // gateCompleteAction tells the limiter actor which BBR lifecycle operation a
@@ -292,8 +293,13 @@ func (g *gateState) registerWait(a *gateWaitAttempt) error {
 	if g.poison != nil {
 		return g.poison
 	}
-	if a.reservation.state != gateReservationProvisional && a.reservation.state != gateReservationAborted {
+	if a.reservation.state == gateReservationPoisoned {
 		return errors.New("bbr: gate-next permission is no longer available")
+	}
+	if a.reservation.successorGranted {
+		a.state = gateWaitGranted
+		a.result <- nil
+		return nil
 	}
 	for _, waiter := range g.waiters {
 		if waiter.reservation == a.reservation && waiter.state == gateWaitWaiting {
@@ -343,6 +349,7 @@ func (g *gateState) grantWait(r *gateReservation) bool {
 		}
 		g.removeWait(a)
 		a.state = gateWaitGranted
+		r.successorGranted = true
 		a.result <- nil
 		return true
 	}

--- a/flowcontrol/bbr/gate_state.go
+++ b/flowcontrol/bbr/gate_state.go
@@ -3,6 +3,7 @@ package bbr
 import (
 	"context"
 	"errors"
+	"sync"
 	"time"
 
 	"capnproto.org/go/capnp/v3/flowcontrol"
@@ -18,10 +19,11 @@ import (
 // surviving successors remain valid provisional entries. Fatal completion
 // preserves the first poison error and makes the controller terminal.
 type gateState struct {
-	nextID       uint64
-	reservations []*gateReservation
-	waiters      []*gateWaitAttempt
-	poison       error
+	nextID        uint64
+	reservations  []*gateReservation
+	waiters       []*gateWaitAttempt
+	pendingGrants []*gateReservation
+	poison        error
 }
 
 type gateReservationState uint8
@@ -39,6 +41,7 @@ type gateReservation struct {
 	state            gateReservationState
 	packet           packetMeta
 	successorGranted bool
+	successorUsed    bool
 }
 
 // gateCompleteAction tells the limiter actor which BBR lifecycle operation a
@@ -125,6 +128,38 @@ func (l *Limiter) gatePoison(err error) error {
 	_, eventErr := l.gateEvent(gateEvent{kind: gatePoisonEvent, err: err})
 	return eventErr
 }
+
+// gateController is the stable GateNext facade for one Limiter actor.
+type gateController struct {
+	limiter *Limiter
+}
+
+func (c *gateController) CommitMessage(size uint64) (func(context.Context) error, func(flowcontrol.MessageOutcomeKind, error)) {
+	r, err := c.limiter.gateCommit(size)
+	if err != nil {
+		return func(ctx context.Context) error {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return ctxErr
+			}
+			return err
+		}, func(flowcontrol.MessageOutcomeKind, error) {}
+	}
+
+	var completeOnce sync.Once
+	return func(ctx context.Context) error {
+			return c.limiter.gateWait(ctx, r)
+		}, func(kind flowcontrol.MessageOutcomeKind, err error) {
+			completeOnce.Do(func() {
+				_, _ = c.limiter.gateComplete(r, kind, err)
+			})
+		}
+}
+
+func (c *gateController) Poison(err error) {
+	_ = c.limiter.gatePoison(err)
+}
+
+var _ flowcontrol.GateNextController = (*gateController)(nil)
 
 // gateWait waits for one successor permission. Cancellation is resolved by
 // the actor: a canceled attempt is removed without consuming permission, while
@@ -213,6 +248,7 @@ func (l *Limiter) handleGateEvent(now time.Time, event gateEvent) {
 	switch event.kind {
 	case gateCommitEvent:
 		if l.gate.poison == nil {
+			l.gate.consumePendingGrant()
 			result.reservation = l.gate.commit(event.size)
 			result.reservation.packet = l.doSendAt(now, event.size)
 		} else {
@@ -226,9 +262,13 @@ func (l *Limiter) handleGateEvent(now time.Time, event gateEvent) {
 		case gateActionUnsend:
 			l.unsend(event.reservation)
 		}
+		if l.gate.poison != nil {
+			l.gate.dropPendingGrants()
+		}
 		l.gate.failWaiters()
 	case gatePoisonEvent:
 		l.gate.poisonWith(event.err)
+		l.gate.dropPendingGrants()
 		l.gate.failWaiters()
 	case gateWaitEvent:
 		result.err = l.gate.registerWait(event.waiter)
@@ -238,6 +278,7 @@ func (l *Limiter) handleGateEvent(now time.Time, event gateEvent) {
 		result.granted = l.gate.grantWait(event.reservation)
 	default:
 		l.gate.poisonWith(errors.New("bbr: invalid gate-next event"))
+		l.gate.dropPendingGrants()
 		l.gate.failWaiters()
 	}
 	event.reply <- result
@@ -296,6 +337,9 @@ func (g *gateState) registerWait(a *gateWaitAttempt) error {
 	if a.reservation.state == gateReservationPoisoned {
 		return errors.New("bbr: gate-next permission is no longer available")
 	}
+	if a.reservation.successorUsed {
+		return errors.New("bbr: gate-next permission is no longer available")
+	}
 	if a.reservation.successorGranted {
 		a.state = gateWaitGranted
 		a.result <- nil
@@ -350,10 +394,43 @@ func (g *gateState) grantWait(r *gateReservation) bool {
 		g.removeWait(a)
 		a.state = gateWaitGranted
 		r.successorGranted = true
+		g.pendingGrants = append(g.pendingGrants, r)
 		a.result <- nil
 		return true
 	}
 	return false
+}
+
+// grantNextWait grants one actor-queued successor when admission is open.
+func (g *gateState) grantNextWait() bool {
+	for _, a := range g.waiters {
+		if a.state == gateWaitWaiting && g.grantWait(a.reservation) {
+			return true
+		}
+	}
+	return false
+}
+
+// consumePendingGrant converts the oldest granted successor permission into
+// the next exact-size message reservation. A missing grant denotes the
+// bootstrap message of a new limiter generation.
+func (g *gateState) consumePendingGrant() {
+	if len(g.pendingGrants) == 0 {
+		return
+	}
+	r := g.pendingGrants[0]
+	copy(g.pendingGrants, g.pendingGrants[1:])
+	g.pendingGrants[len(g.pendingGrants)-1] = nil
+	g.pendingGrants = g.pendingGrants[:len(g.pendingGrants)-1]
+	r.successorUsed = true
+}
+
+func (g *gateState) dropPendingGrants() {
+	for _, r := range g.pendingGrants {
+		r.successorUsed = true
+	}
+	clear(g.pendingGrants)
+	g.pendingGrants = nil
 }
 
 func (g *gateState) failWaiters() {

--- a/flowcontrol/bbr/gate_state_test.go
+++ b/flowcontrol/bbr/gate_state_test.go
@@ -267,7 +267,7 @@ func TestGateWaitResultGrantWinsCanceledCaller(t *testing.T) {
 	assert.NoError(t, lim.gateWaitResult(ctx, a))
 }
 
-func TestGateWaitRegistrationRejectsDuplicateAndTerminalReservation(t *testing.T) {
+func TestGateWaitRegistrationRejectsDuplicateAndPoisonedReservation(t *testing.T) {
 	lim := NewLimiter(nil)
 	defer lim.Release()
 	r, err := lim.gateCommit(10)
@@ -283,10 +283,45 @@ func TestGateWaitRegistrationRejectsDuplicateAndTerminalReservation(t *testing.T
 	if !assert.NoError(t, err) {
 		return
 	}
-	_, err = lim.gateComplete(terminal, flowcontrol.MessageOutcomeSucceeded, nil)
+	fatal := errors.New("fatal")
+	_, err = lim.gateComplete(terminal, flowcontrol.MessageOutcomeFatal, fatal)
 	assert.NoError(t, err)
 	_, err = lim.gateStartWait(context.Background(), terminal)
-	assert.EqualError(t, err, "bbr: gate-next permission is no longer available")
+	assert.ErrorIs(t, err, fatal)
+}
+
+func TestGateWaitRemainsUsableAfterAcknowledgement(t *testing.T) {
+	lim := NewLimiter(nil)
+	defer lim.Release()
+	r, err := lim.gateCommit(10)
+	if !assert.NoError(t, err) {
+		return
+	}
+	_, err = lim.gateComplete(r, flowcontrol.MessageOutcomeSucceeded, nil)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	first, err := lim.gateStartWait(context.Background(), r)
+	if !assert.NoError(t, err) {
+		return
+	}
+	granted, err := lim.gateGrant(r)
+	assert.NoError(t, err)
+	assert.True(t, granted)
+	assert.NoError(t, <-first.result)
+
+	// Ticket forwarding may invoke the same published permission again after
+	// another caller won the grant. It must reuse that grant, not consume a
+	// second admission opportunity.
+	retry, err := lim.gateStartWait(context.Background(), r)
+	if !assert.NoError(t, err) {
+		return
+	}
+	assert.NoError(t, <-retry.result)
+	granted, err = lim.gateGrant(r)
+	assert.NoError(t, err)
+	assert.False(t, granted)
 }
 
 func TestGateGrantRejectsMissingAndPoisonedWaiter(t *testing.T) {

--- a/flowcontrol/bbr/gate_state_test.go
+++ b/flowcontrol/bbr/gate_state_test.go
@@ -306,10 +306,10 @@ func TestGateWaitRemainsUsableAfterAcknowledgement(t *testing.T) {
 	if !assert.NoError(t, err) {
 		return
 	}
+	assert.NoError(t, <-first.result)
 	granted, err := lim.gateGrant(r)
 	assert.NoError(t, err)
-	assert.True(t, granted)
-	assert.NoError(t, <-first.result)
+	assert.False(t, granted)
 
 	// Ticket forwarding may invoke the same published permission again after
 	// another caller won the grant. It must reuse that grant, not consume a
@@ -322,6 +322,122 @@ func TestGateWaitRemainsUsableAfterAcknowledgement(t *testing.T) {
 	granted, err = lim.gateGrant(r)
 	assert.NoError(t, err)
 	assert.False(t, granted)
+}
+
+func TestGateControllerIsStable(t *testing.T) {
+	lim := NewLimiter(nil)
+	defer lim.Release()
+
+	assert.Same(t, lim.GateNext(), lim.GateNext())
+}
+
+func TestGatePendingGrantClosesWindowAndConvertsAtCommit(t *testing.T) {
+	now := time.Unix(1, 0)
+	lim := newLimiterState(clock.NewManual(now), limiterOptions{})
+	lim.maxPacketsInflight = 1
+	first := applyGateEvent(lim, now, gateEvent{kind: gateCommitEvent, size: 10}).reservation
+	waiter := newGateWaitAttempt(first)
+	registered := applyGateEvent(lim, now, gateEvent{kind: gateWaitEvent, waiter: waiter})
+	if !assert.NoError(t, registered.err) {
+		return
+	}
+	assert.False(t, lim.prepareStep(now).acceptSend)
+
+	ack := applyGateEvent(lim, now.Add(time.Millisecond), gateEvent{
+		kind:        gateCompleteEvent,
+		reservation: first,
+		outcome:     flowcontrol.MessageOutcomeSucceeded,
+	})
+	assert.Equal(t, gateActionAck, ack.action)
+	assert.True(t, lim.prepareStep(now.Add(time.Millisecond)).acceptSend)
+	assert.True(t, lim.gate.grantNextWait())
+	assert.NoError(t, <-waiter.result)
+	assert.Len(t, lim.gate.pendingGrants, 1)
+	assert.False(t, lim.prepareStep(now.Add(time.Millisecond)).acceptSend)
+
+	second := applyGateEvent(lim, now.Add(time.Millisecond), gateEvent{
+		kind: gateCommitEvent,
+		size: 20,
+	}).reservation
+	assert.NotNil(t, second)
+	assert.Empty(t, lim.gate.pendingGrants)
+	assert.True(t, first.successorUsed)
+	assert.Equal(t, uint64(20), lim.inflight())
+	assert.Equal(t, uint64(1), lim.packetsInflight)
+}
+
+func TestGateProductionGrantWaitsForOpenWindow(t *testing.T) {
+	lim := NewLimiter(nil)
+	defer lim.Release()
+	lim.whilePaused(func() {
+		lim.maxPacketsInflight = 1
+	})
+	r, err := lim.gateCommit(10)
+	if !assert.NoError(t, err) {
+		return
+	}
+	waiter, err := lim.gateStartWait(context.Background(), r)
+	if !assert.NoError(t, err) {
+		return
+	}
+	select {
+	case err := <-waiter.result:
+		t.Fatalf("gate granted with a full packet window: %v", err)
+	default:
+	}
+
+	_, err = lim.gateComplete(r, flowcontrol.MessageOutcomeSucceeded, nil)
+	assert.NoError(t, err)
+	assert.NoError(t, <-waiter.result)
+}
+
+func TestGateDefinitelyUnsentReplaysAndWakesSuccessor(t *testing.T) {
+	lim := NewLimiter(nil)
+	defer lim.Release()
+	lim.whilePaused(func() {
+		lim.maxPacketsInflight = 1
+	})
+	r, err := lim.gateCommit(10)
+	if !assert.NoError(t, err) {
+		return
+	}
+	waiter, err := lim.gateStartWait(context.Background(), r)
+	if !assert.NoError(t, err) {
+		return
+	}
+	select {
+	case err := <-waiter.result:
+		t.Fatalf("gate granted with a full packet window: %v", err)
+	default:
+	}
+
+	action, err := lim.gateComplete(r, flowcontrol.MessageOutcomeAbortedBeforeEnqueue, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, gateActionUnsend, action)
+	assert.NoError(t, <-waiter.result)
+
+	next, err := lim.gateCommit(20)
+	assert.NoError(t, err)
+	assert.NotNil(t, next)
+	lim.whilePaused(func() {
+		assert.Empty(t, lim.gate.pendingGrants)
+		assert.Equal(t, uint64(20), lim.inflight())
+		assert.Equal(t, uint64(1), lim.packetsInflight)
+	})
+}
+
+func TestGateControllerWaitSurvivesCompletionBeforeRegistration(t *testing.T) {
+	lim := NewLimiter(nil)
+	defer lim.Release()
+	controller := lim.GateNext()
+	waitNext, complete := controller.CommitMessage(10)
+	complete(flowcontrol.MessageOutcomeSucceeded, nil)
+
+	assert.NoError(t, waitNext(context.Background()))
+	assert.NoError(t, waitNext(context.Background()))
+
+	_, completeNext := controller.CommitMessage(20)
+	completeNext(flowcontrol.MessageOutcomeAbortedBeforeEnqueue, nil)
 }
 
 func TestGateGrantRejectsMissingAndPoisonedWaiter(t *testing.T) {

--- a/flowcontrol/bbr/limiter.go
+++ b/flowcontrol/bbr/limiter.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"capnproto.org/go/capnp/v3/exp/clock"
+	"capnproto.org/go/capnp/v3/flowcontrol"
 )
 
 // A packetMeta contains metadata about a packet that was sent.
@@ -94,6 +95,11 @@ func (l *Limiter) computeBDP() float64 {
 func (l *Limiter) prepareStep(now time.Time) limiterWait {
 	bdp := l.computeBDP()
 
+	// A granted GateNext successor has reserved the next packet admission but
+	// cannot be byte-charged until preparation reveals its final size.
+	if len(l.gate.pendingGrants) > 0 {
+		return limiterWait{}
+	}
 	if l.inflight() == 0 {
 		// With nothing on the wire there is no ACK that can unblock an
 		// inaccurate initial pacing estimate, so always accept a send.
@@ -149,6 +155,9 @@ func (l *Limiter) run(ctx context.Context) {
 
 		now := l.clock.Now()
 		wait := l.prepareStep(now)
+		if wait.acceptSend && l.gate.grantNextWait() {
+			continue
+		}
 		if wait.acceptSend {
 			sendReqs = l.chSend
 		} else if wait.hasDeadline {
@@ -321,10 +330,10 @@ type Limiter struct {
 	// Private test seam for deterministic ProbeBW initialization.
 	randInt func() int
 
-	// Private actor-owned GateNext reservation ledger. It is not exposed until
-	// the capnp admission surface is complete.
-	gate   gateState
-	chGate chan gateEvent
+	// Private actor-owned GateNext reservation ledger and stable facade.
+	gate           gateState
+	gateController *gateController
+	chGate         chan gateEvent
 }
 
 // For testing purpoes; temporarily pauses the goroutine managing the limiter,
@@ -353,6 +362,13 @@ func (l *Limiter) inflight() uint64 {
 func NewLimiter(clk clock.Clock) *Limiter {
 	return newLimiter(clk, limiterOptions{randInt: rand.Int})
 }
+
+// GateNext returns the stable successor-admission controller owned by l.
+func (l *Limiter) GateNext() flowcontrol.GateNextController {
+	return l.gateController
+}
+
+var _ flowcontrol.GateNextFlowLimiter = (*Limiter)(nil)
 
 type limiterOptions struct {
 	randInt func() int
@@ -397,6 +413,7 @@ func newLimiterState(clk clock.Clock, options limiterOptions) *Limiter {
 		done:    make(chan struct{}),
 		randInt: options.randInt,
 	}
+	l.gateController = &gateController{limiter: l}
 	l.changeState(&startupState{}, now)
 	return l
 }

--- a/rpc/flow_test.go
+++ b/rpc/flow_test.go
@@ -4,6 +4,7 @@ package rpc
 
 import (
 	"context"
+	"errors"
 	"net"
 	"sync"
 	"testing"
@@ -12,6 +13,8 @@ import (
 	"capnproto.org/go/capnp/v3"
 	"capnproto.org/go/capnp/v3/flowcontrol"
 	"capnproto.org/go/capnp/v3/rpc/internal/testcapnp"
+	"capnproto.org/go/capnp/v3/rpc/transport"
+	serverpkg "capnproto.org/go/capnp/v3/server"
 )
 
 // observingLimiter reports when a call to StartMessage is waiting for a
@@ -24,6 +27,70 @@ type observingLimiter struct {
 	started, proceeded uint64
 	changed            chan struct{}
 }
+
+type countingTransport struct {
+	Transport
+
+	mu          sync.Mutex
+	newMessages int
+}
+
+func (t *countingTransport) NewMessage() (transport.OutgoingMessage, error) {
+	msg, err := t.Transport.NewMessage()
+	if err == nil {
+		t.mu.Lock()
+		t.newMessages++
+		t.mu.Unlock()
+	}
+	return msg, err
+}
+
+func (t *countingTransport) count() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.newMessages
+}
+
+type blockingGateController struct {
+	waitEntered chan struct{}
+	grant       chan struct{}
+	completions chan flowcontrol.MessageOutcomeKind
+	poisons     chan error
+}
+
+func (g *blockingGateController) CommitMessage(uint64) (func(context.Context) error, func(flowcontrol.MessageOutcomeKind, error)) {
+	return func(ctx context.Context) error {
+			g.waitEntered <- struct{}{}
+			select {
+			case <-g.grant:
+				return nil
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}, func(kind flowcontrol.MessageOutcomeKind, _ error) {
+			g.completions <- kind
+		}
+}
+
+func (g *blockingGateController) Poison(err error) {
+	g.poisons <- err
+}
+
+type blockingGateLimiter struct {
+	gate *blockingGateController
+}
+
+func (*blockingGateLimiter) StartMessage(context.Context, uint64) (func(), error) {
+	return func() {}, errors.New("legacy StartMessage called for prepared RPC send")
+}
+
+func (*blockingGateLimiter) Release() {}
+
+func (l *blockingGateLimiter) GateNext() flowcontrol.GateNextController {
+	return l.gate
+}
+
+var _ flowcontrol.GateNextFlowLimiter = (*blockingGateLimiter)(nil)
 
 func newObservingLimiter(limit int64) *observingLimiter {
 	return &observingLimiter{
@@ -169,6 +236,383 @@ func TestFixedFlowLimit(t *testing.T) {
 	cancel()
 	<-done
 
+}
+
+func TestGateNextRPCImportPreparesAfterGate(t *testing.T) {
+	clientConn, serverConn := net.Pipe()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	unblockServer := make(chan struct{})
+	serverDone := make(chan struct{})
+	go func() {
+		defer close(serverDone)
+		bootstrap := testcapnp.StreamTest_ServerToClient(gatedStreamTestServer{unblock: unblockServer})
+		conn := NewConn(NewStreamTransport(serverConn), &Options{BootstrapClient: capnp.Client(bootstrap)})
+		defer conn.Close()
+		<-ctx.Done()
+	}()
+
+	trans := &countingTransport{Transport: NewStreamTransport(clientConn)}
+	conn := NewConn(trans, nil)
+	defer conn.Close()
+	client := testcapnp.StreamTest(conn.Bootstrap(ctx))
+	defer client.Release()
+	if err := client.Resolve(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	gate := &blockingGateController{
+		waitEntered: make(chan struct{}, 1),
+		grant:       make(chan struct{}),
+		completions: make(chan flowcontrol.MessageOutcomeKind, 4),
+		poisons:     make(chan error, 1),
+	}
+	limiter := &blockingGateLimiter{gate: gate}
+	capnp.Client(client).SetFlowLimiter(limiter)
+
+	if err := client.Push(ctx, func(p testcapnp.StreamTest_push_Params) error {
+		return p.SetData([]byte{1})
+	}); err != nil {
+		t.Fatal(err)
+	}
+	before := trans.count()
+
+	placed := make(chan struct{})
+	secondDone := make(chan error, 1)
+	go func() {
+		secondDone <- client.Push(ctx, func(p testcapnp.StreamTest_push_Params) error {
+			close(placed)
+			return p.SetData([]byte{2})
+		})
+	}()
+	<-gate.waitEntered
+	select {
+	case <-placed:
+		t.Fatal("RPC PlaceArgs ran behind a closed GateNext permission")
+	default:
+	}
+	if got := trans.count(); got != before {
+		t.Fatalf("transport NewMessage count = %d; want %d while gate is closed", got, before)
+	}
+
+	close(gate.grant)
+	if err := <-secondDone; err != nil {
+		t.Fatal(err)
+	}
+	<-placed
+	if got := trans.count(); got != before+1 {
+		t.Fatalf("transport NewMessage count = %d; want %d after gate opened", got, before+1)
+	}
+
+	close(unblockServer)
+	if err := capnp.Client(client).WaitStreaming(); err != nil {
+		t.Fatal(err)
+	}
+	for range 2 {
+		if kind := <-gate.completions; kind != flowcontrol.MessageOutcomeSucceeded {
+			t.Fatalf("terminal outcome = %v; want succeeded", kind)
+		}
+	}
+	select {
+	case kind := <-gate.completions:
+		t.Fatalf("duplicate terminal completion %v", kind)
+	default:
+	}
+	select {
+	case err := <-gate.poisons:
+		t.Fatalf("unexpected controller poison: %v", err)
+	default:
+	}
+	cancel()
+	<-serverDone
+}
+
+func TestGateNextRPCPipelinePreparesAfterGate(t *testing.T) {
+	const (
+		parentInterface = 0xf001
+		parentMethod    = 1
+		childInterface  = 0xf002
+		childMethod     = 2
+	)
+	clientConn, serverConn := net.Pipe()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	child := capnp.NewClient(serverpkg.New([]serverpkg.Method{{
+		Method: capnp.Method{InterfaceID: childInterface, MethodID: childMethod},
+		Impl: func(context.Context, *serverpkg.Call) error {
+			return nil
+		},
+	}}, nil, nil))
+	defer child.Release()
+	unblockParent := make(chan struct{})
+	parent := capnp.NewClient(serverpkg.New([]serverpkg.Method{{
+		Method: capnp.Method{InterfaceID: parentInterface, MethodID: parentMethod},
+		Impl: func(_ context.Context, call *serverpkg.Call) error {
+			call.Go()
+			<-unblockParent
+			results, err := call.AllocResults(capnp.ObjectSize{PointerCount: 1})
+			if err != nil {
+				return err
+			}
+			id := results.Message().CapTable().Add(child)
+			return results.SetPtr(0, capnp.NewInterface(results.Segment(), id).ToPtr())
+		},
+	}}, nil, nil))
+	defer parent.Release()
+
+	serverDone := make(chan struct{})
+	go func() {
+		defer close(serverDone)
+		conn := NewConn(NewStreamTransport(serverConn), &Options{BootstrapClient: parent})
+		defer conn.Close()
+		<-ctx.Done()
+	}()
+
+	trans := &countingTransport{Transport: NewStreamTransport(clientConn)}
+	conn := NewConn(trans, nil)
+	defer conn.Close()
+	client := conn.Bootstrap(ctx)
+	defer client.Release()
+	if err := client.Resolve(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	gate := &blockingGateController{
+		waitEntered: make(chan struct{}, 1),
+		grant:       make(chan struct{}),
+		completions: make(chan flowcontrol.MessageOutcomeKind, 4),
+		poisons:     make(chan error, 1),
+	}
+	client.SetFlowLimiter(&blockingGateLimiter{gate: gate})
+
+	parentAnswer, releaseParent := client.SendCall(ctx, capnp.Send{
+		Method: capnp.Method{InterfaceID: parentInterface, MethodID: parentMethod},
+	})
+	defer releaseParent()
+	before := trans.count()
+
+	placed := make(chan struct{})
+	type pipelineResult struct {
+		answer  *capnp.Answer
+		release capnp.ReleaseFunc
+	}
+	pipelineDone := make(chan pipelineResult, 1)
+	go func() {
+		answer, release := parentAnswer.PipelineSend(ctx, []capnp.PipelineOp{{Field: 0}}, capnp.Send{
+			Method: capnp.Method{InterfaceID: childInterface, MethodID: childMethod},
+			PlaceArgs: func(capnp.Struct) error {
+				close(placed)
+				return nil
+			},
+		})
+		pipelineDone <- pipelineResult{answer: answer, release: release}
+	}()
+	<-gate.waitEntered
+	select {
+	case <-placed:
+		t.Fatal("pipelined RPC PlaceArgs ran behind a closed GateNext permission")
+	default:
+	}
+	if got := trans.count(); got != before {
+		t.Fatalf("transport NewMessage count = %d; want %d while pipeline gate is closed", got, before)
+	}
+
+	close(gate.grant)
+	pipelined := <-pipelineDone
+	defer pipelined.release()
+	<-placed
+	if got := trans.count(); got != before+1 {
+		t.Fatalf("transport NewMessage count = %d; want %d after pipeline gate opened", got, before+1)
+	}
+
+	close(unblockParent)
+	if _, err := parentAnswer.Struct(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pipelined.answer.Struct(); err != nil {
+		t.Fatal(err)
+	}
+	for range 2 {
+		if kind := <-gate.completions; kind != flowcontrol.MessageOutcomeSucceeded {
+			t.Fatalf("terminal outcome = %v; want succeeded", kind)
+		}
+	}
+	select {
+	case kind := <-gate.completions:
+		t.Fatalf("duplicate terminal completion %v", kind)
+	default:
+	}
+	select {
+	case err := <-gate.poisons:
+		t.Fatalf("unexpected controller poison: %v", err)
+	default:
+	}
+	cancel()
+	<-serverDone
+}
+
+func TestGateNextRPCPrecommitCancellationDoesNotPoisonStream(t *testing.T) {
+	clientConn, serverConn := net.Pipe()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	unblockServer := make(chan struct{})
+	serverDone := make(chan struct{})
+	go func() {
+		defer close(serverDone)
+		bootstrap := testcapnp.StreamTest_ServerToClient(gatedStreamTestServer{unblock: unblockServer})
+		conn := NewConn(NewStreamTransport(serverConn), &Options{BootstrapClient: capnp.Client(bootstrap)})
+		defer conn.Close()
+		<-ctx.Done()
+	}()
+
+	trans := &countingTransport{Transport: NewStreamTransport(clientConn)}
+	conn := NewConn(trans, nil)
+	defer conn.Close()
+	client := testcapnp.StreamTest(conn.Bootstrap(ctx))
+	defer client.Release()
+	if err := client.Resolve(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	gate := &blockingGateController{
+		waitEntered: make(chan struct{}, 2),
+		grant:       make(chan struct{}),
+		completions: make(chan flowcontrol.MessageOutcomeKind, 4),
+		poisons:     make(chan error, 1),
+	}
+	capnp.Client(client).SetFlowLimiter(&blockingGateLimiter{gate: gate})
+	if err := client.Push(ctx, func(p testcapnp.StreamTest_push_Params) error {
+		return p.SetData([]byte{1})
+	}); err != nil {
+		t.Fatal(err)
+	}
+	before := trans.count()
+
+	callCtx, cancelCall := context.WithCancel(ctx)
+	placedCanceled := make(chan struct{})
+	canceledDone := make(chan error, 1)
+	go func() {
+		canceledDone <- client.Push(callCtx, func(p testcapnp.StreamTest_push_Params) error {
+			close(placedCanceled)
+			return p.SetData([]byte{2})
+		})
+	}()
+	<-gate.waitEntered
+	cancelCall()
+	if err := <-canceledDone; !errors.Is(err, context.Canceled) {
+		t.Fatalf("canceled Push = %v; want context.Canceled", err)
+	}
+	select {
+	case <-placedCanceled:
+		t.Fatal("canceled RPC call reached PlaceArgs before admission")
+	default:
+	}
+	if got := trans.count(); got != before {
+		t.Fatalf("transport NewMessage count = %d; want %d after pre-commit cancellation", got, before)
+	}
+	select {
+	case err := <-gate.poisons:
+		t.Fatalf("pre-commit cancellation poisoned controller: %v", err)
+	default:
+	}
+
+	placedSuccessor := make(chan struct{})
+	successorDone := make(chan error, 1)
+	go func() {
+		successorDone <- client.Push(ctx, func(p testcapnp.StreamTest_push_Params) error {
+			close(placedSuccessor)
+			return p.SetData([]byte{3})
+		})
+	}()
+	<-gate.waitEntered
+	close(gate.grant)
+	if err := <-successorDone; err != nil {
+		t.Fatalf("successor Push after cancellation = %v", err)
+	}
+	<-placedSuccessor
+
+	close(unblockServer)
+	if err := capnp.Client(client).WaitStreaming(); err != nil {
+		t.Fatalf("stream poisoned by pre-commit cancellation: %v", err)
+	}
+	for range 2 {
+		if kind := <-gate.completions; kind != flowcontrol.MessageOutcomeSucceeded {
+			t.Fatalf("terminal outcome = %v; want succeeded", kind)
+		}
+	}
+	select {
+	case kind := <-gate.completions:
+		t.Fatalf("canceled call produced terminal completion %v", kind)
+	default:
+	}
+	cancel()
+	<-serverDone
+}
+
+func TestGateNextRPCApplicationExceptionIsSuccessfulTransportOutcome(t *testing.T) {
+	const (
+		interfaceID = 0xf003
+		methodID    = 3
+	)
+	clientConn, serverConn := net.Pipe()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	applicationErr := errors.New("application failure")
+	bootstrap := capnp.NewClient(serverpkg.New([]serverpkg.Method{{
+		Method: capnp.Method{InterfaceID: interfaceID, MethodID: methodID},
+		Impl: func(context.Context, *serverpkg.Call) error {
+			return applicationErr
+		},
+	}}, nil, nil))
+	defer bootstrap.Release()
+
+	serverDone := make(chan struct{})
+	go func() {
+		defer close(serverDone)
+		conn := NewConn(NewStreamTransport(serverConn), &Options{BootstrapClient: bootstrap})
+		defer conn.Close()
+		<-ctx.Done()
+	}()
+	conn := NewConn(NewStreamTransport(clientConn), nil)
+	defer conn.Close()
+	client := conn.Bootstrap(ctx)
+	defer client.Release()
+	if err := client.Resolve(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	gate := &blockingGateController{
+		waitEntered: make(chan struct{}, 1),
+		grant:       make(chan struct{}),
+		completions: make(chan flowcontrol.MessageOutcomeKind, 2),
+		poisons:     make(chan error, 1),
+	}
+	client.SetFlowLimiter(&blockingGateLimiter{gate: gate})
+	answer, release := client.SendCall(ctx, capnp.Send{
+		Method: capnp.Method{InterfaceID: interfaceID, MethodID: methodID},
+	})
+	defer release()
+	if _, err := answer.Struct(); err == nil {
+		t.Fatal("application call unexpectedly succeeded")
+	}
+	if kind := <-gate.completions; kind != flowcontrol.MessageOutcomeSucceeded {
+		t.Fatalf("terminal outcome = %v; want succeeded transport", kind)
+	}
+	select {
+	case kind := <-gate.completions:
+		t.Fatalf("duplicate terminal completion %v", kind)
+	default:
+	}
+	select {
+	case err := <-gate.poisons:
+		t.Fatalf("application exception poisoned controller: %v", err)
+	default:
+	}
+	cancel()
+	<-serverDone
 }
 
 type gatedStreamTestServer struct {


### PR DESCRIPTION
## Summary

- expose BBR's stable `GateNext` controller and admit one successor through the existing pacing/congestion window
- preserve successor permission across ACK or definitely-unsent completion, then convert the pending permission into exact-size accounting at commit
- activate private prepared-send admission for direct imports and unresolved promised-answer pipelines, including generation-aware FIFO handoff after resolution
- keep receive-side forwarding and legacy non-preparer hooks unchanged; remove the obsolete recursive forwarding shim

This is the activation PR from the reviewed three-PR GateNext plan. It does not change BBR congestion-control math, public flow-control interfaces, the RPC wire protocol, generated code, or the question lifecycle.

## Correctness

- a closed gate prevents both `PlaceArgs` and transport-message allocation for imported and pipelined RPC sends
- pre-commit cancellation is definitely unsent, retry-safe, and does not poison a stream
- success, remote application exceptions, definitely-unsent replay, fatal poison, after-ACK waits, exact-once completion, and limiter-generation drain are covered
- unresolved pipeline waits do not hold Promise resolution open; a resolved target acquires its FIFO position before the origin position is released
- no flow-control wait runs on the RPC receive goroutine

## Review

- plan completion: all PR3 activation items addressed
- scope check: clean
- pre-landing review: no findings
- credential scan: clean

## Test plan

- [x] `gofmt` on changed Go files
- [x] `go test -count=1 ./...`
- [x] `go test -race -short -count=1 ./ ./flowcontrol/bbr ./rpc`
- [x] `go test -race -short ./...`
- [x] focused RPC, GateNext, flow-control, and pipeline tests repeated 100 times
- [x] focused race tests repeated 20 times
- [x] `git diff --check origin/main...HEAD`
- [ ] `GOARCH=386 go test ./...` is unsupported on the local macOS host (`darwin/386`); covered by the Linux CI matrix
