### PR TITLE
capnp: reject cyclic client promise resolution

### DIFF
--- a/capability.go
+++ b/capability.go
@@ -423,6 +423,84 @@ type resolveState struct {
 	resolvedHook *rc.Ref[clientHook]
 }
 
+// clientPromiseResolutionMu serializes updates to the graph formed by
+// resolveState.resolvedHook.  Keeping the check and edge publication atomic
+// prevents concurrent fulfillments from introducing a cycle.
+var clientPromiseResolutionMu sync.Mutex
+
+var errClientPromiseResolutionCycle = errors.New("client promise resolution cycle")
+
+// clientPromiseResolutionReaches reports whether following the resolved
+// promise chain from hook reaches target.  The caller must hold
+// clientPromiseResolutionMu.
+func clientPromiseResolutionReaches(hook *rc.Ref[clientHook], target *clientHook) bool {
+	for hook != nil {
+		if hook.Value() == target {
+			return true
+		}
+
+		resolution, ok := hook.Value().resolution.Get()
+		if !ok {
+			return false
+		}
+
+		var next *rc.Ref[clientHook]
+		resolved := mutex.With1(resolution, func(state *resolveState) bool {
+			if !state.isResolved() {
+				return false
+			}
+			next = state.resolvedHook
+			return true
+		})
+		if !resolved {
+			return false
+		}
+		hook = next
+	}
+	return false
+}
+
+// publishClientPromiseResolution publishes source's resolution, consuming
+// target.  source remains owned by the caller.
+func publishClientPromiseResolution(source, target *rc.Ref[clientHook]) {
+	// Unless ownership is transferred to the source promise below, release
+	// the target on every exit, including duplicate-settlement panics.
+	defer func() {
+		target.Release()
+	}()
+	// Releasing a client hook can invoke arbitrary Shutdown code.  Keep any
+	// displaced target alive until after the resolution graph is unlocked.
+	var displacedTarget *rc.Ref[clientHook]
+	defer func() {
+		displacedTarget.Release()
+	}()
+
+	func() {
+		clientPromiseResolutionMu.Lock()
+		defer clientPromiseResolutionMu.Unlock()
+
+		if clientPromiseResolutionReaches(target, source.Value()) {
+			displacedTarget = target
+			rejected := ErrorClient(errClientPromiseResolutionCycle)
+			target, _, _ = rejected.startCall()
+			rejected.Release()
+		}
+
+		resolution, ok := source.Value().resolution.Get()
+		if !ok {
+			panic("BUG: clientPromise referred to a clientHook that was not a promise")
+		}
+		resolution.With(func(state *resolveState) {
+			if state.isResolved() {
+				panic("ClientPromise.Fulfill called more than once")
+			}
+			state.resolvedHook = target
+			target = nil // resolveState now owns the target reference.
+			close(state.resolved)
+		})
+	}()
+}
+
 // NewClient creates the first reference to a capability.
 // If hook is nil, then NewClient returns nil.
 //
@@ -1530,18 +1608,9 @@ func (cp *clientPromise) fulfill(dq *deferred.Queue, c Client) {
 		rh = h
 	}
 
-	// Mark hook as resolved.
-	r, ok := hook.Value().resolution.Get()
-	if !ok {
-		panic("BUG: clientPromise referred to a clientHook that was not a promise")
-	}
-	r.With(func(s *resolveState) {
-		if s.isResolved() {
-			panic("ClientPromise.Fulfill called more than once")
-		}
-		s.resolvedHook = rh
-		close(s.resolved)
-	})
+	// Mark hook as resolved.  Edge publication is serialized with ancestry
+	// checks so simultaneous fulfillments cannot each publish half of a cycle.
+	publishClientPromiseResolution(hook, rh)
 
 	if cursor, ok := cp.cursor.AddRef(); ok {
 		dq.Defer(cursor.Release)

--- a/capability_test.go
+++ b/capability_test.go
@@ -5,7 +5,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"capnproto.org/go/capnp/v3/flowcontrol"
@@ -390,6 +392,249 @@ func TestPromisedClientSnapshotOutlivesClient(t *testing.T) {
 			}
 			snapshot.Release()
 		}
