### PR TITLE
rpc: guard error answer cleanup

### DIFF
--- a/rpc/answer.go
+++ b/rpc/answer.go
@@ -409,7 +409,9 @@ func (ans *ansent) completeSendException(dq *deferred.Queue) {
 //
 // shutdown has its own strategy for cleaning up an answer.
 func (ans *ansent) destroy(dq *deferred.Queue) error {
-	dq.Defer(ans.returner.msgReleaser.Decr)
+	if ans.returner.msgReleaser != nil {
+		dq.Defer(ans.returner.msgReleaser.Decr)
+	}
 	c := ans.lockedConn()
 	c.lk.answers.Remove(ans.returner.id)
 	for _, s := range ans.returner.resultsCapTable {

--- a/rpc/answer.go
+++ b/rpc/answer.go
@@ -409,6 +409,7 @@ func (ans *ansent) completeSendException(dq *deferred.Queue) {
 //
 // shutdown has its own strategy for cleaning up an answer.
 func (ans *ansent) destroy(dq *deferred.Queue) error {
+	// errorAnswer has no return message when newReturn fails.
 	if ans.returner.msgReleaser != nil {
 		dq.Defer(ans.returner.msgReleaser.Decr)
 	}

--- a/rpc/answer_finish_test.go
+++ b/rpc/answer_finish_test.go
@@ -1,0 +1,41 @@
+package rpc
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+
+	"capnproto.org/go/capnp/v3"
+	rpccp "capnproto.org/go/capnp/v3/std/capnp/rpc"
+)
+
+func TestFinishDestroysErrorAnswerWithoutReturnMessage(t *testing.T) {
+	const id answerID = 11
+	conn := new(Conn)
+	if !conn.lk.answers.Create(id, errorAnswer(conn, id, errors.New("return allocation failed"))) {
+		t.Fatal("answer ID already present")
+	}
+
+	_, seg := capnp.NewSingleSegmentMessage(nil)
+	message, err := rpccp.NewRootMessage(seg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	finish, err := message.NewFinish()
+	if err != nil {
+		t.Fatal(err)
+	}
+	finish.SetQuestionId(uint32(id))
+	in := &countingIncomingMessage{message: message}
+
+	if err := conn.handleFinish(context.Background(), in); err != nil {
+		t.Fatal("handle Finish:", err)
+	}
+	if got := atomic.LoadInt32(&in.releases); got != 1 {
+		t.Fatalf("incoming message releases = %d; want 1", got)
+	}
+	if _, ok := conn.lk.answers.Find(id); ok {
+		t.Fatal("error answer remains live after Finish")
+	}
+}

--- a/rpc/answer_finish_test.go
+++ b/rpc/answer_finish_test.go
@@ -3,12 +3,30 @@ package rpc
 import (
 	"context"
 	"errors"
+	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"capnproto.org/go/capnp/v3"
 	rpccp "capnproto.org/go/capnp/v3/std/capnp/rpc"
 )
+
+func newAnswerBootstrapMessage(t *testing.T, id answerID) *countingIncomingMessage {
+	t.Helper()
+
+	_, seg := capnp.NewSingleSegmentMessage(nil)
+	message, err := rpccp.NewRootMessage(seg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bootstrap, err := message.NewBootstrap()
+	if err != nil {
+		t.Fatal(err)
+	}
+	bootstrap.SetQuestionId(uint32(id))
+	return &countingIncomingMessage{message: message}
+}
 
 func TestFinishDestroysErrorAnswerWithoutReturnMessage(t *testing.T) {
 	const id answerID = 11
@@ -37,5 +55,50 @@ func TestFinishDestroysErrorAnswerWithoutReturnMessage(t *testing.T) {
 	}
 	if _, ok := conn.lk.answers.Find(id); ok {
 		t.Fatal("error answer remains live after Finish")
+	}
+}
+
+func TestBootstrapReuseAfterReturnAllocationFailure(t *testing.T) {
+	const id answerID = 12
+	conn := &Conn{
+		transport: newMessageErrorTransport{err: errors.New("return allocation failed")},
+	}
+	if !conn.lk.answers.Create(id, errorAnswer(conn, id, errors.New("existing answer"))) {
+		t.Fatal("answer ID already present")
+	}
+	in := newAnswerBootstrapMessage(t, id)
+
+	err := conn.handleBootstrap(in)
+	if err == nil || !strings.Contains(err.Error(), "answer ID 12 reused") {
+		t.Fatalf("handle Bootstrap error = %v; want answer reuse error", err)
+	}
+	if got := atomic.LoadInt32(&in.releases); got != 1 {
+		t.Fatalf("incoming message releases = %d; want 1", got)
+	}
+	if _, ok := conn.lk.answers.Find(id); !ok {
+		t.Fatal("existing answer removed after rejected Bootstrap")
+	}
+}
+
+func TestBootstrapReuseReleasesUnsentReturn(t *testing.T) {
+	const id answerID = 13
+	transport := newFailingSendTransport(nil)
+	conn := &Conn{transport: transport}
+	if !conn.lk.answers.Create(id, errorAnswer(conn, id, errors.New("existing answer"))) {
+		t.Fatal("answer ID already present")
+	}
+	in := newAnswerBootstrapMessage(t, id)
+
+	err := conn.handleBootstrap(in)
+	if err == nil || !strings.Contains(err.Error(), "answer ID 13 reused") {
+		t.Fatalf("handle Bootstrap error = %v; want answer reuse error", err)
+	}
+	if got := atomic.LoadInt32(&in.releases); got != 1 {
+		t.Fatalf("incoming message releases = %d; want 1", got)
+	}
+	select {
+	case <-transport.firstRelease:
+	case <-time.After(2 * time.Second):
+		t.Fatal("unsent Bootstrap Return was not released")
 	}
 }

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -703,7 +703,11 @@ func (c *Conn) handleBootstrap(in transport.IncomingMessage) error {
 
 	c.withLocked(func(c *lockedConn) {
 		if _, ok := c.lk.answers.Find(ans.returner.id); ok {
-			dq.Defer(ans.returner.msgReleaser.Decr)
+			if ans.returner.msgReleaser != nil {
+				// The answer and unsent send path each own one reference.
+				dq.Defer(ans.returner.msgReleaser.Decr)
+				dq.Defer(ans.returner.msgReleaser.Decr)
+			}
 			err = rpcerr.Failed(errors.New("incoming bootstrap: answer ID " + str.Utod(ans.returner.id) + " reused"))
 			return
 		}


### PR DESCRIPTION
## Summary

- guard answer destruction when a failed Return allocation left no message releaser
- prevent a subsequent `Finish` from invoking `Decr` on a nil releaser
- verify the placeholder answer is retired and the incoming message is released exactly once

This fixes a pre-existing lifecycle defect found during the adversarial review of the unknown-`Finish` interoperability work.

## Test coverage

- focused regression repeated under normal and race test runners
- `go test ./...`
- `go test -race -short ./...`
- `git diff --check`

## Compatibility

No public API, schema, or wire-format changes.
