### PR TITLE
rpc: add executable lifecycle conformance oracle

### DIFF
--- a/rpc/lifecycle_driver_test.go
+++ b/rpc/lifecycle_driver_test.go
@@ -1,0 +1,367 @@
+package rpc_test
+
+import (
+	"sync"
+	"testing"
+
+	"capnproto.org/go/capnp/v3/rpc"
+	"capnproto.org/go/capnp/v3/rpc/transport"
+	rpccp "capnproto.org/go/capnp/v3/std/capnp/rpc"
+)
+
+// lifecycleWireFlow names a message direction relative to the Go connection
+// under test.
+type lifecycleWireFlow uint8
+
+const (
+	lifecyclePeerToGo lifecycleWireFlow = iota
+	lifecycleGoToPeer
+)
+
+func (f lifecycleWireFlow) String() string {
+	switch f {
+	case lifecyclePeerToGo:
+		return "peer->go"
+	case lifecycleGoToPeer:
+		return "go->peer"
+	default:
+		return "unknown"
+	}
+}
+
+// lifecycleWireObservation is the scalar protocol state needed by lifecycle
+// tests.  It intentionally does not retain pointers into the message arena.
+type lifecycleWireObservation struct {
+	Sequence   uint64
+	Flow       lifecycleWireFlow
+	Which      rpccp.Message_Which
+	SummaryErr string
+
+	QuestionID uint32
+	AnswerID   uint32
+	PromiseID  uint32
+	ImportID   uint32
+
+	NoFinishNeeded    bool
+	ReleaseResultCaps bool
+	ReferenceCount    uint32
+	ResultCapCount    int
+
+	ResolveWhich      rpccp.Resolve_Which
+	ResolveCapWhich   rpccp.CapDescriptor_Which
+	ResolveCapID      uint32
+	TargetWhich       rpccp.MessageTarget_Which
+	PromisedQuestion  uint32
+	DisembargoContext rpccp.Disembargo_context_Which
+	DisembargoID      uint32
+
+	incomingReleaseCalls int
+}
+
+func (o lifecycleWireObservation) IncomingReleaseCalls() int {
+	return o.incomingReleaseCalls
+}
+
+// lifecycleObservedTransport is a protocol-only decorator.  A connection can
+// use it anywhere it accepts rpc.Transport; tests retain the decorator to
+// inspect a stable copy of messages and exact IncomingMessage.Release calls.
+//
+// Sequence is the order in which the decorator observed transport operations.
+// It is useful for diagnostics, but tests should use protocol acknowledgements
+// (and synctest.Wait where appropriate) to establish causal ordering.
+type lifecycleObservedTransport struct {
+	rpc.Transport
+
+	mu           sync.Mutex
+	nextSequence uint64
+	observations []lifecycleWireObservation
+}
+
+func observeLifecycleTransport(inner rpc.Transport) *lifecycleObservedTransport {
+	return &lifecycleObservedTransport{Transport: inner}
+}
+
+func (t *lifecycleObservedTransport) NewMessage() (transport.OutgoingMessage, error) {
+	out, err := t.Transport.NewMessage()
+	if err != nil {
+		return nil, err
+	}
+	return &lifecycleObservedOutgoing{OutgoingMessage: out, observer: t}, nil
+}
+
+func (t *lifecycleObservedTransport) RecvMessage() (transport.IncomingMessage, error) {
+	in, err := t.Transport.RecvMessage()
+	if err != nil {
+		return nil, err
+	}
+	index := t.record(lifecyclePeerToGo, in.Message())
+	return &lifecycleObservedIncoming{
+		IncomingMessage: in,
+		observer:        t,
+		observation:     index,
+	}, nil
+}
+
+func (t *lifecycleObservedTransport) record(flow lifecycleWireFlow, msg rpccp.Message) int {
+	return t.recordObservation(summarizeLifecycleWireMessage(flow, msg))
+}
+
+func (t *lifecycleObservedTransport) recordObservation(observation lifecycleWireObservation) int {
+	t.mu.Lock()
+	observation.Sequence = t.nextSequence
+	t.nextSequence++
+	t.observations = append(t.observations, observation)
+	index := len(t.observations) - 1
+	t.mu.Unlock()
+	return index
+}
+
+func (t *lifecycleObservedTransport) recordIncomingRelease(index int) {
+	t.mu.Lock()
+	t.observations[index].incomingReleaseCalls++
+	t.mu.Unlock()
+}
+
+func (t *lifecycleObservedTransport) Observations() []lifecycleWireObservation {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return append([]lifecycleWireObservation(nil), t.observations...)
+}
+
+type lifecycleObservedIncoming struct {
+	transport.IncomingMessage
+	observer    *lifecycleObservedTransport
+	observation int
+}
+
+func (in *lifecycleObservedIncoming) Release() {
+	in.observer.recordIncomingRelease(in.observation)
+	in.IncomingMessage.Release()
+}
+
+type lifecycleObservedOutgoing struct {
+	transport.OutgoingMessage
+	observer *lifecycleObservedTransport
+}
+
+func (out *lifecycleObservedOutgoing) Send() error {
+	observation := summarizeLifecycleWireMessage(lifecycleGoToPeer, out.Message())
+	if err := out.OutgoingMessage.Send(); err != nil {
+		return err
+	}
+	out.observer.recordObservation(observation)
+	return nil
+}
+
+func summarizeLifecycleWireMessage(flow lifecycleWireFlow, msg rpccp.Message) lifecycleWireObservation {
+	o := lifecycleWireObservation{
+		Flow:  flow,
+		Which: msg.Which(),
+	}
+	switch o.Which {
+	case rpccp.Message_Which_bootstrap:
+		m, err := msg.Bootstrap()
+		if err != nil {
+			o.SummaryErr = err.Error()
+			break
+		}
+		o.QuestionID = m.QuestionId()
+	case rpccp.Message_Which_call:
+		m, err := msg.Call()
+		if err != nil {
+			o.SummaryErr = err.Error()
+			break
+		}
+		o.QuestionID = m.QuestionId()
+		target, err := m.Target()
+		if err != nil {
+			o.SummaryErr = err.Error()
+			break
+		}
+		summarizeLifecycleTarget(&o, target)
+	case rpccp.Message_Which_return:
+		m, err := msg.Return()
+		if err != nil {
+			o.SummaryErr = err.Error()
+			break
+		}
+		o.AnswerID = m.AnswerId()
+		o.NoFinishNeeded = m.NoFinishNeeded()
+		if m.Which() == rpccp.Return_Which_results {
+			results, err := m.Results()
+			if err != nil {
+				o.SummaryErr = err.Error()
+				break
+			}
+			caps, err := results.CapTable()
+			if err != nil {
+				o.SummaryErr = err.Error()
+				break
+			}
+			o.ResultCapCount = caps.Len()
+		}
+	case rpccp.Message_Which_finish:
+		m, err := msg.Finish()
+		if err != nil {
+			o.SummaryErr = err.Error()
+			break
+		}
+		o.QuestionID = m.QuestionId()
+		o.ReleaseResultCaps = m.ReleaseResultCaps()
+	case rpccp.Message_Which_resolve:
+		m, err := msg.Resolve()
+		if err != nil {
+			o.SummaryErr = err.Error()
+			break
+		}
+		o.PromiseID = m.PromiseId()
+		o.ResolveWhich = m.Which()
+		if o.ResolveWhich == rpccp.Resolve_Which_cap {
+			cap, err := m.Cap()
+			if err != nil {
+				o.SummaryErr = err.Error()
+				break
+			}
+			o.ResolveCapWhich = cap.Which()
+			o.ResolveCapID = lifecycleCapDescriptorID(cap)
+		}
+	case rpccp.Message_Which_release:
+		m, err := msg.Release()
+		if err != nil {
+			o.SummaryErr = err.Error()
+			break
+		}
+		o.ImportID = m.Id()
+		o.ReferenceCount = m.ReferenceCount()
+	case rpccp.Message_Which_disembargo:
+		m, err := msg.Disembargo()
+		if err != nil {
+			o.SummaryErr = err.Error()
+			break
+		}
+		target, err := m.Target()
+		if err != nil {
+			o.SummaryErr = err.Error()
+			break
+		}
+		summarizeLifecycleTarget(&o, target)
+		context := m.Context()
+		o.DisembargoContext = context.Which()
+		switch o.DisembargoContext {
+		case rpccp.Disembargo_context_Which_senderLoopback:
+			o.DisembargoID = context.SenderLoopback()
+		case rpccp.Disembargo_context_Which_receiverLoopback:
+			o.DisembargoID = context.ReceiverLoopback()
+		}
+	}
+	return o
+}
+
+func summarizeLifecycleTarget(o *lifecycleWireObservation, target rpccp.MessageTarget) {
+	o.TargetWhich = target.Which()
+	switch o.TargetWhich {
+	case rpccp.MessageTarget_Which_importedCap:
+		o.ImportID = target.ImportedCap()
+	case rpccp.MessageTarget_Which_promisedAnswer:
+		answer, err := target.PromisedAnswer()
+		if err != nil {
+			o.SummaryErr = err.Error()
+			return
+		}
+		o.PromisedQuestion = answer.QuestionId()
+	}
+}
+
+func lifecycleCapDescriptorID(cap rpccp.CapDescriptor) uint32 {
+	switch cap.Which() {
+	case rpccp.CapDescriptor_Which_senderHosted:
+		return cap.SenderHosted()
+	case rpccp.CapDescriptor_Which_senderPromise:
+		return cap.SenderPromise()
+	case rpccp.CapDescriptor_Which_receiverHosted:
+		return cap.ReceiverHosted()
+	case rpccp.CapDescriptor_Which_thirdPartyHosted:
+		thirdParty, err := cap.ThirdPartyHosted()
+		if err == nil {
+			return thirdParty.VineId()
+		}
+	}
+	return 0
+}
+
+// newLifecycleDriver gives a Conn-side observed transport and a scripted peer.
+// The peer uses the existing sendMessage/recvMessage wire helpers.
+func newLifecycleDriver(t testing.TB, buffer int) (*lifecycleObservedTransport, rpc.Transport) {
+	t.Helper()
+	goSide, peerSide := transport.NewPipe(buffer)
+	observed := observeLifecycleTransport(rpc.NewTransport(goSide))
+	peer := rpc.NewTransport(peerSide)
+	t.Cleanup(func() {
+		_ = observed.Close()
+		_ = peer.Close()
+	})
+	return observed, peer
+}
+
+func TestLifecycleObservedTransportRecordsProtocolAndIncomingReleases(t *testing.T) {
+	observed, peer := newLifecycleDriver(t, 4)
+
+	if err := sendMessage(t.Context(), peer, &rpcMessage{
+		Which: rpccp.Message_Which_return,
+		Return: &rpcReturn{
+			AnswerID:       17,
+			NoFinishNeeded: true,
+			Which:          rpccp.Return_Which_results,
+			Results:        &rpcPayload{},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	in, err := observed.RecvMessage()
+	if err != nil {
+		t.Fatal(err)
+	}
+	in.Release()
+	in.Release()
+
+	out, err := observed.NewMessage()
+	if err != nil {
+		t.Fatal(err)
+	}
+	finish, err := out.Message().NewFinish()
+	if err != nil {
+		t.Fatal(err)
+	}
+	finish.SetQuestionId(17)
+	finish.SetReleaseResultCaps(true)
+	if err := out.Send(); err != nil {
+		t.Fatal(err)
+	}
+	out.Release()
+
+	peerMessage, err := peer.RecvMessage()
+	if err != nil {
+		t.Fatal(err)
+	}
+	peerMessage.Release()
+
+	got := observed.Observations()
+	if len(got) != 2 {
+		t.Fatalf("observations = %d; want 2", len(got))
+	}
+	if got[0].Flow != lifecyclePeerToGo ||
+		got[0].Which != rpccp.Message_Which_return ||
+		got[0].AnswerID != 17 ||
+		!got[0].NoFinishNeeded ||
+		got[0].IncomingReleaseCalls() != 2 ||
+		got[0].SummaryErr != "" {
+		t.Fatalf("incoming observation = %+v", got[0])
+	}
+	if got[1].Flow != lifecycleGoToPeer ||
+		got[1].Which != rpccp.Message_Which_finish ||
+		got[1].QuestionID != 17 ||
+		!got[1].ReleaseResultCaps ||
+		got[1].SummaryErr != "" {
+		t.Fatalf("outgoing observation = %+v", got[1])
+	}
+}

--- a/rpc/lifecycle_invariants_test.go
+++ b/rpc/lifecycle_invariants_test.go
@@ -1,0 +1,766 @@
+package rpc_test
+
+import (
+	"crypto/sha1"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"slices"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+type schemaIdentity struct {
+	GitBlob string
+	SHA256  string
+}
+
+var rpcSchemaSource = struct {
+	Canonical schemaIdentity
+	Local     schemaIdentity
+}{
+	Canonical: schemaIdentity{
+		GitBlob: "0b821519acf9b221801639dfaf8c7adc25a26b08",
+		SHA256:  "2ecc3049d4f7f2d48a3a368dbb9ef4b97b31c1365996d615bd19c267983a1931",
+	},
+	Local: schemaIdentity{
+		GitBlob: "bc8ad6e0d84cce2b3bb159ba855ddbd8368ad5e0",
+		SHA256:  "3a2646562b0b8d5f421e1281b7283b39fb8cf7f27a44fa9a6679f6011b2a2da7",
+	},
+}
+
+type invariantStatus uint8
+
+const (
+	invariantStatusInvalid invariantStatus = iota
+	invariantSupported
+	invariantDeferred
+	invariantLocalSchemaDivergent
+)
+
+func (s invariantStatus) String() string {
+	switch s {
+	case invariantSupported:
+		return "supported"
+	case invariantDeferred:
+		return "deferred"
+	case invariantLocalSchemaDivergent:
+		return "local-schema-divergent"
+	default:
+		return "invalid"
+	}
+}
+
+type clauseSourceKind uint8
+
+const (
+	clauseSourceInvalid clauseSourceKind = iota
+	clauseDeclaration
+	clauseSection
+)
+
+type reviewedClause struct {
+	SourceKind    clauseSourceKind
+	Declaration   string
+	Excerpt       string
+	ExcerptDigest string
+}
+
+type constraintBuilder func(ruleInput) (constraintAlternatives, error)
+
+type invariantRule struct {
+	Action actionKind
+	Probe  ruleInput
+	Build  constraintBuilder
+}
+
+func newInvariantRule(action actionKind, build constraintBuilder) invariantRule {
+	return invariantRule{
+		Action: action,
+		Probe:  probeFor(action),
+		Build:  build,
+	}
+}
+
+type lifecycleInvariant struct {
+	ID            string
+	CanonicalBlob string
+	Declaration   string
+	Slug          string
+	Paraphrase    string
+	Status        invariantStatus
+	Clauses       []reviewedClause
+	Rules         []invariantRule
+
+	// A divergent invariant's canonical clauses must be absent from the local
+	// schema, while this exact gap-spanning anchor must remain present.
+	LocalAbsenceAnchor       string
+	LocalAbsenceAnchorDigest string
+}
+
+func newLifecycleInvariant(
+	declaration string,
+	slug string,
+	paraphrase string,
+	status invariantStatus,
+	clauses []reviewedClause,
+	rules ...invariantRule,
+) lifecycleInvariant {
+	return lifecycleInvariant{
+		ID:            invariantID(declaration, slug),
+		CanonicalBlob: rpcSchemaSource.Canonical.GitBlob,
+		Declaration:   declaration,
+		Slug:          slug,
+		Paraphrase:    paraphrase,
+		Status:        status,
+		Clauses:       clauses,
+		Rules:         rules,
+	}
+}
+
+func invariantID(declaration, slug string) string {
+	return "rpc-v2@" + rpcSchemaSource.Canonical.GitBlob[:8] + ":" + declaration + ":" + slug
+}
+
+func clause(declaration, excerpt, digest string) reviewedClause {
+	return reviewedClause{
+		SourceKind:    clauseDeclaration,
+		Declaration:   declaration,
+		Excerpt:       excerpt,
+		ExcerptDigest: digest,
+	}
+}
+
+func sectionClause(path, excerpt, digest string) reviewedClause {
+	return reviewedClause{
+		SourceKind:    clauseSection,
+		Declaration:   path,
+		Excerpt:       excerpt,
+		ExcerptDigest: digest,
+	}
+}
+
+func lifecycleInvariants() []lifecycleInvariant {
+	invariants := []lifecycleInvariant{
+		newLifecycleInvariant(
+			"Call.questionId",
+			"question-id-retirement",
+			"A question ID remains occupied until Return and Finish retire it.",
+			invariantSupported,
+			[]reviewedClause{clause(
+				"Call.questionId",
+				`A question ID can be reused once both:
+- A matching Return has been received from the callee.
+- A matching Finish has been sent from the caller.`,
+				"2fc81182310ac7fbcf4ad85762066111eb75550d5557df41df5e8650dd527ad0",
+			)},
+			newInvariantRule(actionLocalCall, buildQuestionRetirementConstraints),
+			newInvariantRule(actionWireCall, buildQuestionRetirementConstraints),
+			newInvariantRule(actionPeerReturn, buildQuestionRetirementConstraints),
+			newInvariantRule(actionWireFinish, buildQuestionRetirementConstraints),
+		),
+		newLifecycleInvariant(
+			"Finish.releaseResultCaps",
+			"result-cap-release",
+			"Cancel-owned Finish releases every capability in a later result.",
+			invariantSupported,
+			[]reviewedClause{clause(
+				"Finish.releaseResultCaps",
+				"If true, all capabilities that were in the results should be considered released.\n"+
+					"The sender must not send separate `Release` messages for them.",
+				"44dce5d2dd5142f2d2e0f8bac5624c169b67c6ea136a3e91993853a9d0fa9433",
+			)},
+			newInvariantRule(actionLocalCancel, buildCancelResultConstraints),
+			newInvariantRule(actionWireFinish, buildCancelResultConstraints),
+			newInvariantRule(actionPeerReturn, buildCancelResultConstraints),
+		),
+		newLifecycleInvariant(
+			"Return.noFinishNeeded",
+			"question-retirement",
+			"A capability-free noFinishNeeded Return retires the question; a compatibility Finish is harmless.",
+			invariantSupported,
+			[]reviewedClause{clause(
+				"Return.noFinishNeeded",
+				"If true, the sender does not need the receiver to send a `Finish` message; its answer table\n"+
+					"entry has already been cleaned up. This implies that the results do not contain any\n"+
+					"capabilities, since the `Finish` message would normally release those capabilities from\n"+
+					"promise pipelining responsibility. The caller may still send a `Finish` message if it wants,\n"+
+					"which will be silently ignored by the callee.",
+				"e0a3a15a1a573e3d2043432ae38121fe1fcb2e86869cba7c48ebcb2f75c01c1a",
+			)},
+			newInvariantRule(actionPeerReturn, buildNoFinishNeededConstraints),
+			newInvariantRule(actionWireFinish, buildNoFinishNeededConstraints),
+			newInvariantRule(actionPeerFinish, buildNoFinishNeededConstraints),
+		),
+		newLifecycleInvariant(
+			"CapDescriptor.senderPromise",
+			"single-resolution",
+			"Each senderPromise incarnation receives at most one Resolve.",
+			invariantSupported,
+			[]reviewedClause{
+				clause(
+					"CapDescriptor.senderPromise",
+					"A promise that the sender will resolve later. The sender will send exactly one Resolve\n"+
+						"message at a future point in time to replace this promise. Note that even if the same\n"+
+						"`senderPromise` is received multiple times, only one `Resolve` is sent to cover all of\n"+
+						"them. If `senderPromise` is released before the `Resolve` is sent, the sender (of this\n"+
+						"`CapDescriptor`) may choose not to send the `Resolve` at all.",
+					"f9e40d053b672f3a85e3da394d13a1b879bc49bf8c28ac1dedfe0c09235288c1",
+				),
+				clause(
+					"Resolve.promiseId",
+					"promiseId @0 :ExportId;\n"+
+						"The ID of the promise to be resolved.\n\n"+
+						"Unlike all other instances of `ExportId` sent from the exporter, the `Resolve` message does\n"+
+						"_not_ increase the reference count of `promiseId`. In fact, it is expected that the receiver\n"+
+						"will release the export soon after receiving `Resolve`, and the sender will not send this\n"+
+						"`ExportId` again until it has been released and recycled.\n\n"+
+						"When an export ID sent over the wire (e.g. in a `CapDescriptor`) is indicated to be a promise,\n"+
+						"this indicates that the sender will follow up at some point with a `Resolve` message. If the\n"+
+						"same `promiseId` is sent again before `Resolve`, still only one `Resolve` is sent. If the\n"+
+						"same ID is sent again later _after_ a `Resolve`, it can only be because the export's\n"+
+						"reference count hit zero in the meantime and the ID was re-assigned to a new export, therefore\n"+
+						"this later promise does _not_ correspond to the earlier `Resolve`.",
+					"184087dca8b5720cca48c314fcc1ae86288acaef0bfc44a2d3143c4f9548ba4c",
+				),
+				clause(
+					"ExportId.referenceCounting",
+					"ExportId/ImportIds are subject to reference counting. Whenever an `ExportId` is sent over the\n"+
+						"wire (from the exporter to the importer), the export's reference count is incremented (unless\n"+
+						"otherwise specified). The reference count is later decremented by a `Release` message. Since\n"+
+						"the `Release` message can specify an arbitrary number by which to reduce the reference count, the\n"+
+						"importer should usually batch reference decrements and only send a `Release` when it believes the\n"+
+						"reference count has hit zero. Of course, it is possible that a new reference to the export is\n"+
+						"in-flight at the time that the `Release` message is sent, so it is necessary for the exporter to\n"+
+						"keep track of the reference count on its end as well to avoid race conditions.",
+					"d12924dc161e6c484bed6d74651d47106e74d7a9ca6e644552a50bb2a2158239",
+				),
+			},
+			newInvariantRule(actionPeerResolve, buildPromiseSingleResolutionConstraints),
+			newInvariantRule(actionWireResolve, buildPromiseSingleResolutionConstraints),
+			newInvariantRule(actionLocalResolve, buildPromiseSingleResolutionConstraints),
+		),
+		newLifecycleInvariant(
+			"Resolve.promiseId",
+			"late-resolution-release",
+			"A late Resolve for a released imported promise releases its replacement without reviving the promise.",
+			invariantSupported,
+			[]reviewedClause{
+				clause(
+					"Resolve.promiseId",
+					"If a promise ID's reference count reaches zero before a `Resolve` is sent, the `Resolve`\n"+
+						"message may or may not still be sent (the `Resolve` may have already been in-flight when\n"+
+						"`Release` was sent, but if the `Release` is received before `Resolve` then there is no longer\n"+
+						"any reason to send a `Resolve`). Thus a `Resolve` may be received for a promise of which\n"+
+						"the receiver has no knowledge, because it already released it earlier. In this case, the\n"+
+						"receiver should simply release the capability to which the promise resolved.",
+					"bc9d0aa20433b598b0bab8e75b7858856416baf9b3c3e73b04a59b3c850a2e25",
+				),
+				clause(
+					"Resolve.cap",
+					"cap @1 :CapDescriptor;\n"+
+						"The object to which the promise resolved.\n\n"+
+						"The sender promises that from this point forth, until `promiseId` is released, it shall\n"+
+						"simply forward all messages to the capability designated by `cap`. This is true even if\n"+
+						"`cap` itself happens to designate another promise, and that other promise later resolves --\n"+
+						"messages sent to `promiseId` shall still go to that other promise, not to its resolution.\n"+
+						"This is important in the case that the receiver of the `Resolve` ends up sending a\n"+
+						"`Disembargo` message towards `promiseId` in order to control message ordering -- that\n"+
+						"`Disembargo` really needs to reflect back to exactly the object designated by `cap` even\n"+
+						"if that object is itself a promise.",
+					"10258fb3803ddde67b236d440fe77dd1e1677a0287e92413cf452385ed6d39f0",
+				),
+				clause(
+					"CapDescriptor.referenceCounting",
+					"Keep in mind that `ExportIds` in a `CapDescriptor` are subject to reference counting. See the\n"+
+						"description of `ExportId`.",
+					"59d2d6daad803f57b474677a4dd7bba1568777774f2d12b7843de56f36ffb964",
+				),
+				clause(
+					"ExportId.referenceCounting",
+					"ExportId/ImportIds are subject to reference counting. Whenever an `ExportId` is sent over the\n"+
+						"wire (from the exporter to the importer), the export's reference count is incremented (unless\n"+
+						"otherwise specified). The reference count is later decremented by a `Release` message. Since\n"+
+						"the `Release` message can specify an arbitrary number by which to reduce the reference count, the\n"+
+						"importer should usually batch reference decrements and only send a `Release` when it believes the\n"+
+						"reference count has hit zero. Of course, it is possible that a new reference to the export is\n"+
+						"in-flight at the time that the `Release` message is sent, so it is necessary for the exporter to\n"+
+						"keep track of the reference count on its end as well to avoid race conditions.",
+					"d12924dc161e6c484bed6d74651d47106e74d7a9ca6e644552a50bb2a2158239",
+				),
+			},
+			newInvariantRule(actionLocalRelease, buildLateResolveConstraints),
+			newInvariantRule(actionWireRelease, buildLateResolveConstraints),
+			newInvariantRule(actionPeerResolve, buildLateResolveConstraints),
+		),
+		newLifecycleInvariant(
+			"Release.referenceCount",
+			"reference-decrement",
+			"Release decrements the exporter-owned reference count and retires only at zero.",
+			invariantSupported,
+			[]reviewedClause{
+				clause(
+					"Release.referenceCount",
+					"referenceCount @1 :UInt32;\n"+
+						"The amount by which to decrement the reference count. The export is only actually released\n"+
+						"when the reference count reaches zero.",
+					"7aad0df169e059d72aa358590cca189da7f0c2bc095774b65e792c3dc3f301c9",
+				),
+				clause(
+					"ExportId.referenceCounting",
+					"ExportId/ImportIds are subject to reference counting. Whenever an `ExportId` is sent over the\n"+
+						"wire (from the exporter to the importer), the export's reference count is incremented (unless\n"+
+						"otherwise specified). The reference count is later decremented by a `Release` message. Since\n"+
+						"the `Release` message can specify an arbitrary number by which to reduce the reference count, the\n"+
+						"importer should usually batch reference decrements and only send a `Release` when it believes the\n"+
+						"reference count has hit zero. Of course, it is possible that a new reference to the export is\n"+
+						"in-flight at the time that the `Release` message is sent, so it is necessary for the exporter to\n"+
+						"keep track of the reference count on its end as well to avoid race conditions.",
+					"d12924dc161e6c484bed6d74651d47106e74d7a9ca6e644552a50bb2a2158239",
+				),
+				clause(
+					"ImportId.lifetime",
+					"An `ImportId` remains valid in importer -> exporter messages until the importer has sent\n"+
+						"`Release` messages that (it believes) have reduced the reference count to zero.",
+					"97c851b796f1f066979f5c522eae91d1f1bac9f86efa8474edfece5ecccebe3c",
+				),
+			},
+			newInvariantRule(actionLocalRelease, buildReferenceDecrementConstraints),
+			newInvariantRule(actionPeerRelease, buildReferenceDecrementConstraints),
+			newInvariantRule(actionWireRelease, buildReferenceDecrementConstraints),
+		),
+		newLifecycleInvariant(
+			"Disembargo",
+			"promise-resolution-ordering",
+			"Disembargo preserves the required delivery edge across a promise path change.",
+			invariantSupported,
+			[]reviewedClause{
+				clause(
+					"Disembargo",
+					"Message sent to indicate that an embargo on a recently-resolved promise may now be lifted.\n\n"+
+						"Embargos are used to enforce E-order in the presence of promise resolution. That is, if an\n"+
+						"application makes two calls foo() and bar() on the same capability reference, in that order,\n"+
+						"the calls should be delivered in the order in which they were made. But if foo() is called\n"+
+						"on a promise, and that promise happens to resolve before bar() is called, then the two calls\n"+
+						"may travel different paths over the network, and thus could arrive in the wrong order. In\n"+
+						"this case, the call to `bar()` must be embargoed, and a `Disembargo` message must be sent along\n"+
+						"the same path as `foo()` to ensure that the `Disembargo` arrives after `foo()`. Once the\n"+
+						"`Disembargo` arrives, `bar()` can then be delivered.",
+					"d6af96339c82cba73124d8fd95824f24af02c682154e46a102b93787cf468f69",
+				),
+				sectionClause(
+					"Protocol.eOrder",
+					"Unless otherwise specified, messages must be delivered to the receiving application in the same\n"+
+						"order in which they were initiated by the sending application. The goal is to support \"E-Order\",\n"+
+						"which states that two calls made on the same reference must be delivered in the order which they\n"+
+						"were made:\n"+
+						"http://erights.org/elib/concurrency/partial-order.html",
+					"76b68be8a32fb4413e43adb735795019693c6842f3c2ad7a7c78dd41071912cf",
+				),
+				sectionClause(
+					"Disembargo.samePathAlternative",
+					"Note that in the case where Carol actually lives in Vat B (i.e., the same vat that the promise\n"+
+						"already pointed at), no embargo is needed, because the pipelined calls are delivered over the\n"+
+						"same path as the later direct calls.\n\n"+
+						"Keep in mind that promise resolution happens both in the form of Resolve messages as well as\n"+
+						"Return messages (which resolve PromisedAnswers). Embargos apply in both cases.",
+					"a1151b6b770d9b51b9fa3b84e0490ddc5dd67a9c45bd411792eaff48d360055d",
+				),
+				clause(
+					"Disembargo.context.senderLoopback/receiverLoopback",
+					"senderLoopback @1 :EmbargoId;\n"+
+						"The sender is requesting a disembargo on a promise that is known to resolve back to a\n"+
+						"capability hosted by the sender. As soon as the receiver has echoed back all pipelined calls\n"+
+						"on this promise, it will deliver the Disembargo back to the sender with `receiverLoopback`\n"+
+						"set to the same value as `senderLoopback`. This value is chosen by the sender, and since\n"+
+						"it is also consumed be the sender, the sender can use whatever strategy it wants to make sure\n"+
+						"the value is unambiguous.\n\n"+
+						"The receiver must verify that the target capability actually resolves back to the sender's\n"+
+						"vat. Otherwise, the sender has committed a protocol error and should be disconnected.\n\n"+
+						"receiverLoopback @2 :EmbargoId;\n"+
+						"The receiver previously sent a `senderLoopback` Disembargo towards a promise resolving to\n"+
+						"this capability, and that Disembargo is now being echoed back.",
+					"9c8d0f3d3211386d47809376f661f0433203388480ce8f480360548c8f5c2755",
+				),
+			},
+			newInvariantRule(actionWireCall, buildDisembargoConstraints),
+			newInvariantRule(actionPeerResolve, buildDisembargoConstraints),
+			newInvariantRule(actionWireDisembargo, buildDisembargoConstraints),
+			newInvariantRule(actionPeerDisembargo, buildDisembargoConstraints),
+			newInvariantRule(actionObserveDelivery, buildDisembargoConstraints),
+		),
+		newLifecycleInvariant(
+			"FourTables.connectionLoss",
+			"terminal-drain",
+			"Disconnect fails questions, breaks imports, and implicitly releases exports and answers.",
+			invariantSupported,
+			[]reviewedClause{
+				sectionClause(
+					"FourTables.connectionLoss",
+					"When a Cap'n Proto connection is lost, everything on the four tables is lost. All questions are\n"+
+						"canceled and throw exceptions. All imports become broken (all future calls to them throw\n"+
+						"exceptions). All exports and answers are implicitly released. The only things not lost are\n"+
+						"persistent capabilities (`SturdyRef`s). The application must plan for this and should respond by\n"+
+						"establishing a new connection and restoring from these persistent capabilities.",
+					"58cfecf459448a64a40b153147d98095844622698f502e5fac091af24a363902",
+				),
+				clause(
+					"ExportId.connectionLoss",
+					"When a connection is lost, all exports are implicitly released. It is not possible to restore\n"+
+						"a connection state after disconnect (although a transport layer could implement a concept of\n"+
+						"persistent connections if it is transparent to the RPC layer).",
+					"669cc81e9893efaa6927f21d4e2d321342c32e04c48063339a9002a8224e4782",
+				),
+				clause(
+					"Message.abort",
+					"abort @1 :Exception;\n"+
+						"Sent when a connection is being aborted due to an unrecoverable error. This could be e.g.\n"+
+						"because the sender received an invalid or nonsensical message or because the sender had an\n"+
+						"internal error. The sender will shut down the outgoing half of the connection after `abort`\n"+
+						"and will completely close the connection shortly thereafter (it's up to the sender how much\n"+
+						"of a time buffer they want to offer for the client to receive the `abort` before the\n"+
+						"connection is reset).",
+					"472e6cd2d128015cdb97b5e482f8b8588d467e4486e1c83aeea913969cb4f789",
+				),
+			},
+			newInvariantRule(actionLocalClose, buildDisconnectConstraints),
+			newInvariantRule(actionPeerAbort, buildDisconnectConstraints),
+		),
+		newLifecycleInvariant(
+			"Return.releaseParamCaps",
+			"param-cap-release",
+			"Return releases each parameter capability reference when releaseParamCaps is true.",
+			invariantDeferred,
+			[]reviewedClause{clause(
+				"Return.releaseParamCaps",
+				"If true, all capabilities that were in the params should be considered released. The sender\n"+
+					"must not send separate `Release` messages for them. Level 0 implementations in particular\n"+
+					"should always set this true. This defaults true because if level 0 implementations forget to\n"+
+					"set it they'll never notice (just silently leak caps), but if level >=1 implementations forget\n"+
+					"to set it to false they'll quickly get errors.\n\n"+
+					"The receiver should act as if the sender had sent a release message with count=1 for each\n"+
+					"CapDescriptor in the original Call message.",
+				"1210e77a0dcff7ed80de75074c3e5042e2a91a5148f54ab2ce02d3c832ee74b4",
+			)},
+		),
+	}
+
+	divergent := newLifecycleInvariant(
+		"CapDescriptor.senderPromise",
+		"resolved-target-shortening",
+		"A reused senderPromise must not name an export whose Resolve was already sent.",
+		invariantLocalSchemaDivergent,
+		[]reviewedClause{clause(
+			"CapDescriptor.senderPromise",
+			"`senderPromise` must not refer to an export for which `Resolve` was already sent in the past.\n"+
+				"The reason for this is that the receiver may no longer have a record of that past `Resolve`.\n"+
+				"In fact, it's extremely likely that when the receiver received the `Resolve`, it promptly\n"+
+				"released the promise from its import table, since it updated all references to the new taget.\n"+
+				"This means that if the old promise's export ID were sent again here, the receiver wouldn't\n"+
+				"know anything about it and wouldn't know that it's already resolved.\n\n"+
+				"In order to avoid the above case, if the sender detects that promise A is resolving to\n"+
+				"promise B, but promise B has already previously resolved to C, then the sender should simply\n"+
+				"resolve promise A directly to C.",
+			"56484603507c1ff849b6c1f0eb8eedc2f5178054baa506e7f64b19f19bd04fea",
+		)},
+	)
+	divergent.LocalAbsenceAnchor = "If `senderPromise` is released before the `Resolve` is sent, the sender (of this\n" +
+		"`CapDescriptor`) may choose not to send the `Resolve` at all.\n\n" +
+		"receiverHosted @3 :ImportId;"
+	divergent.LocalAbsenceAnchorDigest = "c7987ccde4230d26f02c520aaf810e99244479c31767eb4897519426e71a1368"
+	return append(invariants, divergent)
+}
+
+var invariantSlugPattern = regexp.MustCompile(`^[a-z0-9]+(?:-[a-z0-9]+)*$`)
+
+func validateLifecycleInvariants(invariants []lifecycleInvariant, schemaText string) error {
+	normalizedSchema := normalizeSchemaText(schemaText)
+	seen := make(map[string]struct{}, len(invariants))
+	for i, inv := range invariants {
+		if inv.ID == "" {
+			return fmt.Errorf("invariant %d: empty ID", i)
+		}
+		if _, ok := seen[inv.ID]; ok {
+			return fmt.Errorf("invariant %d: duplicate ID %q", i, inv.ID)
+		}
+		seen[inv.ID] = struct{}{}
+		if inv.ID != invariantID(inv.Declaration, inv.Slug) {
+			return fmt.Errorf("invariant %q: ID does not match declaration and slug", inv.ID)
+		}
+		if inv.CanonicalBlob != rpcSchemaSource.Canonical.GitBlob {
+			return fmt.Errorf("invariant %q: canonical blob %q; want %q",
+				inv.ID, inv.CanonicalBlob, rpcSchemaSource.Canonical.GitBlob)
+		}
+		if !invariantSlugPattern.MatchString(inv.Slug) {
+			return fmt.Errorf("invariant %q: invalid slug %q", inv.ID, inv.Slug)
+		}
+		if inv.Paraphrase == "" {
+			return fmt.Errorf("invariant %q: empty paraphrase", inv.ID)
+		}
+		if len(inv.Clauses) == 0 {
+			return fmt.Errorf("invariant %q: no reviewed clauses", inv.ID)
+		}
+		for j, clause := range inv.Clauses {
+			if clause.SourceKind != clauseDeclaration && clause.SourceKind != clauseSection {
+				return fmt.Errorf("invariant %q clause %d: invalid source kind %d", inv.ID, j, clause.SourceKind)
+			}
+			if clause.Declaration == "" || clause.Excerpt == "" {
+				return fmt.Errorf("invariant %q clause %d: empty declaration or excerpt", inv.ID, j)
+			}
+			if err := validateDigest(clause.ExcerptDigest); err != nil {
+				return fmt.Errorf("invariant %q clause %q: %v", inv.ID, clause.Declaration, err)
+			}
+			if got := digestNormalizedText(clause.Excerpt); got != clause.ExcerptDigest {
+				return fmt.Errorf("invariant %q clause %q: excerpt digest = %s; want %s",
+					inv.ID, clause.Declaration, got, clause.ExcerptDigest)
+			}
+			excerptPresent := strings.Contains(normalizedSchema, normalizeSchemaText(clause.Excerpt))
+			if inv.Status == invariantLocalSchemaDivergent && excerptPresent {
+				return fmt.Errorf("invariant %q clause %q: divergent excerpt unexpectedly present in local schema",
+					inv.ID, clause.Declaration)
+			}
+			if inv.Status != invariantLocalSchemaDivergent && !excerptPresent {
+				return fmt.Errorf("invariant %q clause %q: excerpt not found in local schema",
+					inv.ID, clause.Declaration)
+			}
+		}
+
+		switch inv.Status {
+		case invariantSupported:
+			if len(inv.Rules) == 0 {
+				return fmt.Errorf("invariant %q: supported invariant has no executable rules", inv.ID)
+			}
+			if inv.LocalAbsenceAnchor != "" || inv.LocalAbsenceAnchorDigest != "" {
+				return fmt.Errorf("invariant %q: supported invariant has a local-absence anchor", inv.ID)
+			}
+			if err := validateInvariantRules(inv); err != nil {
+				return err
+			}
+		case invariantDeferred:
+			if len(inv.Rules) != 0 {
+				return fmt.Errorf("invariant %q: deferred invariant has executable rules", inv.ID)
+			}
+			if inv.LocalAbsenceAnchor != "" || inv.LocalAbsenceAnchorDigest != "" {
+				return fmt.Errorf("invariant %q: deferred invariant has a local-absence anchor", inv.ID)
+			}
+		case invariantLocalSchemaDivergent:
+			if len(inv.Rules) != 0 {
+				return fmt.Errorf("invariant %q: local-schema-divergent invariant has executable rules", inv.ID)
+			}
+			if inv.LocalAbsenceAnchor == "" {
+				return fmt.Errorf("invariant %q: local-schema-divergent invariant has no absence anchor", inv.ID)
+			}
+			if err := validateDigest(inv.LocalAbsenceAnchorDigest); err != nil {
+				return fmt.Errorf("invariant %q local-absence anchor: %v", inv.ID, err)
+			}
+			if got := digestNormalizedText(inv.LocalAbsenceAnchor); got != inv.LocalAbsenceAnchorDigest {
+				return fmt.Errorf("invariant %q: local-absence anchor digest = %s; want %s",
+					inv.ID, got, inv.LocalAbsenceAnchorDigest)
+			}
+			if !strings.Contains(normalizedSchema, normalizeSchemaText(inv.LocalAbsenceAnchor)) {
+				return fmt.Errorf("invariant %q: local-absence anchor not found in local schema", inv.ID)
+			}
+		default:
+			return fmt.Errorf("invariant %q: invalid status %d", inv.ID, inv.Status)
+		}
+	}
+	return nil
+}
+
+func validateInvariantRules(inv lifecycleInvariant) error {
+	rules := slices.Clone(inv.Rules)
+	slices.SortFunc(rules, func(a, b invariantRule) int {
+		return int(a.Action) - int(b.Action)
+	})
+	for i, rule := range rules {
+		if !rule.Action.valid() {
+			return fmt.Errorf("invariant %q: invalid rule action %d", inv.ID, rule.Action)
+		}
+		if i > 0 && rules[i-1].Action == rule.Action {
+			return fmt.Errorf("invariant %q: duplicate rule action %d", inv.ID, rule.Action)
+		}
+		if rule.Build == nil {
+			return fmt.Errorf("invariant %q action %d: nil constraint builder", inv.ID, rule.Action)
+		}
+		alternatives, err := rule.Build(rule.Probe)
+		if err != nil {
+			return fmt.Errorf("invariant %q action %d: build constraints: %v", inv.ID, rule.Action, err)
+		}
+		if err := validateConstraintAlternatives(alternatives); err != nil {
+			return fmt.Errorf("invariant %q action %d: invalid constraints: %v", inv.ID, rule.Action, err)
+		}
+	}
+	return nil
+}
+
+func validateDigest(digest string) error {
+	decoded, err := hex.DecodeString(digest)
+	if err != nil || len(decoded) != sha256.Size {
+		return fmt.Errorf("invalid SHA-256 digest %q", digest)
+	}
+	return nil
+}
+
+func normalizeSchemaText(s string) string {
+	lines := strings.Split(strings.ReplaceAll(s, "\r\n", "\n"), "\n")
+	for i, line := range lines {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "#") {
+			line = strings.TrimSpace(strings.TrimPrefix(line, "#"))
+		}
+		lines[i] = line
+	}
+	return collapseASCIIWhitespace(strings.Join(lines, "\n"))
+}
+
+func collapseASCIIWhitespace(s string) string {
+	var b strings.Builder
+	space := false
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		isSpace := c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\f' || c == '\v'
+		if isSpace {
+			space = b.Len() > 0
+			continue
+		}
+		if space {
+			b.WriteByte(' ')
+			space = false
+		}
+		b.WriteByte(c)
+	}
+	return b.String()
+}
+
+func digestNormalizedText(s string) string {
+	sum := sha256.Sum256([]byte("capnp-rpc-clause-v1\x00" + normalizeSchemaText(s)))
+	return hex.EncodeToString(sum[:])
+}
+
+func gitBlobID(data []byte) string {
+	header := "blob " + strconv.Itoa(len(data)) + "\x00"
+	sum := sha1.Sum(append([]byte(header), data...))
+	return hex.EncodeToString(sum[:])
+}
+
+func readLocalRPCSchema(t *testing.T) []byte {
+	t.Helper()
+	_, sourceFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("locate lifecycle invariant test source")
+	}
+	path := filepath.Join(filepath.Dir(sourceFile), "..", "std", "capnp", "rpc.capnp")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read local RPC schema: %v", err)
+	}
+	return data
+}
+
+func TestLifecycleInvariantRegistry(t *testing.T) {
+	schema := readLocalRPCSchema(t)
+	sum := sha256.Sum256(schema)
+	if got := hex.EncodeToString(sum[:]); got != rpcSchemaSource.Local.SHA256 {
+		t.Fatalf("local rpc.capnp SHA-256 = %s; want %s", got, rpcSchemaSource.Local.SHA256)
+	}
+	if got := gitBlobID(schema); got != rpcSchemaSource.Local.GitBlob {
+		t.Fatalf("local rpc.capnp git blob = %s; want %s", got, rpcSchemaSource.Local.GitBlob)
+	}
+	if rpcSchemaSource.Canonical == rpcSchemaSource.Local {
+		t.Fatal("canonical and local schema identities are not distinct")
+	}
+	if got := len(lifecycleInvariants()); got != 10 {
+		t.Fatalf("registry length = %d; want 10", got)
+	}
+	if err := validateLifecycleInvariants(lifecycleInvariants(), string(schema)); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestLifecycleInvariantSchemaPathIsCWDIndependent(t *testing.T) {
+	want := readLocalRPCSchema(t)
+	t.Chdir(t.TempDir())
+	if got := readLocalRPCSchema(t); string(got) != string(want) {
+		t.Fatal("local RPC schema changed after working-directory change")
+	}
+}
+
+func TestLifecycleInvariantRegistryDiagnostics(t *testing.T) {
+	schema := string(readLocalRPCSchema(t))
+	tests := []struct {
+		name string
+		edit func([]lifecycleInvariant)
+		want string
+	}{
+		{
+			name: "duplicate ID",
+			edit: func(invariants []lifecycleInvariant) {
+				invariants[1].ID = invariants[0].ID
+			},
+			want: "duplicate ID",
+		},
+		{
+			name: "bad clause digest",
+			edit: func(invariants []lifecycleInvariant) {
+				invariants[0].Clauses[0].ExcerptDigest = "not-a-digest"
+			},
+			want: "invalid SHA-256 digest",
+		},
+		{
+			name: "invalid action",
+			edit: func(invariants []lifecycleInvariant) {
+				invariants[0].Rules[0].Action = actionKind(255)
+			},
+			want: "invalid rule action",
+		},
+		{
+			name: "supported without rules",
+			edit: func(invariants []lifecycleInvariant) {
+				invariants[0].Rules = nil
+			},
+			want: "supported invariant has no executable rules",
+		},
+		{
+			name: "deferred with rule",
+			edit: func(invariants []lifecycleInvariant) {
+				invariants[len(invariants)-2].Rules = []invariantRule{
+					newInvariantRule(actionLocalCall, buildQuestionRetirementConstraints),
+				}
+			},
+			want: "deferred invariant has executable rules",
+		},
+		{
+			name: "supported excerpt drift",
+			edit: func(invariants []lifecycleInvariant) {
+				invariants[0].Clauses[0].Excerpt = "not present in the schema"
+				invariants[0].Clauses[0].ExcerptDigest = digestNormalizedText(invariants[0].Clauses[0].Excerpt)
+			},
+			want: "excerpt not found in local schema",
+		},
+		{
+			name: "divergence loses local anchor",
+			edit: func(invariants []lifecycleInvariant) {
+				last := len(invariants) - 1
+				invariants[last].LocalAbsenceAnchor = "not present in the schema"
+				invariants[last].LocalAbsenceAnchorDigest = digestNormalizedText(invariants[last].LocalAbsenceAnchor)
+			},
+			want: "local-absence anchor not found",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			invariants := lifecycleInvariants()
+			test.edit(invariants)
+			err := validateLifecycleInvariants(invariants, schema)
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("validateLifecycleInvariants() error = %v; want substring %q", err, test.want)
+			}
+		})
+	}
+}