+	})
+}
+
+func requireClientPromiseCycle(t *testing.T, snapshot *ClientSnapshot) {
+	t.Helper()
+
+	if err := snapshot.Resolve(context.Background()); err != nil {
+		t.Fatal("resolve cyclic promise:", err)
+	}
+	got, ok := snapshot.Brand().Value.(error)
+	if !ok || !errors.Is(got, errClientPromiseResolutionCycle) {
+		t.Fatalf("resolved promise brand = %v; want %v", got, errClientPromiseResolutionCycle)
+	}
+}
+
+func TestClientPromiseRejectsDirectResolutionCycle(t *testing.T) {
+	hook := new(dummyHook)
+	client, resolver := NewPromisedClient(hook)
+	snapshot := client.Snapshot()
+
+	self := client.AddRef()
+	resolver.Fulfill(self)
+	self.Release()
+
+	answer, release := client.SendCall(context.Background(), Send{})
+	_, err := answer.Struct()
+	release()
+	if !errors.Is(err, errClientPromiseResolutionCycle) {
+		t.Fatalf("call error = %v; want %v", err, errClientPromiseResolutionCycle)
+	}
+
+	client.Release()
+	requireClientPromiseCycle(t, &snapshot)
+	snapshot.Release()
+	if hook.shutdowns != 1 {
+		t.Fatalf("promise hook shutdowns = %d; want 1", hook.shutdowns)
+	}
+}
+
+func TestClientPromiseRejectsTwoNodeResolutionCycle(t *testing.T) {
+	firstHook := new(dummyHook)
+	secondHook := new(dummyHook)
+	first, firstResolver := NewPromisedClient(firstHook)
+	second, secondResolver := NewPromisedClient(secondHook)
+	firstSnapshot := first.Snapshot()
+	secondSnapshot := second.Snapshot()
+
+	secondTarget := second.AddRef()
+	firstResolver.Fulfill(secondTarget)
+	secondTarget.Release()
+	firstTarget := first.AddRef()
+	secondResolver.Fulfill(firstTarget)
+	firstTarget.Release()
+
+	first.Release()
+	second.Release()
+	requireClientPromiseCycle(t, &firstSnapshot)
+	requireClientPromiseCycle(t, &secondSnapshot)
+	firstSnapshot.Release()
+	secondSnapshot.Release()
+
+	if firstHook.shutdowns != 1 {
+		t.Fatalf("first promise hook shutdowns = %d; want 1", firstHook.shutdowns)
+	}
+	if secondHook.shutdowns != 1 {
+		t.Fatalf("second promise hook shutdowns = %d; want 1", secondHook.shutdowns)
+	}
+}
+
+func TestClientPromiseRejectsSimultaneousResolutionCycle(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		firstHook := new(dummyHook)
+		secondHook := new(dummyHook)
+		first, firstResolver := NewPromisedClient(firstHook)
+		second, secondResolver := NewPromisedClient(secondHook)
+		firstSnapshot := first.Snapshot()
+		secondSnapshot := second.Snapshot()
+		firstTarget := first.AddRef()
+		secondTarget := second.AddRef()
+
+		// Capture both source and target hooks before publishing either edge.
+		// This deterministically exercises the stale-target race where
+		// independent ancestry checks would both pass.
+		firstPromise := firstResolver.(*clientPromise)
+		secondPromise := secondResolver.(*clientPromise)
+		firstSource, ok := firstPromise.hook.AddRef()
+		if !ok {
+			t.Fatal("first promise hook was released")
+		}
+		secondSource, ok := secondPromise.hook.AddRef()
+		if !ok {
+			t.Fatal("second promise hook was released")
+		}
+		firstTargetHook, _, _ := firstTarget.startCall()
+		secondTargetHook, _, _ := secondTarget.startCall()
+
+		firstDone := make(chan struct{})
+		secondDone := make(chan struct{})
+		go func() {
+			publishClientPromiseResolution(firstSource, secondTargetHook)
+			firstSource.Release()
+			close(firstDone)
+		}()
+		go func() {
+			publishClientPromiseResolution(secondSource, firstTargetHook)
+			secondSource.Release()
+			close(secondDone)
+		}()
+
+		firstReleased := make(chan struct{})
+		secondReleased := make(chan struct{})
+		go func() {
+			first.Release()
+			close(firstReleased)
+		}()
+		go func() {
+			second.Release()
+			close(secondReleased)
+		}()
+		synctest.Wait()
+
+		<-firstDone
+		<-secondDone
+		<-firstReleased
+		<-secondReleased
+		firstTarget.Release()
+		secondTarget.Release()
+
+		requireClientPromiseCycle(t, &firstSnapshot)
+		requireClientPromiseCycle(t, &secondSnapshot)
+		firstSnapshot.Release()
+		secondSnapshot.Release()
+		if firstHook.shutdowns != 1 {
+			t.Fatalf("first promise hook shutdowns = %d; want 1", firstHook.shutdowns)
+		}
+		if secondHook.shutdowns != 1 {
+			t.Fatalf("second promise hook shutdowns = %d; want 1", secondHook.shutdowns)
+		}
+	})
+}
+
+func TestClientPromiseCycleReleasesTargetAfterGraphUnlock(t *testing.T) {
+	concrete := NewClient(&dummyHook{brand: Brand{Value: 42}})
+	defer concrete.Release()
+	reentrant, reentrantResolver := NewPromisedClient(new(dummyHook))
+	defer reentrant.Release()
+
+	shutdownDone := make(chan struct{})
+	shutdownHook := &fulfillOnShutdownHook{
+		resolver: reentrantResolver,
+		target:   concrete,
+		done:     shutdownDone,
+	}
+	cycleTarget, cycleTargetResolver := NewPromisedClient(shutdownHook)
+	source, sourceResolver := NewPromisedClient(new(dummyHook))
+	sourceSnapshot := source.Snapshot()
+	defer sourceSnapshot.Release()
+
+	sourcePromise := sourceResolver.(*clientPromise)
+	sourceHook, ok := sourcePromise.hook.AddRef()
+	if !ok {
+		t.Fatal("source promise hook was released")
+	}
+	cycleTargetPromise := cycleTargetResolver.(*clientPromise)
+	cycleTargetHook, ok := cycleTargetPromise.hook.AddRef()
+	if !ok {
+		t.Fatal("cycle target hook was released")
+	}
+
+	// Establish cycleTarget -> source without compressing cycleTarget's
+	// cursor, then make cycleTargetHookForSource its final reference.
+	sourceAsTarget, _, _ := source.startCall()
+	publishClientPromiseResolution(cycleTargetHook, sourceAsTarget)
+	cycleTargetHookForSource := cycleTargetHook.AddRef()
+	cycleTarget.Release()
+	cycleTargetHook.Release()
+
+	// Publishing source -> cycleTarget rejects the cycle.  Releasing the
+	// displaced cycle target runs Shutdown, which synchronously fulfills a
+	// third promise and therefore reacquires the graph mutex.
+	publishClientPromiseResolution(sourceHook, cycleTargetHookForSource)
+	sourceHook.Release()
+
+	select {
+	case <-shutdownDone:
+	default:
+		t.Fatal("cycle target was not shut down after rejection")
+	}
+	if !shutdownHook.graphUnlocked {
+		t.Fatal("cycle target was shut down while the resolution graph was locked")
+	}
+	if err := reentrant.Resolve(context.Background()); err != nil {
+		t.Fatal("resolve promise fulfilled during shutdown:", err)
+	}
+	if !reentrant.IsSame(concrete) {
+		t.Fatalf("reentrant promise = %v; want %v", reentrant, concrete)
+	}
+
+	source.Release()
+	requireClientPromiseCycle(t, &sourceSnapshot)
+}
+
+func TestClientPromiseAcyclicResolutionCompresses(t *testing.T) {
+	first, firstResolver := NewPromisedClient(new(dummyHook))
+	defer first.Release()
+	second, secondResolver := NewPromisedClient(new(dummyHook))
+	defer second.Release()
+	concrete := NewClient(&dummyHook{brand: Brand{Value: 42}})
+	defer concrete.Release()
+
+	secondTarget := second.AddRef()
+	firstResolver.Fulfill(secondTarget)
+	secondTarget.Release()
+	secondResolver.Fulfill(concrete)
+
+	if err := first.Resolve(context.Background()); err != nil {
+		t.Fatal("resolve acyclic chain:", err)
+	}
+	if !first.IsSame(concrete) {
+		t.Fatalf("resolved client = %v; want %v", first, concrete)
+	}
+}
+
+type fulfillOnShutdownHook struct {
+	dummyHook
+	once     sync.Once
+	resolver Resolver[Client]
+	target   Client
+	done     chan struct{}
+
+	graphUnlocked bool
+}
+
+func (h *fulfillOnShutdownHook) Shutdown() {
+	h.once.Do(func() {
+		if !clientPromiseResolutionMu.TryLock() {
+			close(h.done)
+			return
+		}
+		h.graphUnlocked = true
+		clientPromiseResolutionMu.Unlock()
+		h.resolver.Fulfill(h.target)
+		close(h.done)
 	})
 }
 

