### PR TITLE
rpc: honor Return.releaseParamCaps

### DIFF
--- a/rpc/export.go
+++ b/rpc/export.go
@@ -268,7 +268,9 @@ func (c *lockedConn) fillPayloadCapTable(payload rpccp.Payload) (map[exportID]ui
 	for i := 0; i < clients.Len(); i++ {
 		id, isExport, err := c.sendCap(list.At(i), clients.At(i).Snapshot())
 		if err != nil {
-			return nil, rpcerr.WrapFailed("Serializing capability", err)
+			// Call construction needs the partial ledger to undo increments when
+			// serialization fails after an earlier descriptor was exported.
+			return refs, rpcerr.WrapFailed("Serializing capability", err)
 		}
 		if isExport {
 			if refs == nil {

--- a/rpc/promise_lifecycle_synctest_test.go
+++ b/rpc/promise_lifecycle_synctest_test.go
@@ -51,6 +51,7 @@ func sendLifecycleCapabilityFieldReturn(
 	t *testing.T,
 	peer rpc.Transport,
 	answerID uint32,
+	releaseParamCaps bool,
 	descriptor func(rpccp.CapDescriptor),
 ) {
 	t.Helper()
@@ -65,6 +66,7 @@ func sendLifecycleCapabilityFieldReturn(
 		t.Fatal(err)
 	}
 	ret.SetAnswerId(answerID)
+	ret.SetReleaseParamCaps(releaseParamCaps)
 	results, err := ret.NewResults()
 	if err != nil {
 		t.Fatal(err)
@@ -359,6 +361,7 @@ func TestLifecyclePromisePathShorteningPreservesDeliveryOrder(t *testing.T) {
 			t,
 			peer,
 			questionA,
+			false, // the peer reflects this parameter capability in a later Call
 			func(cap rpccp.CapDescriptor) { cap.SetReceiverHosted(export.SenderHosted) },
 		)
 		var (

--- a/rpc/question.go
+++ b/rpc/question.go
@@ -9,6 +9,7 @@ import (
 	"capnproto.org/go/capnp/v3/flowcontrol"
 	"capnproto.org/go/capnp/v3/internal/syncutil"
 	rpccp "capnproto.org/go/capnp/v3/std/capnp/rpc"
+	"capnproto.org/go/capnp/v3/util/deferred"
 )
 
 // A questionID is an index into the questions table.
@@ -32,6 +33,7 @@ type question struct {
 	noFinishNeeded bool
 	finish         questionFinishState
 	called         [][]capnp.PipelineOp // paths to called clients
+	paramExports   map[exportID]uint32  // refs from this Call's parameter table
 }
 
 type questionTerminalOwner uint8
@@ -140,9 +142,31 @@ func (q *question) signalDrainDone() {
 	}
 }
 
+// releaseParamExports transfers the parameter export references out of q and
+// releases them unless shutdown has already released the entire export table.
+// The caller MUST hold q.c.lk.
+func (q *question) releaseParamExports(c *lockedConn, dq *deferred.Queue) error {
+	refs := q.paramExports
+	q.paramExports = nil
+	if len(refs) == 0 || c.lk.closing {
+		return nil
+	}
+	return c.releaseExportRefs(dq, refs)
+}
+
+// discardParamExports transfers the parameter export references out of q
+// without releasing them. The peer retains responsibility through ordinary
+// Release messages, or shutdown has already released the whole export table.
+// The caller MUST hold q.c.lk.
+func (q *question) discardParamExports() {
+	q.paramExports = nil
+}
+
 // handleCallSend completes the initial Call send. The caller MUST NOT hold
 // q.c.lk; it is invoked by the sender loop.
 func (q *question) handleCallSend(ctx context.Context, outcome sendOutcome, annotation string) {
+	dq := &deferred.Queue{}
+	defer dq.Run()
 	var callErr error
 	if outcome.err != nil {
 		callErr = rpcerr.Annotate(outcome.err, annotation)
@@ -191,6 +215,9 @@ func (q *question) handleCallSend(ctx context.Context, outcome sendOutcome, anno
 			q.p.Reject(callErr)
 			q.c.withLocked(func(c *lockedConn) {
 				if current, ok := c.lk.questions.Find(q.id); ok && current == q {
+					if err := q.releaseParamExports(c, dq); err != nil {
+						c.er.ReportError(rpcerr.Annotate(err, "discard unsent Call parameter exports"))
+					}
 					c.lk.questions.Remove(q.id)
 				}
 			})
@@ -340,7 +367,7 @@ func (c *lockedConn) startCall(ctx context.Context, s capnp.Send, preflight func
 
 	q := c.newQuestion(s.Method)
 	c.sendMessageOutcome(ctx, func(m rpccp.Message) error {
-		return c.newCallMessage(m, q.id, s, populateTarget)
+		return c.newCallMessage(m, q, s, populateTarget)
 	}, false, func(outcome sendOutcome) { q.handleCallSend(ctx, outcome, "send message") })
 
 	ans := q.p.Answer()
@@ -413,6 +440,8 @@ func (p *preparedCall) Commit(terminal func(flowcontrol.MessageOutcomeKind, erro
 
 	var committed bool
 	var commitErr error
+	dq := &deferred.Queue{}
+	defer dq.Run()
 	p.c.withLocked(func(c *lockedConn) {
 		if p.ctx.Err() != nil {
 			commitErr = p.ctx.Err()
@@ -428,7 +457,12 @@ func (p *preparedCall) Commit(terminal func(flowcontrol.MessageOutcomeKind, erro
 				return
 			}
 		}
-		if _, err := c.fillPayloadCapTable(p.payload); err != nil {
+		refs, err := c.fillPayloadCapTable(p.payload)
+		if err != nil {
+			p.q.paramExports = refs
+			if releaseErr := p.q.releaseParamExports(c, dq); releaseErr != nil {
+				c.er.ReportError(rpcerr.Annotate(releaseErr, "discard uncommitted Call parameter exports"))
+			}
 			commitErr = rpcerr.Annotate(err, "build call message")
 			return
 		}
@@ -443,6 +477,16 @@ func (p *preparedCall) Commit(terminal func(flowcontrol.MessageOutcomeKind, erro
 				terminal(flowcontrol.MessageOutcomeFatal, outcome.err)
 			}
 		})
+		if committed {
+			// The sender may run immediately after commit, but Return handling
+			// cannot observe q until this lock is released.
+			p.q.paramExports = refs
+			return
+		}
+		p.q.paramExports = refs
+		if err := p.q.releaseParamExports(c, dq); err != nil {
+			c.er.ReportError(rpcerr.Annotate(err, "discard uncommitted Call parameter exports"))
+		}
 	})
 	if !committed {
 		p.msg.abort()
@@ -477,15 +521,16 @@ func (p *preparedCall) Abort() {
 	p.removeQuestion()
 }
 
-func (c *lockedConn) newCallMessage(msg rpccp.Message, qid questionID, s capnp.Send, populateTarget func(rpccp.MessageTarget) error) error {
-	payload, err := newCallMessageUnsealed(msg, qid, s, populateTarget)
+func (c *lockedConn) newCallMessage(msg rpccp.Message, q *question, s capnp.Send, populateTarget func(rpccp.MessageTarget) error) error {
+	payload, err := newCallMessageUnsealed(msg, q.id, s, populateTarget)
 	if err != nil {
 		return err
 	}
 	if s.PlaceArgs == nil {
 		return nil
 	}
-	_, err = c.fillPayloadCapTable(payload)
+	refs, err := c.fillPayloadCapTable(payload)
+	q.paramExports = refs
 	if err != nil {
 		return rpcerr.Annotate(err, "build call message")
 	}

--- a/rpc/question_lifecycle_synctest_test.go
+++ b/rpc/question_lifecycle_synctest_test.go
@@ -8,6 +8,7 @@ import (
 
 	"capnproto.org/go/capnp/v3"
 	"capnproto.org/go/capnp/v3/rpc"
+	"capnproto.org/go/capnp/v3/server"
 	rpccp "capnproto.org/go/capnp/v3/std/capnp/rpc"
 )
 
@@ -330,6 +331,53 @@ func TestLifecycleQuestionCancelBalancesLateCapabilityReturn(t *testing.T) {
 		}
 		if err := checkConstraintAlternatives(alternatives, ledger); err != nil {
 			t.Fatal(err)
+		}
+	})
+}
+
+func TestLifecycleQuestionReturnReleasesParameterExports(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		fixture := newQuestionTraceFixture(t)
+		shutdown := make(chan struct{})
+		local := newLifecycleServer(func(context.Context, *server.Call) error {
+			return nil
+		}, func() { close(shutdown) })
+
+		answer, releaseAnswer := fixture.target.SendCall(context.Background(), capnp.Send{
+			Method:   capnp.Method{InterfaceID: interfaceID, MethodID: methodID},
+			ArgsSize: capnp.ObjectSize{PointerCount: 1},
+			PlaceArgs: func(args capnp.Struct) error {
+				id := args.Message().CapTable().Add(local)
+				return args.SetPtr(0, capnp.NewInterface(args.Segment(), id).ToPtr())
+			},
+		})
+
+		call, releaseCall, err := recvMessage(context.Background(), fixture.peer)
+		if err != nil {
+			local.Release()
+			t.Fatal("receive Call:", err)
+		}
+		if call.Which != rpccp.Message_Which_call || len(call.Call.Params.CapTable) != 1 {
+			releaseCall()
+			local.Release()
+			t.Fatalf("Call = %+v; want one parameter capability", call)
+		}
+		questionID := call.Call.QuestionID
+		releaseCall()
+		local.Release()
+
+		sendLifecycleReturn(t, fixture.peer, questionID, false, 0)
+		if _, err := answer.Struct(); err != nil {
+			t.Fatal("read Return:", err)
+		}
+		releaseAnswer()
+		receiveLifecycleFinish(t, fixture.peer, questionID, false)
+		synctest.Wait()
+
+		select {
+		case <-shutdown:
+		default:
+			t.Fatal("parameter export was not released by Return.releaseParamCaps")
 		}
 	})
 }

--- a/rpc/question_lifecycle_test.go
+++ b/rpc/question_lifecycle_test.go
@@ -13,6 +13,7 @@ import (
 	"capnproto.org/go/capnp/v3/exp/spsc"
 	transportpkg "capnproto.org/go/capnp/v3/rpc/transport"
 	rpccp "capnproto.org/go/capnp/v3/std/capnp/rpc"
+	"capnproto.org/go/capnp/v3/util/deferred"
 )
 
 type gatedQuestionCaller struct {
@@ -631,6 +632,56 @@ func TestQuestionInitialCallFailureIDPolicy(t *testing.T) {
 			}
 		})
 	})
+}
+
+func TestQuestionParamExportsReleaseExactAliasCount(t *testing.T) {
+	c := &Conn{bgctx: context.Background()}
+	q := &question{c: c}
+	export := (*lockedConn)(c).lk.exports.Add(&expent{wireRefs: 4, cancel: func() {}})
+	q.paramExports = map[exportID]uint32{export: 3}
+
+	dq := &deferred.Queue{}
+	c.withLocked(func(c *lockedConn) {
+		if err := q.releaseParamExports(c, dq); err != nil {
+			t.Fatal(err)
+		}
+		if err := q.releaseParamExports(c, dq); err != nil {
+			t.Fatal(err)
+		}
+	})
+	dq.Run()
+
+	c.withLocked(func(c *lockedConn) {
+		entry, ok := c.lk.exports.Find(export)
+		if !ok || entry.wireRefs != 1 {
+			t.Fatalf("aliased parameter export refs = %v; want 1", entry)
+		}
+		if q.paramExports != nil {
+			t.Fatal("parameter exports retained after release")
+		}
+	})
+}
+
+func TestQuestionParamExportsDiscardOnShutdown(t *testing.T) {
+	c := &Conn{bgctx: context.Background()}
+	q := &question{c: c}
+	export := (*lockedConn)(c).lk.exports.Add(&expent{wireRefs: 1, cancel: func() {}})
+	q.paramExports = map[exportID]uint32{export: 1}
+
+	dq := &deferred.Queue{}
+	c.withLocked(func(c *lockedConn) {
+		c.lk.closing = true
+		if err := q.releaseParamExports(c, dq); err != nil {
+			t.Fatal(err)
+		}
+		if q.paramExports != nil {
+			t.Fatal("parameter exports retained after shutdown discard")
+		}
+		if _, ok := c.lk.exports.Find(export); !ok {
+			t.Fatal("shutdown discard released export before connection cleanup")
+		}
+	})
+	dq.Run()
 }
 
 func TestQuestionFinishFailureRetainsID(t *testing.T) {

--- a/rpc/question_lifecycle_test.go
+++ b/rpc/question_lifecycle_test.go
@@ -684,6 +684,51 @@ func TestQuestionParamExportsDiscardOnShutdown(t *testing.T) {
 	dq.Run()
 }
 
+func TestQuestionAmbiguousReturnReleasesParameterExports(t *testing.T) {
+	c, q := newUnsentQuestion()
+	q.owner = questionOwnerSendFailure
+	export := (*lockedConn)(c).lk.exports.Add(&expent{wireRefs: 2, cancel: func() {}})
+	q.paramExports = map[exportID]uint32{export: 1}
+
+	incoming := newQuestionReturnMessage(t, false, false)
+	if err := c.handleReturn(context.Background(), incoming); err != nil {
+		t.Fatal(err)
+	}
+
+	c.withLocked(func(c *lockedConn) {
+		entry, ok := c.lk.exports.Find(export)
+		if !ok || entry.wireRefs != 1 {
+			t.Fatalf("ambiguous Return export refs = %v; want 1", entry)
+		}
+		if q.paramExports != nil {
+			t.Fatal("ambiguous Return retained parameter exports")
+		}
+	})
+}
+
+func TestQuestionCanceledLateReturnReleasesParameterExports(t *testing.T) {
+	c, q := newUnsentQuestion()
+	q.owner = questionOwnerCancel
+	q.finish = questionFinishSent
+	export := (*lockedConn)(c).lk.exports.Add(&expent{wireRefs: 2, cancel: func() {}})
+	q.paramExports = map[exportID]uint32{export: 1}
+
+	incoming := newQuestionReturnMessage(t, false, false)
+	if err := c.handleReturn(context.Background(), incoming); err != nil {
+		t.Fatal(err)
+	}
+
+	c.withLocked(func(c *lockedConn) {
+		entry, ok := c.lk.exports.Find(export)
+		if !ok || entry.wireRefs != 1 {
+			t.Fatalf("canceled late Return export refs = %v; want 1", entry)
+		}
+		if q.paramExports != nil {
+			t.Fatal("canceled late Return retained parameter exports")
+		}
+	})
+}
+
 func TestQuestionFinishFailureRetainsID(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -488,7 +488,13 @@ func (c *lockedConn) releaseAnswers(dq *deferred.Queue, answers []*ansent) {
 
 func (c *lockedConn) releaseQuestions(dq *deferred.Queue, questions []*question) {
 	for _, q := range questions {
-		if q != nil && q.owner == questionOwnerNone {
+		if q == nil {
+			continue
+		}
+		// release has already cleared and deferred every export snapshot, so
+		// question-local accounting must not decrement the export table here.
+		q.discardParamExports()
+		if q.owner == questionOwnerNone {
 			// Terminal owners resolve or reject their own Promise. Questions
 			// without one are still pending and are rejected by shutdown.
 			qr := q // Capture a different variable each time through the loop.
@@ -1136,11 +1142,25 @@ func (c *Conn) handleReturn(_ context.Context, in transport.IncomingMessage) err
 			return
 		}
 		q.returnReceived = true
+		releaseParamCaps := ret.ReleaseParamCaps()
+		applyParamExports := func() {
+			if releaseParamCaps {
+				if err := q.releaseParamExports(c, dq); err != nil {
+					c.er.ReportError(rpcerr.Annotate(err, "incoming return: release parameter exports"))
+				}
+			} else {
+				q.discardParamExports()
+			}
+		}
 
 		switch q.owner {
 		case questionOwnerCancel:
 			// Cancellation owns the single Finish(true). A late Return never
 			// parses result capabilities and cannot suppress that Finish.
+			// This path does not parse results, so it can release parameter
+			// exports immediately. Normal results must parse first because a
+			// receiverHosted result can still name one of those exports.
+			applyParamExports()
 			dq.Defer(in.Release)
 			if q.finish == questionFinishSent {
 				c.lk.questions.release(qid)
@@ -1148,6 +1168,7 @@ func (c *Conn) handleReturn(_ context.Context, in transport.IncomingMessage) err
 			return
 		case questionOwnerSendFailure:
 			// Delivery was ambiguous and shutdown owns the retained ID.
+			applyParamExports()
 			dq.Defer(in.Release)
 			return
 		case questionOwnerNone:
@@ -1161,6 +1182,7 @@ func (c *Conn) handleReturn(_ context.Context, in transport.IncomingMessage) err
 		}
 
 		pr := c.parseReturn(dq, ret, q.called) // fills in CapTable and adds imports to local vat
+		applyParamExports()
 		if pr.parseFailed {
 			c.er.ReportError(rpcerr.Annotate(pr.err, "incoming return"))
 		}


### PR DESCRIPTION
## Summary
- retain outbound Call parameter export counts on questions and release them when an incoming Return sets releaseParamCaps
- preserve ownership across ordinary, prepared, cancelled, ambiguous-send, and shutdown paths
- add deterministic lifecycle coverage for exact export release and correct Return flags

## Verification
- go test ./rpc
- go test -race ./rpc

Closes #662