### PR TITLE
capnp: settle promises retained by snapshots

### DIFF
--- a/capability.go
+++ b/capability.go
@@ -467,10 +467,16 @@ func newPromisedClient(hook ClientHook) (Client, *clientPromise) {
 		metadata:   *NewMetadata(),
 		resolution: maybe.New(&rs),
 	})
+	promiseHook := mutex.With1(&cursor.Value().hook, func(h **rc.Ref[clientHook]) *rc.WeakRef[clientHook] {
+		return (*h).Weak()
+	})
 	cs := mutex.New(clientState{cursor: cursor, flow: newClientFlow(flowcontrol.NopLimiter)})
 	c := Client{client: &client{state: cs}}
 	setupLeakReporting(c)
-	return c, &clientPromise{cursor: cursor.Weak()}
+	return c, &clientPromise{
+		hook:   promiseHook,
+		cursor: cursor.Weak(),
+	}
 }
 
 // startCall holds onto a hook to prevent it from shutting down until
@@ -1479,6 +1485,12 @@ func SetClientLeakFunc(clientLeakFunc func(msg string)) {
 
 // A ClientPromise resolves the identity of a client created by NewPromisedClient.
 type clientPromise struct {
+	// hook keeps settlement reachable while any client view remains live.
+	// In particular, ClientSnapshot holds a clientHook without retaining
+	// the original clientCursor.
+	hook *rc.WeakRef[clientHook]
+
+	// cursor is retained separately for best-effort path shortening.
 	cursor *rc.WeakRef[clientCursor]
 }
 
@@ -1502,11 +1514,11 @@ func (cp *clientPromise) Fulfill(c Client) {
 // to return answers or shut down the underlying hook; instead, it adds functions
 // to do this to dq.
 func (cp *clientPromise) fulfill(dq *deferred.Queue, c Client) {
-	cursor, ok := cp.cursor.AddRef()
+	hook, ok := cp.hook.AddRef()
 	if !ok {
 		return
 	}
-	dq.Defer(cursor.Release)
+	dq.Defer(hook.Release)
 
 	// Obtain next client hook.
 	var rh *rc.Ref[clientHook]
@@ -1519,20 +1531,22 @@ func (cp *clientPromise) fulfill(dq *deferred.Queue, c Client) {
 	}
 
 	// Mark hook as resolved.
-	cursor.Value().hook.With(func(h **rc.Ref[clientHook]) {
-		r, ok := (*h).Value().resolution.Get()
-		if !ok {
-			panic("BUG: clientPromise referred to a clientHook that was not a promise")
+	r, ok := hook.Value().resolution.Get()
+	if !ok {
+		panic("BUG: clientPromise referred to a clientHook that was not a promise")
+	}
+	r.With(func(s *resolveState) {
+		if s.isResolved() {
+			panic("ClientPromise.Fulfill called more than once")
 		}
-		r.With(func(s *resolveState) {
-			if s.isResolved() {
-				panic("ClientPromise.Fulfill called more than once")
-			}
-			s.resolvedHook = rh
-			close(s.resolved)
-		})
+		s.resolvedHook = rh
+		close(s.resolved)
 	})
-	cursor.Value().compress()
+
+	if cursor, ok := cp.cursor.AddRef(); ok {
+		dq.Defer(cursor.Release)
+		cursor.Value().compress()
+	}
 }
 
 // A WeakClient is a weak reference to a capability: it refers to a

--- a/capability_test.go
+++ b/capability_test.go
@@ -338,6 +338,61 @@ func TestPromisedClient_EarlyClose(t *testing.T) {
 	}
 }
 
+func TestPromisedClientSnapshotOutlivesClient(t *testing.T) {
+	t.Run("Fulfill", func(t *testing.T) {
+		promised, resolver := NewPromisedClient(new(dummyHook))
+		snapshot := promised.Snapshot()
+		defer snapshot.Release()
+		promised.Release()
+
+		const replacementBrand = 42
+		replacement := NewClient(&dummyHook{brand: Brand{Value: replacementBrand}})
+		defer replacement.Release()
+		resolver.Fulfill(replacement)
+
+		if err := snapshot.Resolve(context.Background()); err != nil {
+			t.Fatal("resolve snapshot:", err)
+		}
+		if got := snapshot.Brand().Value; got != replacementBrand {
+			t.Fatalf("resolved snapshot brand = %v; want %d", got, replacementBrand)
+		}
+	})
+
+	t.Run("ReleaseRace", func(t *testing.T) {
+		for range 100 {
+			promised, resolver := NewPromisedClient(new(dummyHook))
+			snapshot := promised.Snapshot()
+			wantErr := errors.New("promise rejected")
+
+			start := make(chan struct{})
+			released := make(chan struct{})
+			rejected := make(chan struct{})
+			go func() {
+				<-start
+				promised.Release()
+				close(released)
+			}()
+			go func() {
+				<-start
+				resolver.Reject(wantErr)
+				close(rejected)
+			}()
+			close(start)
+			<-released
+			<-rejected
+
+			if err := snapshot.Resolve(context.Background()); err != nil {
+				t.Fatal("resolve snapshot:", err)
+			}
+			gotErr, ok := snapshot.Brand().Value.(error)
+			if !ok || !errors.Is(gotErr, wantErr) {
+				t.Fatalf("resolved snapshot brand = %v; want %v", gotErr, wantErr)
+			}
+			snapshot.Release()
+		}
+	})
+}
+
 type dummyHook struct {
 	calls     int
 	brand     Brand

--- a/rpc/import.go
+++ b/rpc/import.go
@@ -22,33 +22,49 @@ type impent struct {
 	// Release.referenceCount field.
 	wireRefs int
 
-	// generation is a counter used to disambiguate the following
-	// condition:
-	//
-	// 1) An import given to application code.
-	// 2) A new reference to the import is received over the wire, while
-	//    the application concurrently closes the import.
-	//    importClient.Shutdown is called, but the receive has the lock
-	//    first.
-	// 3) Conn.addImport attempts to return a weak client reference, but
-	//    can't because it has been closed.  It creates a new client
-	//    with a new importClient.
-	// 4) importClient.Shutdown attempts to remove the import from the import
-	//    table.  This is the critical step: it needs to be informed that
-	//    it should not do this because another client has been created.
-	//    No release message should be sent.
-	//
-	// The generation counter solves this by amending steps 3 and 4.  When
-	// a new importClient is created, generation is incremented.
-	// When importClient.Shutdown is called, then it must check that the
-	// importClient's generation matches the entry's generation before
-	// removing the entry from the table and sending a release message.
+	// generation identifies the newest importClient hook. Only that hook may
+	// send calls or be reflected back to the peer. It is incremented when a
+	// weak client cursor can no longer be upgraded and addImport creates a
+	// replacement hook.
 	generation uint64
+
+	// liveHooks counts importClient hooks that have not called Shutdown.
+	// Snapshots retain hooks independently of client cursors, so hooks from
+	// older generations may remain live after generation advances. The import
+	// entry and its promise resolver must remain registered until every hook
+	// generation shuts down.
+	liveHooks int
 
 	// If resolver is non-nil, then this is a promise (received as
 	// CapDescriptor_Which_senderPromise), and when a resolve message
 	// arrives we should use this to fulfill the promise locally.
 	resolver capnp.Resolver[capnp.Client]
+}
+
+// importPromiseResolvers settles every live local view of one unresolved
+// import. A new client generation gets a new resolver, while snapshots may
+// keep earlier generations alive after their client cursors are released.
+type importPromiseResolvers []capnp.Resolver[capnp.Client]
+
+func (rs importPromiseResolvers) Fulfill(client capnp.Client) {
+	for _, resolver := range rs {
+		resolver.Fulfill(client)
+	}
+}
+
+func (rs importPromiseResolvers) Reject(err error) {
+	for _, resolver := range rs {
+		resolver.Reject(err)
+	}
+}
+
+func joinImportPromiseResolvers(
+	first, second capnp.Resolver[capnp.Client],
+) capnp.Resolver[capnp.Client] {
+	if resolvers, ok := first.(importPromiseResolvers); ok {
+		return append(resolvers, second)
+	}
+	return importPromiseResolvers{first, second}
 }
 
 // takeResolver transfers terminal ownership of an imported promise.
@@ -70,13 +86,16 @@ func (c *lockedConn) addImport(id importID, isPromise bool) capnp.Client {
 		client, ok := ent.wc.AddRef()
 		if !ok {
 			ent.generation++
+			ent.liveHooks++
 			hook := &importClient{
 				c:          (*Conn)(c),
 				id:         id,
 				generation: ent.generation,
 			}
 			if isPromise && ent.resolver != nil {
-				client, ent.resolver = capnp.NewPromisedClient(hook)
+				var resolver capnp.Resolver[capnp.Client]
+				client, resolver = capnp.NewPromisedClient(hook)
+				ent.resolver = joinImportPromiseResolvers(ent.resolver, resolver)
 			} else {
 				client = capnp.NewClient(hook)
 			}
@@ -98,9 +117,10 @@ func (c *lockedConn) addImport(id importID, isPromise bool) capnp.Client {
 		client = capnp.NewClient(hook)
 	}
 	c.lk.imports.Create(id, &impent{
-		wc:       client.WeakRef(),
-		wireRefs: 1,
-		resolver: resolver,
+		wc:        client.WeakRef(),
+		wireRefs:  1,
+		liveHooks: 1,
+		resolver:  resolver,
 	})
 	return client
 }
@@ -203,9 +223,14 @@ func (ic *importClient) Shutdown() {
 		defer c.tasks.Done()
 
 		ent, ok := c.lk.imports.Find(ic.id)
-		if !ok || ic.generation != ent.generation {
-			// A new reference was added concurrently with the Shutdown.  See
-			// impent.generation documentation for an explanation.
+		if !ok {
+			return
+		}
+		if ent.liveHooks <= 0 {
+			panic("rpc: import has no live hooks")
+		}
+		ent.liveHooks--
+		if ent.liveHooks > 0 {
 			return
 		}
 		c.lk.imports.Remove(ic.id)

--- a/rpc/import_shutdown_test.go
+++ b/rpc/import_shutdown_test.go
@@ -2,6 +2,7 @@ package rpc
 
 import (
 	"context"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"testing/synctest"
@@ -18,6 +19,22 @@ type trackedImportResolver struct {
 	allowReject   <-chan struct{}
 	fulfills      atomic.Int32
 	rejects       atomic.Int32
+}
+
+type terminalCountingImportResolver struct {
+	inner    capnp.Resolver[capnp.Client]
+	fulfills atomic.Int32
+	rejects  atomic.Int32
+}
+
+func (r *terminalCountingImportResolver) Fulfill(client capnp.Client) {
+	r.fulfills.Add(1)
+	r.inner.Fulfill(client)
+}
+
+func (r *terminalCountingImportResolver) Reject(err error) {
+	r.rejects.Add(1)
+	r.inner.Reject(err)
 }
 
 func (r *trackedImportResolver) Fulfill(client capnp.Client) {
@@ -147,6 +164,181 @@ func TestImportedPromiseShutdownRejectsBeforeDone(t *testing.T) {
 		}
 		if got := tracker.rejects.Load(); got != 1 {
 			t.Fatalf("promise Reject calls after second Close = %d; want 1", got)
+		}
+	})
+}
+
+func TestImportedPromiseShutdownRejectsRetainedSnapshot(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		left, right := transportpkg.NewPipe(16)
+		conn := NewConn(NewTransport(left), nil)
+		peer := NewTransport(right)
+		defer peer.Close()
+
+		const id = importID(8)
+		var client capnp.Client
+		conn.withLocked(func(c *lockedConn) {
+			client = c.addImport(id, true)
+		})
+
+		snapshot := client.Snapshot()
+		defer snapshot.Release()
+		client.Release()
+
+		conn.withLocked(func(c *lockedConn) {
+			imp, ok := c.lk.imports.Find(id)
+			if !ok {
+				t.Fatal("promise import was removed while its snapshot remained live")
+			}
+			if live, ok := imp.wc.AddRef(); ok {
+				live.Release()
+				t.Fatal("promise import retained a live client cursor")
+			}
+		})
+
+		resolveCtx, cancelResolve := context.WithCancel(context.Background())
+		defer cancelResolve()
+		resolveResult := make(chan error, 1)
+		go func() {
+			resolveResult <- snapshot.Resolve(resolveCtx)
+		}()
+
+		closeResult := make(chan error, 1)
+		go func() {
+			closeResult <- conn.Close()
+		}()
+		synctest.Wait()
+
+		if err := <-closeResult; err != nil {
+			t.Fatal("close connection:", err)
+		}
+		select {
+		case err := <-resolveResult:
+			if err != nil {
+				t.Fatalf("snapshot Resolve error = %v; want nil", err)
+			}
+		default:
+			cancelResolve()
+			synctest.Wait()
+			<-resolveResult
+			t.Fatal("snapshot remained unresolved after connection shutdown")
+		}
+
+		resolutionErr, ok := snapshot.Brand().Value.(error)
+		if !ok || !capnp.IsDisconnected(resolutionErr) {
+			t.Fatalf("resolved snapshot brand = %v; want disconnected error", resolutionErr)
+		}
+	})
+}
+
+func TestImportedPromiseShutdownRejectsSnapshotAcrossTransientGeneration(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		left, right := transportpkg.NewPipe(16)
+		conn := NewConn(NewTransport(left), nil)
+		peer := NewTransport(right)
+		defer peer.Close()
+
+		const id = importID(9)
+		var first capnp.Client
+		conn.withLocked(func(c *lockedConn) {
+			first = c.addImport(id, true)
+		})
+		snapshot := first.Snapshot()
+		defer snapshot.Release()
+		first.Release()
+
+		var current capnp.Client
+		conn.withLocked(func(c *lockedConn) {
+			current = c.addImport(id, true)
+		})
+		current.Release()
+
+		conn.withLocked(func(c *lockedConn) {
+			imp, ok := c.lk.imports.Find(id)
+			if !ok {
+				t.Fatal("transient current generation removed import retained by an older snapshot")
+			}
+			if imp.liveHooks != 1 {
+				t.Fatalf("live import hooks = %d; want 1 retained snapshot hook", imp.liveHooks)
+			}
+		})
+
+		if err := conn.Close(); err != nil {
+			t.Fatal("close connection:", err)
+		}
+		if !snapshot.IsResolved() {
+			t.Fatal("snapshot remained unresolved after connection shutdown")
+		}
+		if err := snapshot.Resolve(context.Background()); err != nil {
+			t.Fatal("resolve retained snapshot:", err)
+		}
+		resolutionErr, ok := snapshot.Brand().Value.(error)
+		if !ok || !capnp.IsDisconnected(resolutionErr) {
+			t.Fatalf("resolved snapshot brand = %v; want disconnected error", resolutionErr)
+		}
+	})
+}
+
+func TestImportedPromiseResolveRaceShutdownHasSingleTerminalCallback(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		left, right := transportpkg.NewPipe(16)
+		conn := NewConn(NewTransport(left), nil)
+		peer := NewTransport(right)
+		defer peer.Close()
+
+		const id = importID(10)
+		var client capnp.Client
+		tracker := &terminalCountingImportResolver{}
+		conn.withLocked(func(c *lockedConn) {
+			client = c.addImport(id, true)
+			imp, ok := c.lk.imports.Find(id)
+			if !ok {
+				t.Fatal("promise import was not created")
+			}
+			tracker.inner = imp.takeResolver()
+			imp.resolver = tracker
+		})
+		snapshot := client.Snapshot()
+		defer snapshot.Release()
+		client.Release()
+
+		in := resolveToException(t, id)
+		start := make(chan struct{})
+		resolveResult := make(chan error, 1)
+		closeResult := make(chan error, 1)
+		go func() {
+			<-start
+			resolveResult <- conn.handleResolve(context.Background(), in)
+		}()
+		go func() {
+			<-start
+			closeResult <- conn.Close()
+		}()
+		close(start)
+		synctest.Wait()
+
+		if err := <-resolveResult; err != nil {
+			t.Fatal("handle Resolve:", err)
+		}
+		if err := <-closeResult; err != nil {
+			t.Fatal("close connection:", err)
+		}
+		if got := tracker.fulfills.Load(); got != 0 {
+			t.Fatalf("promise Fulfill calls = %d; want 0", got)
+		}
+		if got := tracker.rejects.Load(); got != 1 {
+			t.Fatalf("promise Reject calls = %d; want 1", got)
+		}
+		if !snapshot.IsResolved() {
+			t.Fatal("snapshot remained unresolved after Resolve/Close race")
+		}
+		if err := snapshot.Resolve(context.Background()); err != nil {
+			t.Fatal("resolve retained snapshot:", err)
+		}
+		resolutionErr, ok := snapshot.Brand().Value.(error)
+		if !ok || (!capnp.IsDisconnected(resolutionErr) &&
+			!strings.Contains(resolutionErr.Error(), "resolution failed")) {
+			t.Fatalf("resolved snapshot brand = %v; want Resolve or shutdown rejection", resolutionErr)
 		}
 	})
 }

--- a/rpc/resolve_lifecycle_test.go
+++ b/rpc/resolve_lifecycle_test.go
@@ -470,11 +470,66 @@ func TestHandleResolveRejectsCurrentPromiseGeneration(t *testing.T) {
 	if err := current.Resolve(context.Background()); err != nil {
 		t.Fatal("resolve re-received imported promise:", err)
 	}
+	if !oldSnapshot.IsResolved() {
+		t.Error("original snapshot remained unresolved after current generation resolved")
+	} else if err := oldSnapshot.Resolve(context.Background()); err != nil {
+		t.Fatal("resolve original imported promise snapshot:", err)
+	}
+	oldResolutionErr, ok := oldSnapshot.Brand().Value.(error)
+	if !ok || !strings.Contains(oldResolutionErr.Error(), "resolution failed") {
+		t.Fatalf("original resolved promise brand = %v; want resolution failure", oldResolutionErr)
+	}
 	resolved := current.Snapshot()
 	resolutionErr, ok := resolved.Brand().Value.(error)
 	resolved.Release()
 	if !ok || !strings.Contains(resolutionErr.Error(), "resolution failed") {
 		t.Fatalf("resolved promise brand = %v; want resolution failure", resolutionErr)
+	}
+}
+
+func TestHandleResolveRejectsSnapshotAcrossTransientGeneration(t *testing.T) {
+	conn, _ := newResolveLifecycleConn(t)
+
+	var first capnp.Client
+	conn.withLocked(func(c *lockedConn) {
+		first = c.addImport(resolvePromiseID, true)
+	})
+	snapshot := first.Snapshot()
+	defer snapshot.Release()
+	first.Release()
+
+	var current capnp.Client
+	conn.withLocked(func(c *lockedConn) {
+		current = c.addImport(resolvePromiseID, true)
+	})
+	current.Release()
+
+	conn.withLocked(func(c *lockedConn) {
+		imp, ok := c.lk.imports.Find(resolvePromiseID)
+		if !ok {
+			t.Fatal("transient current generation removed import retained by an older snapshot")
+		}
+		if imp.liveHooks != 1 {
+			t.Fatalf("live import hooks = %d; want 1 retained snapshot hook", imp.liveHooks)
+		}
+	})
+
+	in := resolveToException(t, resolvePromiseID)
+	if err := conn.handleResolve(context.Background(), in); err != nil {
+		t.Fatal("handleResolve:", err)
+	}
+	if got := atomic.LoadInt32(&in.releases); got != 1 {
+		t.Fatalf("incoming message releases = %d; want 1", got)
+	}
+	if !snapshot.IsResolved() {
+		t.Fatal("original snapshot remained unresolved after incoming Resolve")
+	}
+	if err := snapshot.Resolve(context.Background()); err != nil {
+		t.Fatal("resolve original imported promise snapshot:", err)
+	}
+	resolutionErr, ok := snapshot.Brand().Value.(error)
+	if !ok || !strings.Contains(resolutionErr.Error(), "resolution failed") {
+		t.Fatalf("original resolved promise brand = %v; want resolution failure", resolutionErr)
 	}
 }
 


### PR DESCRIPTION
## Summary

- make promise settlement depend on a live promise hook, so retained snapshots still observe fulfillment or rejection after the original client cursor is released
- keep the cursor weak reference only for best-effort path compression
- retain unresolved import generations until every live hook shuts down, so earlier snapshots and the current cursor receive one terminal settlement outside the connection lock

## Testing

- focused promise and RPC lifecycle tests, 100 repetitions
- focused race tests, including 1,000 Resolve-vs-Close repetitions
- `go test ./... -count=1`
- `go test -race -short ./... -count=1`
- `go vet ./rpc`

Closes #653.