--- a/rpc/resolve_cycle_test.go
+++ b/rpc/resolve_cycle_test.go
@@ -1,0 +1,113 @@
+package rpc
+
+import (
+	"context"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"testing/synctest"
+
+	"capnproto.org/go/capnp/v3"
+)
+
+type cyclePipelineCaller struct{}
+
+func (cyclePipelineCaller) PipelineSend(
+	context.Context,
+	[]capnp.PipelineOp,
+	capnp.Send,
+) (*capnp.Answer, capnp.ReleaseFunc) {
+	panic("unexpected pipeline send")
+}
+
+func (cyclePipelineCaller) PipelineRecv(
+	context.Context,
+	[]capnp.PipelineOp,
+	capnp.Recv,
+) capnp.PipelineCaller {
+	panic("unexpected pipeline recv")
+}
+
+func TestHandleResolveRejectsDelayedReceiverAnswerCycle(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		conn, _ := newResolveLifecycleConn(t)
+		promise := addResolvePromise(t, conn)
+		promiseSnapshot := promise.Snapshot()
+		defer promiseSnapshot.Release()
+
+		// Preserve a cursor rooted at the original promise hook.  Unlike
+		// Client.AddRef, ClientSnapshot.Client creates an independent cursor.
+		resultMessage, resultSegment := capnp.NewSingleSegmentMessage(nil)
+		resultClient := promiseSnapshot.Client()
+		resultCap := resultMessage.CapTable().Add(resultClient)
+		result := capnp.NewInterface(resultSegment, resultCap).ToPtr()
+		defer resultMessage.Release()
+
+		answerPromise := capnp.NewPromise(capnp.Method{}, cyclePipelineCaller{}, nil)
+		const delayedAnswerID = answerID(45)
+		conn.withLocked(func(c *lockedConn) {
+			// Mark this pipeline as belonging to the same connection.  This
+			// ensures isLocalClient does not hide the promise graph behind an
+			// embargo, and the assertion below pins that prerequisite.
+			c.setAnswerQuestion(answerPromise.Answer(), &question{c: conn})
+			if !c.lk.answers.Create(delayedAnswerID, &ansent{promise: answerPromise}) {
+				t.Fatal("create delayed receiver answer")
+			}
+		})
+		defer func() {
+			conn.withLocked(func(c *lockedConn) {
+				c.lk.answers.Remove(delayedAnswerID)
+			})
+		}()
+
+		in := resolveToReceiverAnswer(t, resolvePromiseID, delayedAnswerID)
+		if err := conn.handleResolve(context.Background(), in); err != nil {
+			t.Fatal("handle Resolve:", err)
+		}
+		if got := atomic.LoadInt32(&in.releases); got != 1 {
+			t.Fatalf("incoming message releases = %d; want 1", got)
+		}
+		requirePromiseResolverConsumed(t, conn, resolvePromiseID)
+		conn.withLocked(func(c *lockedConn) {
+			embargoes := 0
+			c.lk.embargoes.Range(func(_ embargoID, _ *embargo) bool {
+				embargoes++
+				return true
+			})
+			if embargoes != 0 {
+				t.Fatalf("delayed receiver answer created %d embargoes; want 0", embargoes)
+			}
+		})
+
+		fulfilled := make(chan struct{})
+		released := make(chan struct{})
+		go func() {
+			answerPromise.Fulfill(result)
+			close(fulfilled)
+		}()
+		go func() {
+			promise.Release()
+			close(released)
+		}()
+		synctest.Wait()
+		<-fulfilled
+		<-released
+		answerPromise.ReleaseClients()
+
+		if err := promiseSnapshot.Resolve(context.Background()); err != nil {
+			t.Fatal("resolve imported promise snapshot:", err)
+		}
+		resolutionErr, ok := promiseSnapshot.Brand().Value.(error)
+		if !ok || !strings.Contains(resolutionErr.Error(), "client promise resolution cycle") {
+			t.Fatalf("resolved promise brand = %v; want resolution-cycle error", resolutionErr)
+		}
+
+		lockObserved := false
+		conn.withLocked(func(*lockedConn) {
+			lockObserved = true
+		})
+		if !lockObserved {
+			t.Fatal("connection lock remained unavailable after cycle rejection")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- serialize promise-resolution ancestry checks with edge publication so the client promise graph remains acyclic under concurrent fulfillment
- resolve a would-be cycle to a deterministic error client before path compression, releasing displaced hooks only after the graph lock is dropped
- cover direct, two-node, simultaneous stale-target, reentrant shutdown, acyclic, and delayed unembargoed `receiverAnswer` resolution paths

## Testing

- focused capability and RPC cycle tests, 100 repetitions
- focused reentrant and race tests
- `go test ./... -count=1`
- `go test -race ./... -count=1`
- `go vet ./rpc`

## Stack

Depends on #655, which provides snapshot-safe promise settlement. This PR is based on `codex/rpc-snapshot-promise-settlement` and should be retargeted to `main` after #655 lands.

Closes #648.