### PR TITLE
rpc: replace Level 3 panics with protocol errors

### DIFF
--- a/rpc/export.go
+++ b/rpc/export.go
@@ -112,9 +112,8 @@ func (c *lockedConn) sendCap(d rpccp.CapDescriptor, snapshot capnp.ClientSnapsho
 				return 0, false, nil
 			}
 		}
-		if c.network != nil && c.network == ic.c.network {
-			panic("TODO: 3PH")
-		}
+		// Three-party handoff is not implemented. If the import belongs to a
+		// different connection, fall through and proxy it as a local export.
 	}
 
 	if pc, ok := bv.(capnp.PipelineClient); ok {
@@ -135,9 +134,8 @@ func (c *lockedConn) sendCap(d rpccp.CapDescriptor, snapshot capnp.ClientSnapsho
 				pa.SetQuestionId(uint32(q.id))
 				return 0, false, nil
 			}
-			if c.network != nil && c.network == q.c.network {
-				panic("TODO: 3PH")
-			}
+			// Three-party handoff is not implemented. If the pipeline belongs
+			// to a different connection, proxy it as a local export.
 		}
 	}
 

--- a/rpc/level3_fallback_test.go
+++ b/rpc/level3_fallback_test.go
@@ -1,0 +1,583 @@
+package rpc
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"capnproto.org/go/capnp/v3"
+	"capnproto.org/go/capnp/v3/exc"
+	"capnproto.org/go/capnp/v3/exp/spsc"
+	rpccp "capnproto.org/go/capnp/v3/std/capnp/rpc"
+	"capnproto.org/go/capnp/v3/util/deferred"
+)
+
+func TestUnsupportedLevel3MessagesEchoUnimplemented(t *testing.T) {
+	tests := []struct {
+		name  string
+		build func(rpccp.Message) error
+		want  rpccp.Message_Which
+	}{
+		{
+			name: "provide",
+			build: func(message rpccp.Message) error {
+				_, err := message.NewProvide()
+				return err
+			},
+			want: rpccp.Message_Which_provide,
+		},
+		{
+			name: "accept",
+			build: func(message rpccp.Message) error {
+				_, err := message.NewAccept()
+				return err
+			},
+			want: rpccp.Message_Which_accept,
+		},
+		{
+			name: "thirdPartyAnswer",
+			build: func(message rpccp.Message) error {
+				_, err := message.NewThirdPartyAnswer()
+				return err
+			},
+			want: rpccp.Message_Which_thirdPartyAnswer,
+		},
+		{
+			name: "call.sendResultsTo.thirdParty",
+			build: func(message rpccp.Message) error {
+				call, err := message.NewCall()
+				if err != nil {
+					return err
+				}
+				call.SetQuestionId(41)
+				return call.SendResultsTo().SetThirdParty(capnp.Ptr{})
+			},
+			want: rpccp.Message_Which_call,
+		},
+		{
+			name: "disembargo.context.accept",
+			build: func(message rpccp.Message) error {
+				disembargo, err := message.NewDisembargo()
+				if err != nil {
+					return err
+				}
+				target, err := disembargo.NewTarget()
+				if err != nil {
+					return err
+				}
+				target.SetImportedCap(0)
+				return disembargo.Context().SetAccept([]byte("unsupported"))
+			},
+			want: rpccp.Message_Which_disembargo,
+		},
+	}
+
+	for _, networked := range []bool{false, true} {
+		for _, test := range tests {
+			t.Run(test.name+"/network="+boolString(networked), func(t *testing.T) {
+				var opts *Options
+				if networked {
+					opts = &Options{Network: resolveTestNetwork{}}
+				}
+				conn, peer := newResolveLifecycleConnWithOptions(t, opts)
+
+				out, err := peer.NewMessage()
+				if err != nil {
+					t.Fatal(err)
+				}
+				if err := test.build(out.Message()); err != nil {
+					out.Release()
+					t.Fatal(err)
+				}
+				if err := out.Send(); err != nil {
+					out.Release()
+					t.Fatal(err)
+				}
+				out.Release()
+
+				in := recvPeerMessage(t, peer)
+				defer in.Release()
+				if got := in.Message().Which(); got != rpccp.Message_Which_unimplemented {
+					t.Fatalf("response type = %v; want unimplemented", got)
+				}
+				echo, err := in.Message().Unimplemented()
+				if err != nil {
+					t.Fatal(err)
+				}
+				if got := echo.Which(); got != test.want {
+					t.Fatalf("echoed message type = %v; want %v", got, test.want)
+				}
+				select {
+				case <-conn.Done():
+					t.Fatal("unsupported Level 3 message closed connection")
+				default:
+				}
+				requireEmptyLevel3Tables(t, conn)
+			})
+		}
+	}
+}
+
+func TestUnsupportedLevel3MessageReleaseOnNewMessageFailure(t *testing.T) {
+	tests := []struct {
+		name   string
+		build  func(rpccp.Message) error
+		handle func(*Conn, *countingIncomingMessage)
+	}{
+		{
+			name: "provide",
+			build: func(message rpccp.Message) error {
+				_, err := message.NewProvide()
+				return err
+			},
+		},
+		{
+			name: "accept",
+			build: func(message rpccp.Message) error {
+				_, err := message.NewAccept()
+				return err
+			},
+		},
+		{
+			name: "thirdPartyAnswer",
+			build: func(message rpccp.Message) error {
+				_, err := message.NewThirdPartyAnswer()
+				return err
+			},
+		},
+		{
+			name: "call.sendResultsTo.thirdParty",
+			build: func(message rpccp.Message) error {
+				call, err := message.NewCall()
+				if err != nil {
+					return err
+				}
+				return call.SendResultsTo().SetThirdParty(capnp.Ptr{})
+			},
+			handle: func(conn *Conn, in *countingIncomingMessage) {
+				_ = conn.handleCall(context.Background(), in)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			queue := spsc.New[asyncSend]()
+			conn := &Conn{
+				transport: newMessageErrorTransport{err: errors.New("allocate")},
+			}
+			conn.lk.sendTx = &queue.Tx
+
+			_, seg := capnp.NewSingleSegmentMessage(nil)
+			message, err := rpccp.NewRootMessage(seg)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := test.build(message); err != nil {
+				t.Fatal(err)
+			}
+			in := &countingIncomingMessage{message: message}
+
+			if test.handle == nil {
+				conn.handleUnknownMessageType(context.Background(), in)
+			} else {
+				test.handle(conn, in)
+			}
+			pending, ok := queue.Rx.TryRecv()
+			if !ok {
+				t.Fatal("unimplemented response was not queued")
+			}
+			if err := pending.Send(); err != nil {
+				t.Fatalf("send outcome = %v; want non-fatal allocation failure", err)
+			}
+			if got := atomic.LoadInt32(&in.releases); got != 1 {
+				t.Fatalf("incoming message releases = %d; want 1", got)
+			}
+		})
+	}
+}
+
+func TestThirdPartyHostedCapabilityFallback(t *testing.T) {
+	for _, networked := range []bool{false, true} {
+		t.Run("network="+boolString(networked), func(t *testing.T) {
+			var opts *Options
+			if networked {
+				opts = &Options{Network: resolveTestNetwork{}}
+			}
+			conn, _ := newResolveLifecycleConnWithOptions(t, opts)
+
+			_, seg := capnp.NewSingleSegmentMessage(nil)
+			desc, err := rpccp.NewRootCapDescriptor(seg)
+			if err != nil {
+				t.Fatal(err)
+			}
+			thirdParty, err := desc.NewThirdPartyHosted()
+			if err != nil {
+				t.Fatal(err)
+			}
+			const vineID = importID(17)
+			thirdParty.SetVineId(uint32(vineID))
+
+			var client capnp.Client
+			conn.withLocked(func(c *lockedConn) {
+				client, err = c.recvCap(desc)
+				_, imported := c.lk.imports.Find(vineID)
+				if networked && imported {
+					t.Error("unsupported third-party descriptor mutated imports")
+				}
+				if !networked && !imported {
+					t.Error("vine fallback did not create import")
+				}
+			})
+			if networked {
+				if err == nil || !strings.Contains(err.Error(), "three-party handoff not implemented") {
+					t.Fatalf("recvCap error = %v; want unsupported handoff error", err)
+				}
+				if got := exc.TypeOf(err); got != exc.Unimplemented {
+					t.Fatalf("recvCap error type = %v; want unimplemented", got)
+				}
+				if client.IsValid() {
+					client.Release()
+					t.Fatal("recvCap returned a client after rejecting descriptor")
+				}
+			} else {
+				if err != nil {
+					client.Release()
+					t.Fatal(err)
+				}
+				if !client.IsValid() {
+					t.Fatal("vine fallback returned invalid client")
+				}
+				client.Release()
+			}
+		})
+	}
+}
+
+func TestNetworkedThirdPartyPayloadReleasesPartialCapabilityTable(t *testing.T) {
+	conn, _ := newResolveLifecycleConnWithOptions(t, &Options{Network: resolveTestNetwork{}})
+
+	message, seg := capnp.NewSingleSegmentMessage(nil)
+	defer message.Release()
+	payload, err := rpccp.NewRootPayload(seg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	descriptors, err := payload.NewCapTable(2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const (
+		firstImport = importID(23)
+		vineImport  = importID(24)
+	)
+	descriptors.At(0).SetSenderHosted(uint32(firstImport))
+	thirdParty, err := descriptors.At(1).NewThirdPartyHosted()
+	if err != nil {
+		t.Fatal(err)
+	}
+	thirdParty.SetVineId(uint32(vineImport))
+
+	dq := &deferred.Queue{}
+	conn.withLocked(func(c *lockedConn) {
+		_, _, err = c.recvPayload(dq, payload)
+	})
+	dq.Run()
+	if err == nil || !strings.Contains(err.Error(), "three-party handoff not implemented") {
+		t.Fatalf("recvPayload error = %v; want unsupported handoff error", err)
+	}
+	if got := message.CapTable().Len(); got != 0 {
+		t.Errorf("partially decoded message capability table length = %d; want 0", got)
+	}
+	conn.withLocked(func(c *lockedConn) {
+		if _, ok := c.lk.imports.Find(firstImport); ok {
+			t.Error("partially decoded sender-hosted capability remains imported")
+		}
+		if _, ok := c.lk.imports.Find(vineImport); ok {
+			t.Error("rejected third-party vine was imported")
+		}
+	})
+}
+
+func TestHandleCallRejectsNetworkedThirdPartyPayloadCleanly(t *testing.T) {
+	conn, peer := newResolveLifecycleConnWithOptions(t, &Options{Network: resolveTestNetwork{}})
+
+	_, seg := capnp.NewSingleSegmentMessage(nil)
+	message, err := rpccp.NewRootMessage(seg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	call, err := message.NewCall()
+	if err != nil {
+		t.Fatal(err)
+	}
+	const questionID = answerID(55)
+	call.SetQuestionId(uint32(questionID))
+	target, err := call.NewTarget()
+	if err != nil {
+		t.Fatal(err)
+	}
+	target.SetImportedCap(0)
+	params, err := call.NewParams()
+	if err != nil {
+		t.Fatal(err)
+	}
+	descriptors, err := params.NewCapTable(2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const (
+		firstImport = importID(25)
+		vineImport  = importID(26)
+	)
+	descriptors.At(0).SetSenderHosted(uint32(firstImport))
+	thirdParty, err := descriptors.At(1).NewThirdPartyHosted()
+	if err != nil {
+		t.Fatal(err)
+	}
+	thirdParty.SetVineId(uint32(vineImport))
+	in := &countingIncomingMessage{message: message}
+
+	if err := conn.handleCall(context.Background(), in); err != nil {
+		t.Fatal(err)
+	}
+	if got := atomic.LoadInt32(&in.releases); got != 1 {
+		t.Fatalf("incoming message releases = %d; want 1", got)
+	}
+	conn.withLocked(func(c *lockedConn) {
+		if _, ok := c.lk.imports.Find(firstImport); ok {
+			t.Error("partially decoded sender-hosted capability remains imported")
+		}
+		if _, ok := c.lk.imports.Find(vineImport); ok {
+			t.Error("rejected third-party vine was imported")
+		}
+	})
+
+	response := recvPeerMessage(t, peer)
+	if got := response.Message().Which(); got != rpccp.Message_Which_return {
+		response.Release()
+		t.Fatalf("response type = %v; want return", got)
+	}
+	ret, err := response.Message().Return()
+	if err != nil {
+		response.Release()
+		t.Fatal(err)
+	}
+	exception, err := ret.Exception()
+	if err != nil {
+		response.Release()
+		t.Fatal(err)
+	}
+	if got := exception.Type(); got != rpccp.Exception_Type_unimplemented {
+		response.Release()
+		t.Fatalf("return exception type = %v; want unimplemented", got)
+	}
+	response.Release()
+
+	finish := newFinishMessage(t, questionID)
+	if err := conn.handleFinish(context.Background(), finish); err != nil {
+		t.Fatal(err)
+	}
+	if got := atomic.LoadInt32(&finish.releases); got != 1 {
+		t.Fatalf("finish message releases = %d; want 1", got)
+	}
+	conn.withLocked(func(c *lockedConn) {
+		if _, ok := c.lk.answers.Find(questionID); ok {
+			t.Error("error answer remains after Finish")
+		}
+	})
+	requireEmptyLevel3Tables(t, conn)
+}
+
+func TestSameNetworkCapabilitiesFallBackToProxying(t *testing.T) {
+	tests := []struct {
+		name      string
+		newClient func(*testing.T, *Conn) capnp.Client
+	}{
+		{
+			name: "import",
+			newClient: func(t *testing.T, conn *Conn) (client capnp.Client) {
+				conn.withLocked(func(c *lockedConn) {
+					client = c.addImport(31, false)
+				})
+				return client
+			},
+		},
+		{
+			name: "pipeline",
+			newClient: func(t *testing.T, conn *Conn) capnp.Client {
+				return conn.Bootstrap(context.Background())
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			network := resolveTestNetwork{}
+			dst, _ := newResolveLifecycleConnWithOptions(t, &Options{Network: network})
+			src, _ := newResolveLifecycleConnWithOptions(t, &Options{Network: network})
+			client := test.newClient(t, src)
+			defer client.Release()
+
+			_, seg := capnp.NewSingleSegmentMessage(nil)
+			desc, err := rpccp.NewRootCapDescriptor(seg)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			var (
+				exported exportID
+				isExport bool
+				isLocal  bool
+			)
+			dst.withLocked(func(c *lockedConn) {
+				isLocal = c.isLocalClient(client)
+				exported, isExport, err = c.sendCap(desc, client.Snapshot())
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !isLocal {
+				t.Error("same-network proxied client not treated as local")
+			}
+			if !isExport {
+				t.Fatal("same-network client was not proxied through an export")
+			}
+			switch got := desc.Which(); got {
+			case rpccp.CapDescriptor_Which_senderHosted, rpccp.CapDescriptor_Which_senderPromise:
+			default:
+				t.Fatalf("descriptor type = %v; want sender-hosted or sender-promise proxy", got)
+			}
+
+			dq := &deferred.Queue{}
+			dst.withLocked(func(c *lockedConn) {
+				err = c.releaseExport(dq, exported, 1)
+			})
+			dq.Run()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := src.Close(); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestAwaitFromThirdPartyReturnFailsQuestionCleanly(t *testing.T) {
+	for _, networked := range []bool{false, true} {
+		t.Run("network="+boolString(networked), func(t *testing.T) {
+			var opts *Options
+			if networked {
+				opts = &Options{Network: resolveTestNetwork{}}
+			}
+			conn, peer := newResolveLifecycleConnWithOptions(t, opts)
+			client := conn.Bootstrap(context.Background())
+			defer client.Release()
+
+			bootstrap := recvPeerMessage(t, peer)
+			boot, err := bootstrap.Message().Bootstrap()
+			if err != nil {
+				bootstrap.Release()
+				t.Fatal(err)
+			}
+			questionID := boot.QuestionId()
+			bootstrap.Release()
+
+			out, err := peer.NewMessage()
+			if err != nil {
+				t.Fatal(err)
+			}
+			ret, err := out.Message().NewReturn()
+			if err != nil {
+				out.Release()
+				t.Fatal(err)
+			}
+			ret.SetAnswerId(questionID)
+			if err := ret.SetAwaitFromThirdParty(capnp.Ptr{}); err != nil {
+				out.Release()
+				t.Fatal(err)
+			}
+			if err := out.Send(); err != nil {
+				out.Release()
+				t.Fatal(err)
+			}
+			out.Release()
+
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer cancel()
+			if err := client.Resolve(ctx); err != nil {
+				t.Fatal(err)
+			}
+			resolved := client.Snapshot()
+			resolutionErr, ok := resolved.Brand().Value.(error)
+			resolved.Release()
+			if !ok || !strings.Contains(resolutionErr.Error(), "awaitFromThirdParty") {
+				t.Fatalf("bootstrap resolution = %v; want unsupported return error", resolutionErr)
+			}
+			if got := exc.TypeOf(resolutionErr); got != exc.Unimplemented {
+				t.Fatalf("bootstrap resolution error type = %v; want unimplemented", got)
+			}
+
+			finish := recvPeerMessage(t, peer)
+			defer finish.Release()
+			if got := finish.Message().Which(); got != rpccp.Message_Which_finish {
+				t.Fatalf("response type = %v; want finish", got)
+			}
+			fin, err := finish.Message().Finish()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := fin.QuestionId(); got != questionID {
+				t.Fatalf("finish question ID = %d; want %d", got, questionID)
+			}
+			select {
+			case <-conn.Done():
+				t.Fatal("unsupported Return closed connection")
+			default:
+			}
+			requireEmptyLevel3Tables(t, conn)
+		})
+	}
+}
+
+func requireEmptyLevel3Tables(t *testing.T, conn *Conn) {
+	t.Helper()
+
+	var nonempty []string
+	conn.withLocked(func(c *lockedConn) {
+		c.lk.questions.Range(func(_ questionID, _ *question) bool {
+			nonempty = append(nonempty, "questions")
+			return false
+		})
+		c.lk.answers.Range(func(_ answerID, _ *ansent) bool {
+			nonempty = append(nonempty, "answers")
+			return false
+		})
+		c.lk.imports.Range(func(_ importID, _ *impent) bool {
+			nonempty = append(nonempty, "imports")
+			return false
+		})
+		c.lk.exports.Range(func(_ exportID, _ *expent) bool {
+			nonempty = append(nonempty, "exports")
+			return false
+		})
+		c.lk.embargoes.Range(func(_ embargoID, _ *embargo) bool {
+			nonempty = append(nonempty, "embargoes")
+			return false
+		})
+	})
+	if len(nonempty) > 0 {
+		t.Errorf("unexpected table entries after Level 3 rejection: %v", nonempty)
+	}
+}
+
+func boolString(v bool) string {
+	if v {
+		return "on"
+	}
+	return "off"
+}

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -622,11 +622,13 @@ func (c *Conn) receive(ctx context.Context) func() error {
 					return fmt.Errorf("handle Resolve: %w", err)
 				}
 
-			case rpccp.Message_Which_accept, rpccp.Message_Which_provide:
-				if c.network != nil {
-					panic("TODO: 3PH")
-				}
-				fallthrough
+			case rpccp.Message_Which_accept,
+				rpccp.Message_Which_provide,
+				rpccp.Message_Which_thirdPartyAnswer:
+				// Three-party handoff is not implemented. Echo the message as
+				// Unimplemented so a Level 3 peer can fail or fall back without
+				// losing the connection.
+				c.handleUnknownMessageType(ctx, in)
 
 			default:
 				c.handleUnknownMessageType(ctx, in)
@@ -774,9 +776,10 @@ func (c *Conn) handleCall(ctx context.Context, in transport.IncomingMessage) err
 		// TODO(someday): handle SendResultsTo.yourself
 		c.er.ReportError(errors.New("incoming call: results destination is not caller"))
 
+		release := util.Idempotent(in.Release)
 		c.withLocked(func(c *lockedConn) {
 			c.sendMessage(ctx, func(m rpccp.Message) error {
-				defer in.Release()
+				defer release()
 
 				mm, err := m.NewUnimplemented()
 				if err != nil {
@@ -789,6 +792,7 @@ func (c *Conn) handleCall(ctx context.Context, in transport.IncomingMessage) err
 
 				return nil
 			}, func(err error) {
+				release()
 				if err != nil && !isFatalSendError(err) {
 					c.er.ReportError(rpcerr.Annotate(err, "incoming call: send unimplemented"))
 				}
@@ -1293,24 +1297,23 @@ func (c *lockedConn) parseReturn(dq *deferred.Queue, ret rpccp.Return, called []
 		}
 		return parsedReturn{err: exc.New(exc.Type(e.Type()), "", reason)}
 	case rpccp.Return_Which_awaitFromThirdParty:
-		// TODO: 3PH. Can wait until after the MVP, because we can keep
-		// setting allowThirdPartyTailCall = false
-		fallthrough
+		return parsedReturn{err: rpcerr.Unimplemented(errors.New(
+			"parse return: three-party handoff not implemented: " + w.String(),
+		)), parseFailed: true}
 	default:
 		// TODO: go through other variants and make sure we're handling
 		// them all correctly.
 		return parsedReturn{err: rpcerr.Failed(errors.New(
 			"parse return: unhandled type " + w.String(),
-		)), parseFailed: true, unimplemented: true}
+		)), parseFailed: true}
 	}
 }
 
 type parsedReturn struct {
-	result        capnp.Ptr
-	disembargoes  []senderLoopback
-	err           error
-	parseFailed   bool
-	unimplemented bool
+	result       capnp.Ptr
+	disembargoes []senderLoopback
+	err          error
+	parseFailed  bool
 }
 
 func (c *Conn) handleFinish(ctx context.Context, in transport.IncomingMessage) error {
@@ -1384,14 +1387,16 @@ func (c *lockedConn) recvCap(d rpccp.CapDescriptor) (capnp.Client, error) {
 			thirdPartyDesc, err := d.ThirdPartyHosted()
 			if err != nil {
 				return capnp.Client{}, exc.WrapError(
-					"reading ThridPartyCapDescriptor",
+					"reading third-party capability descriptor",
 					err,
 				)
 			}
 			id := importID(thirdPartyDesc.VineId())
 			return c.addImport(id, false), nil
 		}
-		panic("TODO: 3PH")
+		return capnp.Client{}, rpcerr.Unimplemented(errors.New(
+			"receive capability: three-party handoff not implemented",
+		))
 	case rpccp.CapDescriptor_Which_receiverHosted:
 		id := exportID(d.ReceiverHosted())
 		ent := c.findExport(id)
@@ -1477,15 +1482,9 @@ func (c *lockedConn) isLocalClient(client capnp.Client) bool {
 		if ic.c == (*Conn)(c) {
 			return false
 		}
-		if c.network == nil || c.network != ic.c.network {
-			// Different connections on different networks. We must
-			// be proxying it, so as far as this connection is
-			// concerned, it lives on our side.
-			return true
-		}
-		// Might have to do more refactoring re: what to do in this case;
-		// just checking for embargo or not might not be sufficient:
-		panic("TODO: 3PH")
+		// Until three-party handoff is implemented, capabilities from every
+		// other connection are proxied through this vat.
+		return true
 	}
 
 	if pc, ok := bv.(capnp.PipelineClient); ok {
@@ -1494,10 +1493,7 @@ func (c *lockedConn) isLocalClient(client capnp.Client) bool {
 			if q.c == (*Conn)(c) {
 				return false
 			}
-			if c.network == nil || c.network != q.c.network {
-				return true
-			}
-			panic("TODO: 3PH")
+			return true
 		}
 	}
 
@@ -1548,8 +1544,14 @@ func (c *lockedConn) recvPayload(dq *deferred.Queue, payload rpccp.Payload) (_ c
 			// as this might trigger a deadlock.  Use the deferred.Queue instead.
 			dq.Defer(cl.Release)
 			for j := 0; j < i; j++ {
-				dq.Defer(mtab.At(j).Release)
+				client := mtab.At(j)
+				mtab.Set(capnp.CapabilityID(j), capnp.Client{})
+				dq.Defer(client.Release)
 			}
+			// The clients above are released outside the connection lock. Clear
+			// their now-empty slots so releasing the incoming message cannot
+			// release them a second time.
+			mtab.Reset()
 
 			err = rpcerr.Annotate(err, "read payload: capability "+str.Itod(i))
 			break
@@ -1732,9 +1734,6 @@ func (c *Conn) handleDisembargo(ctx context.Context, in transport.IncomingMessag
 		})
 
 	case rpccp.Disembargo_context_Which_accept:
-		if c.network != nil {
-			panic("TODO: 3PH")
-		}
 		fallthrough
 	default:
 		c.er.ReportError(errors.New("incoming disembargo: context " + d.Context().Which().String() + " not implemented"))
@@ -1863,7 +1862,7 @@ func (c *Conn) handleResolve(ctx context.Context, in transport.IncomingMessage) 
 				rpccp.CapDescriptor_Which_receiverAnswer:
 			case rpccp.CapDescriptor_Which_thirdPartyHosted:
 				if c.network != nil {
-					return rpcerr.Failed(errors.New(
+					return rpcerr.Unimplemented(errors.New(
 						"incoming resolve: third-party handoff not implemented",
 					))
 				}
@@ -1984,14 +1983,19 @@ func (c *Conn) handleUnknownMessageType(ctx context.Context, in transport.Incomi
 	err := errors.New("unknown message type " + in.Message().Which().String() + " from remote")
 	c.er.ReportError(err)
 
+	release := util.Idempotent(in.Release)
 	c.withLocked(func(c *lockedConn) {
 		c.sendMessage(ctx, func(m rpccp.Message) error {
-			defer in.Release()
+			defer release()
 			if err := m.SetUnimplemented(in.Message()); err != nil {
 				return rpcerr.Annotate(err, "send unimplemented")
 			}
 			return nil
-		}, nil)
+		}, func(error) {
+			// prepareMessage does not call build when allocation fails, and a
+			// queued send can instead fail or be aborted during shutdown.
+			release()
+		})
 	})
 }
 


### PR DESCRIPTION
## Summary

- replace peer-triggerable Level 3 panic paths with `Unimplemented` responses, typed errors, or safe proxying
- preserve the schema-defined vine fallback when no network is configured, while rejecting unsupported networked third-party descriptors before import mutation
- clean up partially decoded capability tables and release incoming messages exactly once even when an Unimplemented reply cannot be allocated

## Testing

- focused Level 3 and send-outcome tests, 100 repetitions
- `go test ./... -count=1`
- `go test -race -short ./... -count=1`
- `go vet ./rpc`

Closes #647.