### PR TITLE
test: stabilize resolved handoff allocation count

### DIFF
--- a/rpc/flow_test.go
+++ b/rpc/flow_test.go
@@ -626,6 +626,12 @@ func TestGateNextRPCResolvedPipelineHandoffUsesTargetGate(t *testing.T) {
 	if _, err := parentAnswer.Struct(); err != nil {
 		t.Fatal(err)
 	}
+	// parentAnswer.Struct can wake before the Return drain queues Finish.
+	// Stabilize the global transport count before measuring the handed-off
+	// call below.
+	if err := trans.waitForCount(ctx, 4); err != nil {
+		t.Fatal(err)
+	}
 	target := parentAnswer.Field(0, nil).Client()
 	targetGate := &blockingGateController{
 		waitEntered: make(chan struct{}, 1),


### PR DESCRIPTION
## Summary

- wait for the parent question's asynchronous `Finish` allocation before measuring the resolved pipeline handoff
- prevent `TestGateNextRPCResolvedPipelineHandoffUsesTargetGate` from attributing that legal control message to the handed-off call

## Root cause

`parentAnswer.Struct()` wakes when the promise resolves, before the Return drain necessarily queues `Finish`. On a slower 386 schedule, the test sampled the transport count in that gap and later observed both `Finish` and the pipelined `Call`.

## Testing

- `go test ./rpc -run '^TestGateNextRPCResolvedPipelineHandoffUsesTargetGate$' -count=5000`
- `go test ./rpc -count=100`
- `go test ./... -count=1`
- `go test -race -short ./... -count=1`
- `GOOS=linux GOARCH=386 go test -c ./rpc`