--- a/rpc/lifecycle_oracle_test.go
+++ b/rpc/lifecycle_oracle_test.go
@@ -1,0 +1,1500 @@
+package rpc_test
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+	"testing"
+)
+
+type lifecycleSide uint8
+
+const (
+	sideInvalid lifecycleSide = iota
+	sideGo
+	sidePeer
+)
+
+func (s lifecycleSide) String() string {
+	switch s {
+	case sideGo:
+		return "go"
+	case sidePeer:
+		return "peer"
+	default:
+		return "invalid"
+	}
+}
+
+type lifecycleIDSpace uint8
+
+const (
+	spaceInvalid lifecycleIDSpace = iota
+	spaceQuestion
+	spaceExport
+	spaceEmbargo
+)
+
+func (s lifecycleIDSpace) String() string {
+	switch s {
+	case spaceQuestion:
+		return "question"
+	case spaceExport:
+		return "export"
+	case spaceEmbargo:
+		return "embargo"
+	default:
+		return "invalid"
+	}
+}
+
+// incarnation names a protocol identity without baking the implementation's
+// concrete allocator choice into the oracle. Owner and space keep equal wire
+// integers in opposite directions distinct. Generation changes only after a
+// live identity has been retired and the concrete ID is observed again.
+type incarnation struct {
+	Owner      lifecycleSide
+	Space      lifecycleIDSpace
+	Ordinal    uint32
+	Generation uint32
+}
+
+func (id incarnation) String() string {
+	return fmt.Sprintf("%s/%s/%d@g%d", id.Owner, id.Space, id.Ordinal, id.Generation)
+}
+
+type questionRef struct {
+	ID incarnation
+}
+
+func (q questionRef) String() string { return q.ID.String() }
+
+type capRef struct {
+	Export  incarnation
+	Promise bool
+}
+
+func (c capRef) String() string {
+	kind := "cap"
+	if c.Promise {
+		kind = "promise"
+	}
+	return kind + "(" + c.Export.String() + ")"
+}
+
+type rawIDKey struct {
+	Owner lifecycleSide
+	Space lifecycleIDSpace
+	Wire  uint32
+}
+
+type normalizedBinding struct {
+	ID     incarnation
+	Active bool
+}
+
+type ordinalKey struct {
+	Owner lifecycleSide
+	Space lifecycleIDSpace
+}
+
+type idNormalizer struct {
+	bindings map[rawIDKey]normalizedBinding
+	next     map[ordinalKey]uint32
+}
+
+func newIDNormalizer() *idNormalizer {
+	return &idNormalizer{
+		bindings: make(map[rawIDKey]normalizedBinding),
+		next:     make(map[ordinalKey]uint32),
+	}
+}
+
+func (n *idNormalizer) normalize(owner lifecycleSide, space lifecycleIDSpace, wire uint32) incarnation {
+	if owner == sideInvalid || space == spaceInvalid {
+		panic("lifecycle oracle: invalid ID namespace")
+	}
+	key := rawIDKey{Owner: owner, Space: space, Wire: wire}
+	if binding, ok := n.bindings[key]; ok {
+		if !binding.Active {
+			binding.ID.Generation++
+			binding.Active = true
+			n.bindings[key] = binding
+		}
+		return binding.ID
+	}
+	ordinalKey := ordinalKey{Owner: owner, Space: space}
+	id := incarnation{
+		Owner:   owner,
+		Space:   space,
+		Ordinal: n.next[ordinalKey],
+	}
+	n.next[ordinalKey]++
+	n.bindings[key] = normalizedBinding{ID: id, Active: true}
+	return id
+}
+
+func (n *idNormalizer) retire(id incarnation) error {
+	for key, binding := range n.bindings {
+		if binding.ID == id {
+			if !binding.Active {
+				return fmt.Errorf("%s is already retired", id)
+			}
+			binding.Active = false
+			n.bindings[key] = binding
+			return nil
+		}
+	}
+	return fmt.Errorf("%s is not bound", id)
+}
+
+func (n *idNormalizer) question(caller lifecycleSide, wire uint32) questionRef {
+	return questionRef{ID: n.normalize(caller, spaceQuestion, wire)}
+}
+
+func (n *idNormalizer) capability(exporter lifecycleSide, wire uint32, promise bool) capRef {
+	return capRef{
+		Export:  n.normalize(exporter, spaceExport, wire),
+		Promise: promise,
+	}
+}
+
+type actionKind uint8
+
+const (
+	actionInvalid actionKind = iota
+	actionLocalCall
+	actionLocalCancel
+	actionLocalRelease
+	actionLocalResolve
+	actionLocalClose
+	actionPeerCall
+	actionPeerReturn
+	actionPeerFinish
+	actionPeerResolve
+	actionPeerRelease
+	actionPeerDisembargo
+	actionPeerAbort
+	actionWireCall
+	actionWireReturn
+	actionWireFinish
+	actionWireResolve
+	actionWireRelease
+	actionWireDisembargo
+	actionObserveImportPromise
+	actionObserveExportPromise
+	actionObserveCompletion
+	actionObserveDelivery
+	actionObserveCapabilityRelease
+	actionObserveConnDone
+)
+
+func (a actionKind) valid() bool {
+	return a > actionInvalid && a <= actionObserveConnDone
+}
+
+func (a actionKind) String() string {
+	switch a {
+	case actionLocalCall:
+		return "LocalCall"
+	case actionLocalCancel:
+		return "LocalCancel"
+	case actionLocalRelease:
+		return "LocalRelease"
+	case actionLocalResolve:
+		return "LocalResolve"
+	case actionLocalClose:
+		return "LocalClose"
+	case actionPeerCall:
+		return "PeerCall"
+	case actionPeerReturn:
+		return "PeerReturn"
+	case actionPeerFinish:
+		return "PeerFinish"
+	case actionPeerResolve:
+		return "PeerResolve"
+	case actionPeerRelease:
+		return "PeerRelease"
+	case actionPeerDisembargo:
+		return "PeerDisembargo"
+	case actionPeerAbort:
+		return "PeerAbort"
+	case actionWireCall:
+		return "WireCall"
+	case actionWireReturn:
+		return "WireReturn"
+	case actionWireFinish:
+		return "WireFinish"
+	case actionWireResolve:
+		return "WireResolve"
+	case actionWireRelease:
+		return "WireRelease"
+	case actionWireDisembargo:
+		return "WireDisembargo"
+	case actionObserveImportPromise:
+		return "ObserveImportPromise"
+	case actionObserveExportPromise:
+		return "ObserveExportPromise"
+	case actionObserveCompletion:
+		return "ObserveCompletion"
+	case actionObserveDelivery:
+		return "ObserveDelivery"
+	case actionObserveCapabilityRelease:
+		return "ObserveCapabilityRelease"
+	case actionObserveConnDone:
+		return "ObserveConnDone"
+	default:
+		return "Invalid"
+	}
+}
+
+type ruleInput struct {
+	Action            actionKind
+	Question          questionRef
+	Capability        capRef
+	Replacement       capRef
+	Count             uint32
+	ReferencesBefore  uint32
+	ResultCaps        uint32
+	NoFinishNeeded    bool
+	ReleaseResultCaps bool
+}
+
+func probeFor(action actionKind) ruleInput {
+	return ruleInput{
+		Action:   action,
+		Question: questionRef{ID: incarnation{Owner: sideGo, Space: spaceQuestion}},
+		Capability: capRef{
+			Export:  incarnation{Owner: sidePeer, Space: spaceExport},
+			Promise: true,
+		},
+		Replacement: capRef{
+			Export: incarnation{Owner: sidePeer, Space: spaceExport, Ordinal: 1},
+		},
+		Count:             1,
+		ReferencesBefore:  1,
+		ResultCaps:        0,
+		NoFinishNeeded:    true,
+		ReleaseResultCaps: true,
+	}
+}
+
+type eventPattern struct {
+	Kind       actionKind
+	Label      string
+	Question   questionRef
+	Capability capRef
+	HasQuestion,
+	HasCapability bool
+}
+
+func eventFor(kind actionKind) eventPattern {
+	return eventPattern{Kind: kind}
+}
+
+func eventForQuestion(kind actionKind, q questionRef) eventPattern {
+	return eventPattern{Kind: kind, Question: q, HasQuestion: true}
+}
+
+func eventForCapability(kind actionKind, c capRef) eventPattern {
+	return eventPattern{Kind: kind, Capability: c, HasCapability: true}
+}
+
+func labeledEvent(kind actionKind, label string) eventPattern {
+	return eventPattern{Kind: kind, Label: label}
+}
+
+func (p eventPattern) valid() bool {
+	return p.Kind.valid()
+}
+
+func (p eventPattern) matches(event lifecycleEvent) bool {
+	if p.Kind != event.Kind || p.Label != "" && p.Label != event.Label {
+		return false
+	}
+	if p.HasQuestion && p.Question != event.Question {
+		return false
+	}
+	if p.HasCapability && p.Capability != event.Capability {
+		return false
+	}
+	return true
+}
+
+func (p eventPattern) String() string {
+	var qualifiers []string
+	if p.Label != "" {
+		qualifiers = append(qualifiers, "label="+p.Label)
+	}
+	if p.HasQuestion {
+		qualifiers = append(qualifiers, "question="+p.Question.String())
+	}
+	if p.HasCapability {
+		qualifiers = append(qualifiers, "capability="+p.Capability.String())
+	}
+	if len(qualifiers) == 0 {
+		return p.Kind.String()
+	}
+	return p.Kind.String() + "[" + strings.Join(qualifiers, ",") + "]"
+}
+
+type cardinality struct {
+	Event eventPattern
+	Min   uint32
+	Max   uint32
+}
+
+type orderEdge struct {
+	Before eventPattern
+	After  eventPattern
+}
+
+type referenceBalance struct {
+	Capability capRef
+	Want       int64
+}
+
+type constraintAlternative struct {
+	Name       string
+	Counts     []cardinality
+	Orders     []orderEdge
+	References []referenceBalance
+}
+
+type constraintAlternatives []constraintAlternative
+
+func validateConstraintAlternatives(alternatives constraintAlternatives) error {
+	if len(alternatives) == 0 {
+		return errors.New("no constraint alternatives")
+	}
+	names := make(map[string]struct{}, len(alternatives))
+	for i, alternative := range alternatives {
+		if alternative.Name == "" {
+			return fmt.Errorf("alternative %d has no name", i)
+		}
+		if _, ok := names[alternative.Name]; ok {
+			return fmt.Errorf("duplicate alternative %q", alternative.Name)
+		}
+		names[alternative.Name] = struct{}{}
+		if len(alternative.Counts)+len(alternative.Orders)+len(alternative.References) == 0 {
+			return fmt.Errorf("alternative %q has no constraints", alternative.Name)
+		}
+		for _, count := range alternative.Counts {
+			if !count.Event.valid() {
+				return fmt.Errorf("alternative %q has invalid cardinality event", alternative.Name)
+			}
+			if count.Min > count.Max {
+				return fmt.Errorf("alternative %q has cardinality min %d greater than max %d", alternative.Name, count.Min, count.Max)
+			}
+		}
+		for _, edge := range alternative.Orders {
+			if !edge.Before.valid() || !edge.After.valid() {
+				return fmt.Errorf("alternative %q has invalid order edge", alternative.Name)
+			}
+		}
+	}
+	return nil
+}
+
+type lifecycleEvent struct {
+	Kind           actionKind
+	Label          string
+	Question       questionRef
+	Capability     capRef
+	ReferenceDelta int64
+}
+
+func (event lifecycleEvent) String() string {
+	pattern := eventPattern{
+		Kind:          event.Kind,
+		Label:         event.Label,
+		Question:      event.Question,
+		Capability:    event.Capability,
+		HasQuestion:   event.Question.ID.Space != spaceInvalid,
+		HasCapability: event.Capability.Export.Space != spaceInvalid,
+	}
+	s := pattern.String()
+	if event.ReferenceDelta != 0 {
+		s += fmt.Sprintf("{ref=%+d}", event.ReferenceDelta)
+	}
+	return s
+}
+
+type lifecycleLedger []lifecycleEvent
+
+func (ledger lifecycleLedger) count(pattern eventPattern) uint32 {
+	var count uint32
+	for _, event := range ledger {
+		if pattern.matches(event) {
+			count++
+		}
+	}
+	return count
+}
+
+func (ledger lifecycleLedger) indexes(pattern eventPattern) []int {
+	var indexes []int
+	for i, event := range ledger {
+		if pattern.matches(event) {
+			indexes = append(indexes, i)
+		}
+	}
+	return indexes
+}
+
+func (ledger lifecycleLedger) referenceBalance(capability capRef) int64 {
+	var balance int64
+	for _, event := range ledger {
+		if event.Capability == capability {
+			balance += event.ReferenceDelta
+		}
+	}
+	return balance
+}
+
+func (ledger lifecycleLedger) check(alternative constraintAlternative) error {
+	var failures []string
+	for _, count := range alternative.Counts {
+		got := ledger.count(count.Event)
+		if got < count.Min || got > count.Max {
+			failures = append(failures,
+				fmt.Sprintf("%s count=%d want=%d..%d", count.Event, got, count.Min, count.Max))
+		}
+	}
+	for _, edge := range alternative.Orders {
+		before := ledger.indexes(edge.Before)
+		after := ledger.indexes(edge.After)
+		if len(before) == 0 || len(after) == 0 {
+			failures = append(failures,
+				fmt.Sprintf("%s before %s is unobservable", edge.Before, edge.After))
+			continue
+		}
+		if before[len(before)-1] >= after[0] {
+			failures = append(failures,
+				fmt.Sprintf("%s does not happen before %s", edge.Before, edge.After))
+		}
+	}
+	for _, reference := range alternative.References {
+		if got := ledger.referenceBalance(reference.Capability); got != reference.Want {
+			failures = append(failures,
+				fmt.Sprintf("%s balance=%+d want=%+d", reference.Capability, got, reference.Want))
+		}
+	}
+	if len(failures) > 0 {
+		return errors.New(strings.Join(failures, "; "))
+	}
+	return nil
+}
+
+func checkConstraintAlternatives(alternatives constraintAlternatives, ledger lifecycleLedger) error {
+	if err := validateConstraintAlternatives(alternatives); err != nil {
+		return err
+	}
+	var failures []string
+	for _, alternative := range alternatives {
+		if err := ledger.check(alternative); err == nil {
+			return nil
+		} else {
+			failures = append(failures, alternative.Name+": "+err.Error())
+		}
+	}
+	return errors.New(strings.Join(failures, "\n"))
+}
+
+func buildQuestionRetirementConstraints(input ruleInput) (constraintAlternatives, error) {
+	switch input.Action {
+	case actionLocalCall, actionWireCall:
+		return constraintAlternatives{{
+			Name: "call-bound",
+			Counts: []cardinality{{
+				Event: eventForQuestion(actionWireCall, input.Question),
+				Min:   1,
+				Max:   1,
+			}},
+		}}, nil
+	case actionPeerReturn:
+		return constraintAlternatives{{
+			Name: "returned",
+			Counts: []cardinality{
+				{Event: eventForQuestion(actionPeerReturn, input.Question), Min: 1, Max: 1},
+				{Event: eventForQuestion(actionObserveCompletion, input.Question), Min: 1, Max: 1},
+			},
+		}}, nil
+	case actionWireFinish:
+		return constraintAlternatives{{
+			Name: "finished",
+			Counts: []cardinality{{
+				Event: eventForQuestion(actionWireFinish, input.Question),
+				Min:   1,
+				Max:   1,
+			}},
+		}}, nil
+	default:
+		return nil, fmt.Errorf("question retirement does not apply to %s", input.Action)
+	}
+}
+
+func buildCancelResultConstraints(input ruleInput) (constraintAlternatives, error) {
+	switch input.Action {
+	case actionLocalCancel:
+		return constraintAlternatives{
+			{
+				Name: "return-wins",
+				Counts: []cardinality{
+					{Event: labeledEvent(actionObserveCompletion, "success"), Min: 1, Max: 1},
+					{Event: labeledEvent(actionWireFinish, "releaseResultCaps=false"), Min: 1, Max: 1},
+				},
+			},
+			{
+				Name: "cancel-wins",
+				Counts: []cardinality{
+					{Event: labeledEvent(actionObserveCompletion, "canceled"), Min: 1, Max: 1},
+					{Event: labeledEvent(actionWireFinish, "releaseResultCaps=true"), Min: 1, Max: 1},
+				},
+				References: []referenceBalance{{
+					Capability: input.Capability,
+					Want:       0,
+				}},
+			},
+		}, nil
+	case actionWireFinish, actionPeerFinish:
+		return constraintAlternatives{{
+			Name: "implicit-result-release",
+			Counts: []cardinality{{
+				Event: labeledEvent(input.Action, "releaseResultCaps=true"),
+				Min:   1,
+				Max:   1,
+			}},
+			References: []referenceBalance{{
+				Capability: input.Capability,
+				Want:       0,
+			}},
+		}}, nil
+	case actionPeerReturn, actionWireReturn:
+		return constraintAlternatives{{
+			Name: "late-result-balanced",
+			Counts: []cardinality{{
+				Event: eventFor(input.Action),
+				Min:   1,
+				Max:   1,
+			}},
+			References: []referenceBalance{{
+				Capability: input.Capability,
+				Want:       0,
+			}},
+		}}, nil
+	default:
+		return nil, fmt.Errorf("result release does not apply to %s", input.Action)
+	}
+}
+
+func buildNoFinishNeededConstraints(input ruleInput) (constraintAlternatives, error) {
+	switch input.Action {
+	case actionPeerReturn, actionWireReturn:
+		if !input.NoFinishNeeded {
+			return nil, errors.New("noFinishNeeded Return does not set noFinishNeeded")
+		}
+		if input.ResultCaps != 0 {
+			return nil, fmt.Errorf("noFinishNeeded Return carries %d result capabilities", input.ResultCaps)
+		}
+		return constraintAlternatives{
+			{
+				Name: "retire-without-finish",
+				Counts: []cardinality{
+					{Event: labeledEvent(input.Action, "noFinishNeeded=true,resultCaps=0"), Min: 1, Max: 1},
+					{Event: eventFor(actionWireFinish), Min: 0, Max: 0},
+				},
+			},
+			{
+				Name: "compatibility-finish",
+				Counts: []cardinality{
+					{Event: labeledEvent(input.Action, "noFinishNeeded=true,resultCaps=0"), Min: 1, Max: 1},
+					{Event: eventFor(actionWireFinish), Min: 1, Max: 1},
+				},
+			},
+		}, nil
+	case actionWireFinish, actionPeerFinish:
+		return constraintAlternatives{{
+			Name: "compatibility-finish",
+			Counts: []cardinality{{
+				Event: eventFor(input.Action),
+				Min:   1,
+				Max:   1,
+			}},
+		}}, nil
+	default:
+		return nil, fmt.Errorf("noFinishNeeded does not apply to %s", input.Action)
+	}
+}
+
+func buildPromiseSingleResolutionConstraints(input ruleInput) (constraintAlternatives, error) {
+	switch input.Action {
+	case actionObserveImportPromise, actionObserveExportPromise:
+		resolve := actionPeerResolve
+		if input.Action == actionObserveExportPromise {
+			resolve = actionWireResolve
+		}
+		return constraintAlternatives{
+			{
+				Name: "resolved-once",
+				Counts: []cardinality{{
+					Event: eventForCapability(resolve, input.Capability),
+					Min:   1,
+					Max:   1,
+				}},
+			},
+			{
+				Name: "released-before-resolve",
+				Counts: []cardinality{{
+					Event: eventForCapability(resolve, input.Capability),
+					Min:   0,
+					Max:   1,
+				}},
+			},
+		}, nil
+	case actionLocalResolve, actionPeerResolve, actionWireResolve:
+		return constraintAlternatives{{
+			Name: "single-resolution",
+			Counts: []cardinality{{
+				Event: eventForCapability(input.Action, input.Capability),
+				Min:   1,
+				Max:   1,
+			}},
+		}}, nil
+	case actionLocalRelease, actionPeerRelease, actionWireRelease:
+		return constraintAlternatives{{
+			Name: "early-release",
+			Counts: []cardinality{{
+				Event: eventForCapability(input.Action, input.Capability),
+				Min:   1,
+				Max:   1,
+			}},
+		}}, nil
+	default:
+		return nil, fmt.Errorf("single resolution does not apply to %s", input.Action)
+	}
+}
+
+func buildLateResolveConstraints(input ruleInput) (constraintAlternatives, error) {
+	switch input.Action {
+	case actionLocalRelease, actionWireRelease:
+		return constraintAlternatives{{
+			Name: "promise-released",
+			Counts: []cardinality{{
+				Event: eventForCapability(actionWireRelease, input.Capability),
+				Min:   1,
+				Max:   1,
+			}},
+		}}, nil
+	case actionPeerResolve:
+		return constraintAlternatives{{
+			Name: "late-capability-released",
+			Counts: []cardinality{
+				{Event: eventForCapability(actionPeerResolve, input.Capability), Min: 1, Max: 1},
+				{Event: eventForCapability(actionWireRelease, input.Replacement), Min: 1, Max: 1},
+				{Event: eventFor(actionWireDisembargo), Min: 0, Max: 0},
+			},
+			References: []referenceBalance{{
+				Capability: input.Replacement,
+				Want:       0,
+			}},
+		}}, nil
+	default:
+		return nil, fmt.Errorf("late Resolve does not apply to %s", input.Action)
+	}
+}
+
+func buildReferenceDecrementConstraints(input ruleInput) (constraintAlternatives, error) {
+	switch input.Action {
+	case actionLocalRelease, actionPeerRelease, actionWireRelease:
+		if input.Count > input.ReferencesBefore {
+			return nil, fmt.Errorf(
+				"Release count %d exceeds reference count %d",
+				input.Count,
+				input.ReferencesBefore,
+			)
+		}
+		return constraintAlternatives{{
+			Name: "reference-decrement",
+			Counts: []cardinality{{
+				Event: eventForCapability(input.Action, input.Capability),
+				Min:   1,
+				Max:   1,
+			}},
+			References: []referenceBalance{{
+				Capability: input.Capability,
+				Want:       int64(input.ReferencesBefore - input.Count),
+			}},
+		}}, nil
+	default:
+		return nil, fmt.Errorf("reference decrement does not apply to %s", input.Action)
+	}
+}
+
+func buildDisembargoConstraints(input ruleInput) (constraintAlternatives, error) {
+	switch input.Action {
+	case actionLocalCall, actionWireCall, actionPeerReturn, actionPeerResolve,
+		actionWireDisembargo, actionPeerDisembargo, actionObserveDelivery:
+		return constraintAlternatives{
+			{
+				Name: "same-path",
+				Counts: []cardinality{
+					{Event: eventFor(actionWireDisembargo), Min: 0, Max: 0},
+					{Event: labeledEvent(actionObserveDelivery, "pre-resolution"), Min: 1, Max: 1},
+					{Event: labeledEvent(actionObserveDelivery, "post-resolution"), Min: 1, Max: 1},
+				},
+				Orders: []orderEdge{{
+					Before: labeledEvent(actionObserveDelivery, "pre-resolution"),
+					After:  labeledEvent(actionObserveDelivery, "post-resolution"),
+				}},
+			},
+			{
+				Name: "path-shortened",
+				Counts: []cardinality{
+					{Event: labeledEvent(actionObserveDelivery, "pre-resolution"), Min: 1, Max: 1},
+					{Event: labeledEvent(actionObserveDelivery, "post-resolution"), Min: 1, Max: 1},
+				},
+				Orders: []orderEdge{{
+					Before: labeledEvent(actionObserveDelivery, "pre-resolution"),
+					After:  labeledEvent(actionObserveDelivery, "post-resolution"),
+				}},
+			},
+		}, nil
+	default:
+		return nil, fmt.Errorf("Disembargo ordering does not apply to %s", input.Action)
+	}
+}
+
+func buildDisconnectConstraints(input ruleInput) (constraintAlternatives, error) {
+	switch input.Action {
+	case actionLocalClose, actionPeerAbort, actionObserveCompletion,
+		actionObserveImportPromise, actionObserveCapabilityRelease:
+		return constraintAlternatives{{
+			Name: "four-tables-lost",
+			Counts: []cardinality{
+				{Event: eventFor(actionObserveCompletion), Min: 1, Max: ^uint32(0)},
+				{Event: eventFor(actionObserveCapabilityRelease), Min: 1, Max: ^uint32(0)},
+			},
+		}}, nil
+	default:
+		return nil, fmt.Errorf("disconnect does not apply to %s", input.Action)
+	}
+}
+
+func goConnectionDrainConstraints() constraintAlternatives {
+	return constraintAlternatives{{
+		Name: "go-terminal-drain",
+		Counts: []cardinality{
+			{Event: eventFor(actionObserveCompletion), Min: 1, Max: ^uint32(0)},
+			{Event: eventFor(actionObserveCapabilityRelease), Min: 1, Max: ^uint32(0)},
+			{Event: eventFor(actionObserveConnDone), Min: 1, Max: 1},
+		},
+		// Conn shutdown initiates export release before Done, but releasing a
+		// capnp.Client may schedule its Shutdown callback asynchronously.  The
+		// public callback therefore has no ordering edge with Conn.Done.
+		Orders: []orderEdge{{
+			Before: eventFor(actionObserveCompletion),
+			After:  eventFor(actionObserveConnDone),
+		}},
+	}}
+}
+
+type divergence struct {
+	ActionIndex int
+	Origin      string
+	Reason      string
+	Expected    string
+	Actual      string
+	Replay      string
+}
+
+func (d divergence) Error() string {
+	return fmt.Sprintf(
+		"rpc lifecycle divergence at action %d\norigin: %s\nreason: %s\nexpected: %s\nactual: %s\nreplay:\n%s",
+		d.ActionIndex, d.Origin, d.Reason, d.Expected, d.Actual, d.Replay)
+}
+
+func stableExpected(alternatives constraintAlternatives) string {
+	var names []string
+	for _, alternative := range alternatives {
+		names = append(names, alternative.Name)
+	}
+	slices.Sort(names)
+	return strings.Join(names, " | ")
+}
+
+func stableLedger(ledger lifecycleLedger) string {
+	parts := make([]string, len(ledger))
+	for i, event := range ledger {
+		parts[i] = event.String()
+	}
+	return strings.Join(parts, " -> ")
+}
+
+func stableReplay(events lifecycleLedger) string {
+	var b strings.Builder
+	b.WriteString("rpc-lifecycle-trace-v1\n")
+	for i, event := range events {
+		fmt.Fprintf(&b, "%02d %s\n", i, event)
+	}
+	return strings.TrimSuffix(b.String(), "\n")
+}
+
+func checkWithDiagnostic(
+	actionIndex int,
+	origin string,
+	alternatives constraintAlternatives,
+	ledger lifecycleLedger,
+) error {
+	if err := checkConstraintAlternatives(alternatives, ledger); err != nil {
+		return divergence{
+			ActionIndex: actionIndex,
+			Origin:      origin,
+			Reason:      err.Error(),
+			Expected:    stableExpected(alternatives),
+			Actual:      stableLedger(ledger),
+			Replay:      stableReplay(ledger),
+		}
+	}
+	return nil
+}
+
+type questionState struct {
+	Returned       bool
+	Finished       bool
+	NoFinishNeeded bool
+	ResultCaps     uint32
+}
+
+type promiseState uint8
+
+const (
+	promiseUnresolved promiseState = iota + 1
+	promiseResolved
+	promiseReleased
+)
+
+type promiseRecord struct {
+	State      promiseState
+	References uint32
+}
+
+// lifecycleOracle deliberately models only protocol-visible identities and
+// transitions needed by the six named traces. It does not mirror question.go,
+// import.go, or export.go implementation states.
+type lifecycleOracle struct {
+	ids              *idNormalizer
+	pendingLocalCall bool
+	questions        map[questionRef]questionState
+	imports          map[capRef]promiseRecord
+	exports          map[capRef]promiseRecord
+}
+
+func newLifecycleOracle() *lifecycleOracle {
+	return &lifecycleOracle{
+		ids:       newIDNormalizer(),
+		questions: make(map[questionRef]questionState),
+		imports:   make(map[capRef]promiseRecord),
+		exports:   make(map[capRef]promiseRecord),
+	}
+}
+
+func (o *lifecycleOracle) localCall() error {
+	if o.pendingLocalCall {
+		return errors.New("a local call is already waiting for WireCall")
+	}
+	o.pendingLocalCall = true
+	return nil
+}
+
+func (o *lifecycleOracle) wireCall(rawQuestionID uint32) (questionRef, error) {
+	if !o.pendingLocalCall {
+		return questionRef{}, errors.New("WireCall has no pending LocalCall")
+	}
+	o.pendingLocalCall = false
+	question := o.ids.question(sideGo, rawQuestionID)
+	if _, exists := o.questions[question]; exists {
+		return questionRef{}, fmt.Errorf("question %s reused before retirement", question)
+	}
+	o.questions[question] = questionState{}
+	return question, nil
+}
+
+func (o *lifecycleOracle) peerReturn(
+	question questionRef,
+	noFinishNeeded bool,
+	resultCaps uint32,
+) error {
+	state, ok := o.questions[question]
+	if !ok {
+		return fmt.Errorf("Return references unknown question %s", question)
+	}
+	if state.Returned {
+		return fmt.Errorf("question %s returned more than once", question)
+	}
+	if noFinishNeeded && resultCaps != 0 {
+		return fmt.Errorf(
+			"question %s has noFinishNeeded with %d result capabilities",
+			question,
+			resultCaps,
+		)
+	}
+	state.Returned = true
+	state.NoFinishNeeded = noFinishNeeded
+	state.ResultCaps = resultCaps
+	o.questions[question] = state
+	return o.maybeRetireQuestion(question)
+}
+
+func (o *lifecycleOracle) wireFinish(question questionRef) error {
+	state, ok := o.questions[question]
+	if !ok {
+		return fmt.Errorf("Finish references unknown question %s", question)
+	}
+	if state.Finished {
+		return fmt.Errorf("question %s finished more than once", question)
+	}
+	state.Finished = true
+	o.questions[question] = state
+	return o.maybeRetireQuestion(question)
+}
+
+func (o *lifecycleOracle) maybeRetireQuestion(question questionRef) error {
+	state := o.questions[question]
+	if !state.Returned || !state.Finished && !state.NoFinishNeeded {
+		return nil
+	}
+	delete(o.questions, question)
+	return o.ids.retire(question.ID)
+}
+
+func (o *lifecycleOracle) observeImportedPromise(rawExportID uint32) capRef {
+	capability := o.ids.capability(sidePeer, rawExportID, true)
+	record, ok := o.imports[capability]
+	if !ok {
+		record.State = promiseUnresolved
+	}
+	record.References++
+	o.imports[capability] = record
+	return capability
+}
+
+func (o *lifecycleOracle) observeExportedPromise(rawExportID uint32) capRef {
+	capability := o.ids.capability(sideGo, rawExportID, true)
+	record, ok := o.exports[capability]
+	if !ok {
+		record.State = promiseUnresolved
+	}
+	record.References++
+	o.exports[capability] = record
+	return capability
+}
+
+func (o *lifecycleOracle) localRelease(capability capRef) error {
+	return o.localReleaseCount(capability, 1)
+}
+
+func (o *lifecycleOracle) localReleaseCount(capability capRef, count uint32) error {
+	record, ok := o.imports[capability]
+	if !ok {
+		return fmt.Errorf("LocalRelease references non-imported %s", capability)
+	}
+	if record.State == promiseReleased {
+		return fmt.Errorf("imported %s released more than once", capability)
+	}
+	if count > record.References {
+		return fmt.Errorf(
+			"LocalRelease count %d exceeds %d references to imported %s",
+			count,
+			record.References,
+			capability,
+		)
+	}
+	record.References -= count
+	if record.References == 0 {
+		record.State = promiseReleased
+		if err := o.ids.retire(capability.Export); err != nil {
+			return err
+		}
+	}
+	o.imports[capability] = record
+	return nil
+}
+
+func (o *lifecycleOracle) peerResolve(capability capRef) error {
+	record, ok := o.imports[capability]
+	if !ok {
+		return fmt.Errorf("PeerResolve references non-imported %s", capability)
+	}
+	if record.State == promiseResolved {
+		return fmt.Errorf("imported %s resolved more than once", capability)
+	}
+	if record.State == promiseUnresolved {
+		record.State = promiseResolved
+		o.imports[capability] = record
+	}
+	// A late Resolve for a released import is tolerated. The replacement
+	// obligations live in buildLateResolveConstraints.
+	return nil
+}
+
+func (o *lifecycleOracle) localResolve(capability capRef) error {
+	record, ok := o.exports[capability]
+	if !ok {
+		return fmt.Errorf("LocalResolve references non-exported %s", capability)
+	}
+	if record.State != promiseUnresolved {
+		return fmt.Errorf("exported %s cannot resolve from state %d", capability, record.State)
+	}
+	record.State = promiseResolved
+	o.exports[capability] = record
+	return nil
+}
+
+func (o *lifecycleOracle) peerRelease(capability capRef) error {
+	return o.peerReleaseCount(capability, 1)
+}
+
+func (o *lifecycleOracle) peerReleaseCount(capability capRef, count uint32) error {
+	record, ok := o.exports[capability]
+	if !ok {
+		return fmt.Errorf("PeerRelease references non-exported %s", capability)
+	}
+	if record.State == promiseReleased {
+		return fmt.Errorf("exported %s released more than once", capability)
+	}
+	if count > record.References {
+		return fmt.Errorf(
+			"PeerRelease count %d exceeds %d references to exported %s",
+			count,
+			record.References,
+			capability,
+		)
+	}
+	record.References -= count
+	if record.References == 0 {
+		record.State = promiseReleased
+		if err := o.ids.retire(capability.Export); err != nil {
+			return err
+		}
+	}
+	o.exports[capability] = record
+	return nil
+}
+
+func TestLifecycleIDNormalizerSeparatesDirectionAndGeneration(t *testing.T) {
+	ids := newIDNormalizer()
+	goQuestion := ids.question(sideGo, 7)
+	peerQuestion := ids.question(sidePeer, 7)
+	if goQuestion == peerQuestion {
+		t.Fatal("equal raw question IDs from opposite callers normalized to one identity")
+	}
+	if got, want := goQuestion.String(), "go/question/0@g0"; got != want {
+		t.Fatalf("Go question = %q; want %q", got, want)
+	}
+	if err := ids.retire(goQuestion.ID); err != nil {
+		t.Fatal(err)
+	}
+	reused := ids.question(sideGo, 7)
+	if got, want := reused.String(), "go/question/0@g1"; got != want {
+		t.Fatalf("reused Go question = %q; want %q", got, want)
+	}
+	if got := ids.question(sidePeer, 7); got != peerQuestion {
+		t.Fatalf("Go retirement changed peer identity from %s to %s", peerQuestion, got)
+	}
+}
+
+func TestLifecycleCapabilityIdentityBelongsToExporter(t *testing.T) {
+	ids := newIDNormalizer()
+	senderPromise := ids.capability(sidePeer, 9, true)
+	receiverHosted := ids.capability(sideGo, 9, false)
+	if senderPromise.Export == receiverHosted.Export {
+		t.Fatal("equal raw export IDs owned by opposite exporters normalized to one identity")
+	}
+	if senderPromise.Export.Owner != sidePeer || receiverHosted.Export.Owner != sideGo {
+		t.Fatalf("export ownership = %s and %s; want peer and go", senderPromise, receiverHosted)
+	}
+}
+
+func TestLifecycleLocalCallBindsOnlyAtWireObservation(t *testing.T) {
+	oracle := newLifecycleOracle()
+	if err := oracle.localCall(); err != nil {
+		t.Fatal(err)
+	}
+	if len(oracle.questions) != 0 {
+		t.Fatal("LocalCall chose a concrete question before WireCall observation")
+	}
+	question, err := oracle.wireCall(42)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := question.String(), "go/question/0@g0"; got != want {
+		t.Fatalf("bound question = %q; want %q", got, want)
+	}
+	if err := oracle.peerReturn(question, false, 0); err != nil {
+		t.Fatal(err)
+	}
+	if err := oracle.localCall(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := oracle.wireCall(42); err == nil || !strings.Contains(err.Error(), "reused before retirement") {
+		t.Fatalf("early ID reuse error = %v; want retirement diagnostic", err)
+	}
+	if err := oracle.wireFinish(question); err != nil {
+		t.Fatal(err)
+	}
+	if err := oracle.localCall(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := oracle.wireCall(42); err != nil {
+		t.Fatal("reuse after Return and Finish:", err)
+	}
+}
+
+func TestLifecyclePromiseDirectionsRejectCrossedActions(t *testing.T) {
+	oracle := newLifecycleOracle()
+	imported := oracle.observeImportedPromise(4)
+	exported := oracle.observeExportedPromise(4)
+	if imported.Export == exported.Export {
+		t.Fatal("imported and exported promises share an exporter-owned identity")
+	}
+	if err := oracle.localResolve(imported); err == nil {
+		t.Fatal("LocalResolve accepted an imported promise")
+	}
+	if err := oracle.peerResolve(exported); err == nil {
+		t.Fatal("PeerResolve accepted an exported promise")
+	}
+	if err := oracle.localRelease(exported); err == nil {
+		t.Fatal("LocalRelease accepted a peer-owned release")
+	}
+	if err := oracle.peerRelease(imported); err == nil {
+		t.Fatal("PeerRelease accepted a Go-owned release")
+	}
+}
+
+func TestLifecycleConstraintAlternativesAreCoherent(t *testing.T) {
+	input := probeFor(actionLocalCancel)
+	alternatives, err := buildCancelResultConstraints(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	frankenstein := lifecycleLedger{
+		{Kind: actionObserveCompletion, Label: "success"},
+		{Kind: actionWireFinish, Label: "releaseResultCaps=true"},
+	}
+	err = checkConstraintAlternatives(alternatives, frankenstein)
+	if err == nil {
+		t.Fatal("mixed observations from different alternatives were accepted")
+	}
+	if !strings.Contains(err.Error(), "return-wins") || !strings.Contains(err.Error(), "cancel-wins") {
+		t.Fatalf("alternative failure = %v; want both complete alternatives", err)
+	}
+}
+
+func TestLifecyclePartialOrderIgnoresUnrelatedInterleaving(t *testing.T) {
+	input := probeFor(actionObserveDelivery)
+	alternatives, err := buildDisembargoConstraints(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ordered := lifecycleLedger{
+		{Kind: actionObserveDelivery, Label: "pre-resolution"},
+		{Kind: actionObserveCompletion, Label: "unrelated"},
+		{Kind: actionObserveDelivery, Label: "post-resolution"},
+	}
+	if err := checkConstraintAlternatives(alternatives[1:], ordered); err != nil {
+		t.Fatal("unrelated event overconstrained the partial order:", err)
+	}
+	overtaken := lifecycleLedger{
+		{Kind: actionObserveDelivery, Label: "post-resolution"},
+		{Kind: actionObserveCompletion, Label: "unrelated"},
+		{Kind: actionObserveDelivery, Label: "pre-resolution"},
+	}
+	if err := checkConstraintAlternatives(alternatives[1:], overtaken); err == nil {
+		t.Fatal("post-resolution delivery overtook pre-resolution delivery")
+	}
+}
+
+func TestLifecycleLateResolveBalancesReplacement(t *testing.T) {
+	input := probeFor(actionPeerResolve)
+	alternatives, err := buildLateResolveConstraints(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ledger := lifecycleLedger{
+		{Kind: actionPeerResolve, Capability: input.Capability},
+		{Kind: actionPeerReturn, Label: "unrelated"},
+		{Kind: actionObserveImportPromise, Capability: input.Replacement, ReferenceDelta: 1},
+		{Kind: actionWireRelease, Capability: input.Replacement, ReferenceDelta: -1},
+	}
+	if err := checkConstraintAlternatives(alternatives, ledger); err != nil {
+		t.Fatal(err)
+	}
+	ledger = append(ledger, lifecycleEvent{Kind: actionWireDisembargo})
+	if err := checkConstraintAlternatives(alternatives, ledger); err == nil {
+		t.Fatal("late Resolve accepted an outbound Disembargo")
+	}
+}
+
+func TestLifecycleGoDrainPolicyIsNotAttributedToSchema(t *testing.T) {
+	ledger := lifecycleLedger{
+		{Kind: actionObserveCompletion},
+		{Kind: actionObserveCapabilityRelease},
+		{Kind: actionObserveConnDone},
+	}
+	if err := checkWithDiagnostic(
+		2,
+		"go-rpc:connection-terminal-drain",
+		goConnectionDrainConstraints(),
+		ledger,
+	); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestLifecycleGoDrainAllowsAsynchronousCapabilityShutdown(t *testing.T) {
+	ledger := lifecycleLedger{
+		{Kind: actionObserveCompletion},
+		{Kind: actionObserveConnDone},
+		{Kind: actionObserveCapabilityRelease},
+	}
+	if err := checkConstraintAlternatives(goConnectionDrainConstraints(), ledger); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestLifecycleDiagnosticIsStableAndAlphaRenamed(t *testing.T) {
+	ids := newIDNormalizer()
+	question := ids.question(sideGo, 900)
+	alternatives := constraintAlternatives{{
+		Name: "normal-retirement",
+		Counts: []cardinality{{
+			Event: eventForQuestion(actionWireFinish, question),
+			Min:   1,
+			Max:   1,
+		}},
+	}}
+	ledger := lifecycleLedger{{
+		Kind:     actionWireCall,
+		Question: question,
+	}}
+	err := checkWithDiagnostic(
+		1,
+		"rpc-v2@0b821519:Call.questionId:question-id-retirement",
+		alternatives,
+		ledger,
+	)
+	const want = `rpc lifecycle divergence at action 1
+origin: rpc-v2@0b821519:Call.questionId:question-id-retirement
+reason: normal-retirement: WireFinish[question=go/question/0@g0] count=0 want=1..1
+expected: normal-retirement
+actual: WireCall[question=go/question/0@g0]
+replay:
+rpc-lifecycle-trace-v1
+00 WireCall[question=go/question/0@g0]`
+	if err == nil || err.Error() != want {
+		t.Fatalf("diagnostic:\n%s\nwant:\n%s", err, want)
+	}
+}
+
+// These contract tests are deliberately wire-free.  The synctest traces feed
+// their observations into the same builders, so an accidental weakening of
+// the oracle fails here without needing a particular transport schedule.
+
+func TestLifecycleContractQuestionReuseAfterReturnAndFinish(t *testing.T) {
+	oracle := newLifecycleOracle()
+	if err := oracle.localCall(); err != nil {
+		t.Fatal(err)
+	}
+	first, err := oracle.wireCall(7)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := oracle.peerReturn(first, false, 0); err != nil {
+		t.Fatal(err)
+	}
+	if err := oracle.wireFinish(first); err != nil {
+		t.Fatal(err)
+	}
+	if err := oracle.localCall(); err != nil {
+		t.Fatal(err)
+	}
+	second, err := oracle.wireCall(7)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.ID.Generation+1 != second.ID.Generation {
+		t.Fatalf("reused question generation = %d; want %d", second.ID.Generation, first.ID.Generation+1)
+	}
+}
+
+func TestLifecycleContractCancelBalancesLateCapabilityReturn(t *testing.T) {
+	input := probeFor(actionLocalCancel)
+	alternatives, err := buildCancelResultConstraints(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ledger := lifecycleLedger{
+		{Kind: actionObserveCompletion, Label: "canceled"},
+		{Kind: actionPeerReturn, Capability: input.Capability, ReferenceDelta: 1},
+		{
+			Kind:           actionWireFinish,
+			Label:          "releaseResultCaps=true",
+			Capability:     input.Capability,
+			ReferenceDelta: -1,
+		},
+	}
+	if err := checkConstraintAlternatives(alternatives, ledger); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestLifecycleContractNoFinishNeededAllowsQuestionRetirement(t *testing.T) {
+	input := probeFor(actionPeerReturn)
+	alternatives, err := buildNoFinishNeededConstraints(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ledger := lifecycleLedger{{
+		Kind:  actionPeerReturn,
+		Label: "noFinishNeeded=true,resultCaps=0",
+	}}
+	if err := checkConstraintAlternatives(alternatives, ledger); err != nil {
+		t.Fatal(err)
+	}
+
+	oracle := newLifecycleOracle()
+	if err := oracle.localCall(); err != nil {
+		t.Fatal(err)
+	}
+	first, err := oracle.wireCall(11)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := oracle.peerReturn(first, true, 0); err != nil {
+		t.Fatal(err)
+	}
+	if err := oracle.localCall(); err != nil {
+		t.Fatal(err)
+	}
+	second, err := oracle.wireCall(11)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.ID.Generation+1 != second.ID.Generation {
+		t.Fatalf("reused question generation = %d; want %d", second.ID.Generation, first.ID.Generation+1)
+	}
+
+	invalid := probeFor(actionPeerReturn)
+	invalid.ResultCaps = 1
+	if _, err := buildNoFinishNeededConstraints(invalid); err == nil {
+		t.Fatal("capability-bearing noFinishNeeded Return was accepted")
+	}
+}
+
+func TestLifecycleContractReleasedPromiseBalancesLateResolve(t *testing.T) {
+	input := probeFor(actionPeerResolve)
+	alternatives, err := buildLateResolveConstraints(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ledger := lifecycleLedger{
+		{Kind: actionPeerResolve, Capability: input.Capability},
+		{Kind: actionObserveImportPromise, Capability: input.Replacement, ReferenceDelta: 1},
+		{Kind: actionWireRelease, Capability: input.Replacement, ReferenceDelta: -1},
+	}
+	if err := checkConstraintAlternatives(alternatives, ledger); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestLifecyclePromiseReferenceCountsAndGeneration(t *testing.T) {
+	oracle := newLifecycleOracle()
+	first := oracle.observeImportedPromise(23)
+	repeated := oracle.observeImportedPromise(23)
+	if repeated != first {
+		t.Fatalf("repeated senderPromise = %s; want %s", repeated, first)
+	}
+	if err := oracle.peerResolve(first); err != nil {
+		t.Fatal(err)
+	}
+	if err := oracle.localReleaseCount(first, 1); err != nil {
+		t.Fatal(err)
+	}
+	if got := oracle.imports[first].References; got != 1 {
+		t.Fatalf("references after partial Release = %d; want 1", got)
+	}
+	if err := oracle.peerResolve(first); err == nil {
+		t.Fatal("second Resolve for one senderPromise incarnation was accepted")
+	}
+	if err := oracle.localReleaseCount(first, 1); err != nil {
+		t.Fatal(err)
+	}
+	reused := oracle.observeImportedPromise(23)
+	if reused.Export.Generation != first.Export.Generation+1 {
+		t.Fatalf(
+			"reused senderPromise generation = %d; want %d",
+			reused.Export.Generation,
+			first.Export.Generation+1,
+		)
+	}
+	if err := oracle.peerResolve(reused); err != nil {
+		t.Fatal("Resolve for recycled senderPromise:", err)
+	}
+}
+
+func TestLifecycleReferenceDecrementAllowsPartialRelease(t *testing.T) {
+	input := probeFor(actionWireRelease)
+	input.ReferencesBefore = 3
+	input.Count = 1
+	alternatives, err := buildReferenceDecrementConstraints(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ledger := lifecycleLedger{
+		{Kind: actionObserveImportPromise, Capability: input.Capability, ReferenceDelta: 3},
+		{Kind: actionWireRelease, Capability: input.Capability, ReferenceDelta: -1},
+	}
+	if err := checkConstraintAlternatives(alternatives, ledger); err != nil {
+		t.Fatal(err)
+	}
+	input.Count = 4
+	if _, err := buildReferenceDecrementConstraints(input); err == nil {
+		t.Fatal("Release reference-count underflow was accepted")
+	}
+}
+
+func TestLifecycleContractDisembargoPreventsOvertaking(t *testing.T) {
+	input := probeFor(actionObserveDelivery)
+	alternatives, err := buildDisembargoConstraints(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ordered := lifecycleLedger{
+		{Kind: actionObserveDelivery, Label: "pre-resolution"},
+		{Kind: actionWireDisembargo},
+		{Kind: actionObserveDelivery, Label: "post-resolution"},
+	}
+	if err := checkConstraintAlternatives(alternatives[1:], ordered); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestLifecycleContractDisconnectDrainsBeforeConnDone(t *testing.T) {
+	ledger := lifecycleLedger{
+		{Kind: actionObserveCompletion},
+		{Kind: actionObserveCapabilityRelease},
+		{Kind: actionObserveConnDone},
+	}
+	schemaConstraints, err := buildDisconnectConstraints(probeFor(actionLocalClose))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := checkConstraintAlternatives(schemaConstraints, ledger); err != nil {
+		t.Fatal(err)
+	}
+	if err := checkConstraintAlternatives(goConnectionDrainConstraints(), ledger); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/rpc/wire_test.go
+++ b/rpc/wire_test.go
@@ -88,6 +88,7 @@ type rpcCallSendResultsTo struct {
 type rpcReturn struct {
 	AnswerID         uint32 `capnp:"answerId"`
 	ReleaseParamCaps bool
+	NoFinishNeeded   bool
 
 	Which                 rpccp.Return_Which
 	Results               *rpcPayload


### PR DESCRIPTION
## Summary

- pin the reviewed C++ RPC v2 schema clauses and classify ten lifecycle invariants
- add an executable, directional, generation-aware lifecycle oracle with coherent alternatives, partial-order checks, exact reference ledgers, and stable replay diagnostics
- add a protocol-only observed transport for deterministic `testing/synctest` conformance traces

## Validation

- `go test ./rpc -run 'TestLifecycle' -count=1`
- `go test ./rpc -count=1`
- `go test -race ./rpc -count=1`
- `git diff --check origin/main...HEAD`

## Follow-up stack

This is the foundation for two stacked PRs covering question lifecycle traces and promise/order/disconnect traces.
